### PR TITLE
refactor: rebrand to Aeron Toolbox

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,4 @@
-# Aeron Image Manager API-documentatie
+# Aeron Toolbox API-documentatie
 
 ## Inhoudsopgave
 
@@ -19,7 +19,7 @@
 
 ## Overzicht
 
-De Aeron Image Manager API biedt RESTful-endpoints voor het beheren van afbeeldingen in het Aeron-radioautomatiseringssysteem. Deze API biedt directe databasetoegang om albumhoezen voor tracks en artiestfoto's toe te voegen, op te halen en te verwijderen.
+De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem. De API biedt directe databasetoegang voor afbeeldingenbeheer, mediabrowser, database-onderhoud en backup-management.
 
 **Basis-URL:** `http://localhost:8080/api`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /backups && chown aeron:aeron /backups
 COPY --from=builder /app/zwfm-aeronapi /app/zwfm-aeronapi
 
 # Copy config file (if exists)
-COPY --chown=aeron:aeron config.yaml* /app/
+COPY --chown=aeron:aeron config.json* /app/
 
 # Change ownership
 RUN chown -R aeron:aeron /app

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Aeron Image Manager API
+# Aeron Toolbox
 
-Een **onofficiële** REST API voor het Aeron-radioautomatiseringssysteem, speciaal ontwikkeld voor het **toevoegen en beheren van afbeeldingen** voor tracks en artiesten.
+Een **onofficiële** REST API voor het Aeron-radioautomatiseringssysteem met tools voor afbeeldingenbeheer, mediabrowser, database-onderhoud en backups.
 
 > [!WARNING]
 > Aeron is een product van Broadcast Partners. Deze API is volledig onofficieel en wordt niet ontwikkeld door of in samenwerking met Broadcast Partners. Gebruik is op eigen risico. Maak altijd eerst een back-up van je database voordat je deze tool gebruikt.
 
 ## Functionaliteiten
 
-- **Afbeeldingenbeheer** - Upload en beheer albumhoezen en artiestfoto's
-- **Automatische optimalisatie** - Afbeeldingen worden geschaald en gecomprimeerd naar JPEG
-- **Playlist-integratie** - Bekijk playlists inclusief afbeeldingsstatus
-- **Database onderhoud** - Health monitoring, vacuum en analyze operaties
-- **Backup/restore** - Maak en beheer database backups
+| Module | Beschrijving |
+|--------|--------------|
+| **Afbeeldingenbeheer** | Upload, optimaliseer en beheer albumhoezen en artiestfoto's |
+| **Mediabrowser** | Bekijk artiesten, tracks en playlists met uitgebreide metadata |
+| **Database-onderhoud** | Health monitoring, VACUUM en ANALYZE operaties |
+| **Backup-management** | Maak, download en beheer database backups |
 
 ## Installatie
 
@@ -68,11 +69,9 @@ curl -X POST http://localhost:8080/api/artists/{id}/image \
   -H "Content-Type: application/json" \
   -d '{"url":"https://example.com/artist.jpg"}'
 
-# Trackafbeelding uploaden
-curl -X POST http://localhost:8080/api/tracks/{id}/image \
-  -H "X-API-Key: jouw-api-sleutel" \
-  -H "Content-Type: application/json" \
-  -d '{"url":"https://example.com/album.jpg"}'
+# Database backup maken
+curl -X POST http://localhost:8080/api/db/backup \
+  -H "X-API-Key: jouw-api-sleutel"
 ```
 
 Volledige API-documentatie: [API.md](API.md)

--- a/internal/service/analyze.go
+++ b/internal/service/analyze.go
@@ -1,4 +1,4 @@
-// Package service provides business logic for managing images in the Aeron radio automation system.
+// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -1,4 +1,4 @@
-// Package service provides business logic for managing images in the Aeron radio automation system.
+// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -1,4 +1,4 @@
-// Package service provides business logic for managing images in the Aeron radio automation system.
+// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,4 +1,4 @@
-// Package service provides business logic for managing images in the Aeron radio automation system.
+// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (

--- a/internal/service/vacuum.go
+++ b/internal/service/vacuum.go
@@ -1,4 +1,4 @@
-// Package service provides business logic for managing images in the Aeron radio automation system.
+// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,9 +1,8 @@
-// Package main implements the Aeron Image Manager API server.
+// Package main implements the Aeron Toolbox API server.
 //
-// This server provides an unofficial REST API for managing images in the Aeron
-// radio automation system. It allows adding and managing album covers for tracks
-// and photos for artists directly in the Aeron database, functionality that is
-// not natively supported by the system.
+// This server provides an unofficial REST API for the Aeron radio automation system.
+// It offers image management, database browsing, database maintenance, and backup
+// functionality through direct database access.
 //
 // The API server can be configured via JSON configuration file and supports
 // optional API key authentication for secure access.
@@ -43,7 +42,7 @@ func run() error {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("Aeron Image Manager %s (%s)\n", Version, Commit)
+		fmt.Printf("Aeron Toolbox %s (%s)\n", Version, Commit)
 		fmt.Printf("Build time: %s\n", BuildTime)
 		return nil
 	}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
-# ZWFM Aeron API Tests
+# Aeron Toolbox Tests
 
-This directory contains test fixtures and data for the ZWFM Aeron API project.
+This directory contains test fixtures and data for the Aeron Toolbox project.
 
 ## Structure
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
-// Package main provides version information for the Aeron Image Manager API.
+// Package main provides version information for the Aeron Toolbox API.
 package main
 
 // Version is the build version string, set at build time via ldflags.


### PR DESCRIPTION
## Samenvatting

Hernoemen van "Aeron Image Manager API" naar "Aeron Toolbox" om de uitgebreide functionaliteit beter te weerspiegelen:

- **Afbeeldingenbeheer** - Upload en beheer albumhoezen en artiestfoto's
- **Mediabrowser** - Bekijk artiesten, tracks en playlists
- **Database-onderhoud** - Health monitoring, VACUUM en ANALYZE
- **Backup-management** - Maak, download en beheer backups

## Wijzigingen

- README.md, API.md: titels en beschrijvingen
- main.go, version.go: package comments en version output
- internal/service/*.go: package comments
- tests/README.md: project naam
- Dockerfile: fix config.yaml* → config.json*
- GitHub repo description bijgewerkt