### PR TITLE
feat: add configurable debug logging

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -41,7 +41,7 @@ type HealthResponse struct {
 // ImageUploadResponse represents the response for image upload operations.
 type ImageUploadResponse struct {
 	Artist               string  `json:"artist"`
-	Track                string  `json:"track,omitempty"`
+	Track                string  `json:"track,omitzero"`
 	OriginalSize         int     `json:"original_size"`
 	OptimizedSize        int     `json:"optimized_size"`
 	SizeReductionPercent float64 `json:"savings_percent"`
@@ -56,8 +56,8 @@ type BulkDeleteResponse struct {
 // ImageDeleteResponse represents the response for image delete operations.
 type ImageDeleteResponse struct {
 	Message  string `json:"message"`
-	ArtistID string `json:"artist_id,omitempty"`
-	TrackID  string `json:"track_id,omitempty"`
+	ArtistID string `json:"artist_id,omitzero"`
+	TrackID  string `json:"track_id,omitzero"`
 }
 
 // validateAndGetEntityID extracts and validates the entity ID from the request.
@@ -90,6 +90,7 @@ func (s *Server) handleStats(entityType types.EntityType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		stats, err := s.service.Media.GetStatistics(r.Context(), entityType)
 		if err != nil {
+			slog.Error("Statistieken ophalen mislukt", "entityType", entityType, "error", err)
 			respondError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
@@ -304,6 +305,7 @@ func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
 		opts := parsePlaylistOptions(query)
 		playlist, err := s.service.Media.GetPlaylist(r.Context(), &opts)
 		if err != nil {
+			slog.Error("Playlist ophalen mislukt", "block_id", opts.BlockID, "error", err)
 			respondError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
@@ -312,8 +314,10 @@ func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// All blocks with tracks for a date
-	result, err := s.service.Media.GetPlaylistWithTracks(r.Context(), query.Get("date"))
+	date := query.Get("date")
+	result, err := s.service.Media.GetPlaylistWithTracks(r.Context(), date)
 	if err != nil {
+		slog.Error("Playlist met tracks ophalen mislukt", "date", date, "error", err)
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/api/maintenance.go
+++ b/internal/api/maintenance.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/service"
@@ -23,6 +24,7 @@ type AnalyzeRequest struct {
 func (s *Server) handleDatabaseHealth(w http.ResponseWriter, r *http.Request) {
 	health, err := s.service.Maintenance.GetHealth(r.Context())
 	if err != nil {
+		slog.Error("Database health check mislukt", "error", err)
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -43,6 +45,7 @@ func (s *Server) handleVacuum(w http.ResponseWriter, r *http.Request) {
 		DryRun:  req.DryRun,
 	})
 	if err != nil {
+		slog.Error("Vacuum operatie mislukt", "tables", req.Tables, "error", err)
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -59,6 +62,7 @@ func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.service.Maintenance.Analyze(r.Context(), req.Tables)
 	if err != nil {
+		slog.Error("Analyze operatie mislukt", "tables", req.Tables, "error", err)
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -80,8 +81,9 @@ func (s *Server) Start(port string) error {
 	})
 
 	s.server = &http.Server{
-		Addr:    ":" + port,
-		Handler: router,
+		Addr:              ":" + port,
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	return s.server.ListenAndServe()

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -44,7 +44,7 @@ type Optimizer struct {
 	Config Config
 }
 
-// NewOptimizer creates a new Optimizer with the specified configuration.
+// NewOptimizer returns an Optimizer configured with the specified settings.
 func NewOptimizer(config Config) *Optimizer {
 	return &Optimizer{Config: config}
 }

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -27,7 +27,7 @@ func (e *NotFoundError) Error() string {
 
 func (e *NotFoundError) StatusCode() int { return http.StatusNotFound }
 
-// NewNotFoundError creates a NotFoundError for missing resources.
+// NewNotFoundError returns an error indicating a resource could not be found.
 func NewNotFoundError(resource, id string) *NotFoundError {
 	return &NotFoundError{Resource: resource, ID: id}
 }
@@ -44,7 +44,7 @@ func (e *ValidationError) Error() string {
 
 func (e *ValidationError) StatusCode() int { return http.StatusBadRequest }
 
-// NewValidationError creates a new ValidationError.
+// NewValidationError returns an error indicating input validation failed.
 func NewValidationError(field, message string) *ValidationError {
 	return &ValidationError{Field: field, Message: message}
 }
@@ -68,7 +68,7 @@ func (e *OperationError) Unwrap() error {
 
 func (e *OperationError) StatusCode() int { return http.StatusInternalServerError }
 
-// NewOperationError creates a new OperationError.
+// NewOperationError returns an error indicating a runtime operation failed.
 func NewOperationError(operation string, err error) *OperationError {
 	return &OperationError{Operation: operation, Err: err}
 }
@@ -85,7 +85,7 @@ func (e *ConfigError) Error() string {
 
 func (e *ConfigError) StatusCode() int { return http.StatusInternalServerError }
 
-// NewConfigError creates a new ConfigError.
+// NewConfigError returns an error indicating invalid configuration.
 func NewConfigError(field, message string) *ConfigError {
 	return &ConfigError{Field: field, Message: message}
 }

--- a/internal/util/validators.go
+++ b/internal/util/validators.go
@@ -12,12 +12,15 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/doyensec/safeurl"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-var uuidRegex = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+var uuidRegex = sync.OnceValue(func() *regexp.Regexp {
+	return regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+})
 
 // ValidateEntityID validates that an ID is a proper UUID v4 format.
 func ValidateEntityID(id, entityLabel string) error {
@@ -25,7 +28,7 @@ func ValidateEntityID(id, entityLabel string) error {
 		return types.NewValidationError("id", fmt.Sprintf("ongeldige %s-ID: mag niet leeg zijn", entityLabel))
 	}
 
-	if !uuidRegex.MatchString(id) {
+	if !uuidRegex().MatchString(id) {
 		return types.NewValidationError("id", fmt.Sprintf("ongeldige %s-ID: moet een UUID zijn", entityLabel))
 	}
 


### PR DESCRIPTION
## Summary

- Add `LOG_LEVEL` environment variable for runtime log level configuration
- Add `LogConfig` struct with configurable level (debug/info/warn/error) and format (text/json)
- Add strategic `slog.Debug` calls for entity lookups and image processing flow
- Use `context.WithTimeoutCause` for improved timeout diagnostics in scheduled backups

## Additional improvements

- Apply Go 1.24 optimizations: `omitzero` JSON tags, `slices.SortFunc`, `sync.OnceValue`
- Improve godoc comments to follow Go documentation standards

## Usage

```bash
# Enable debug logging via environment
LOG_LEVEL=debug ./zwfm-aerontoolbox

# Or configure in config.json
{
  "log": {
    "level": "debug",
    "format": "text"
  }
}
```

## Test plan

- [x] Verify `LOG_LEVEL=debug` produces debug output
- [x] Verify default log level is `info`
- [x] Verify JSON format works with `format: "json"`
- [x] Build and lint pass