### PR TITLE
feat: add automatic backup validation

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -854,6 +854,34 @@ jobs:
           echo "::error::Backup timeout na 60 seconden"
           exit 1
 
+      - name: "Backup: On-demand validation endpoint"
+        if: matrix.suite == 'backup'
+        run: |
+          echo "GET /api/db/backups/${{ env.BACKUP_FILENAME }}/validate"
+          RESPONSE=$(curl -s -H "X-API-Key: ${{ env.API_KEY }}" \
+            "http://localhost:${{ env.API_PORT }}/api/db/backups/${{ env.BACKUP_FILENAME }}/validate")
+          VALID=$(echo "$RESPONSE" | jq -r '.data.valid')
+          FORMAT=$(echo "$RESPONSE" | jq -r '.data.format')
+          if [ "$VALID" = "true" ]; then
+            echo "On-demand validatie OK (format: $FORMAT)"
+          else
+            echo "::error::Validatie zou moeten slagen"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+
+      - name: "Backup: Validate non-existent returns 404"
+        if: matrix.suite == 'backup'
+        run: |
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "X-API-Key: ${{ env.API_KEY }}" \
+            "http://localhost:${{ env.API_PORT }}/api/db/backups/aeron-backup-fake.dump/validate")
+          if [ "$HTTP_CODE" = "404" ]; then
+            echo "Correct: niet-bestaand bestand geeft 404"
+          else
+            echo "::error::Verwachtte 404, kreeg $HTTP_CODE"
+            exit 1
+          fi
+
       - name: "Backup: Concurrent backup rejected"
         if: matrix.suite == 'backup'
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Een **onofficiële** REST API voor het Aeron-radioautomatiseringssysteem met too
 | **Afbeeldingenbeheer** | Upload, optimaliseer en beheer albumhoezen en artiestfoto's |
 | **Mediabrowser** | Bekijk artiesten, tracks en playlists met uitgebreide metadata |
 | **Database-onderhoud** | Health monitoring, VACUUM en ANALYZE operaties |
-| **Backup-management** | Maak, download en beheer database backups |
+| **Backup-management** | Maak, valideer, download en beheer database backups |
 
 ## Installatie
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -98,3 +98,15 @@ func (s *Server) handleDeleteBackup(w http.ResponseWriter, r *http.Request) {
 		Filename: filename,
 	})
 }
+
+func (s *Server) handleValidateBackup(w http.ResponseWriter, r *http.Request) {
+	filename := chi.URLParam(r, "filename")
+
+	result, err := s.service.Backup.Validate(filename)
+	if err != nil {
+		respondError(w, errorCode(err), err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, result)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,6 +74,7 @@ func (s *Server) Start(port string) error {
 
 				r.Get("/backups", s.handleListBackups)
 				r.Get("/backup/status", s.handleBackupStatus)
+				r.Get("/backups/{filename}/validate", s.handleValidateBackup)
 				r.Delete("/backups/{filename}", s.handleDeleteBackup)
 			})
 		})

--- a/internal/service/validator.go
+++ b/internal/service/validator.go
@@ -1,0 +1,92 @@
+// Package service provides business logic for the Aeron Toolbox.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
+)
+
+// validateBackup validates backup file integrity based on format.
+func validateBackup(ctx context.Context, filePath, format string) error {
+	if format == "custom" {
+		return validateWithPgRestore(ctx, filePath)
+	}
+	return validatePlainSQL(ctx, filePath)
+}
+
+func validateWithPgRestore(ctx context.Context, filePath string) error {
+	pgRestorePath, err := exec.LookPath("pg_restore")
+	if err != nil {
+		return types.NewConfigError("pg_restore", "pg_restore niet gevonden - installeer postgresql-client")
+	}
+
+	cmd := exec.CommandContext(ctx, pgRestorePath, "--list", filePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		errMsg := strings.TrimSpace(string(output))
+		if errMsg == "" {
+			errMsg = err.Error()
+		}
+		return types.NewOperationError("backup validatie", fmt.Errorf("bestand is corrupt of onleesbaar: %s", errMsg))
+	}
+	return nil
+}
+
+func validatePlainSQL(ctx context.Context, filePath string) (returnErr error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return types.NewOperationError("backup validatie", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && returnErr == nil {
+			returnErr = types.NewOperationError("backup validatie", closeErr)
+		}
+	}()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return types.NewOperationError("backup validatie", err)
+	}
+	if stat.Size() == 0 {
+		return types.NewOperationError("backup validatie", errors.New("bestand is leeg"))
+	}
+
+	// Check header (first 1KB)
+	header := make([]byte, 1024)
+	n, err := file.Read(header)
+	if err != nil && err != io.EOF {
+		return types.NewOperationError("backup validatie", err)
+	}
+	if !strings.Contains(string(header[:n]), "-- PostgreSQL database dump") {
+		return types.NewOperationError("backup validatie", errors.New("ongeldige SQL dump - header ontbreekt"))
+	}
+
+	// Check footer (last 1KB)
+	if stat.Size() > 1024 {
+		if _, err = file.Seek(-1024, io.SeekEnd); err != nil {
+			return types.NewOperationError("backup validatie", err)
+		}
+	} else {
+		if _, err = file.Seek(0, io.SeekStart); err != nil {
+			return types.NewOperationError("backup validatie", err)
+		}
+	}
+
+	footer := make([]byte, 1024)
+	n, err = file.Read(footer)
+	if err != nil && err != io.EOF {
+		return types.NewOperationError("backup validatie", err)
+	}
+	if !strings.Contains(string(footer[:n]), "-- PostgreSQL database dump complete") {
+		return types.NewOperationError("backup validatie", errors.New("SQL dump is incompleet - footer ontbreekt"))
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Backups worden automatisch gevalideerd na pg_dump voltooiing
- Custom format (.dump): validatie via `pg_restore --list` (controleert TOC en checksums)
- Plain format (.sql): controle op PostgreSQL dump header/footer markers
- S3 sync draait alleen na succesvolle validatie
- Nieuw endpoint voor on-demand validatie: `GET /api/db/backups/{filename}/validate`

## Wijzigingen

- `internal/service/validator.go` - Nieuwe validator functies
- `internal/service/backup.go` - Validatie integratie in backup flow
- `internal/api/backup.go` - Validation endpoint handler
- `internal/api/server.go` - Route registratie
- `.github/workflows/comprehensive-test.yml` - Integratietests
- Documentatie updates (API.md, CLAUDE.md, README.md)

## Test plan

- [x] Backup aanmaken (custom format) en validatie controleren via status endpoint
- [x] Backup aanmaken (plain format) en validatie controleren
- [x] On-demand validatie endpoint testen met bestaande backup
- [x] Validatie endpoint met niet-bestaand bestand (verwacht 404)
- [x] CI tests draaien succesvol