### PR TITLE
feat: make scheduler timezone configurable

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -886,7 +886,7 @@ jobs:
             "image": { "target_width": 1280, "target_height": 1280, "quality": 90, "reject_smaller": true },
             "api": { "enabled": true, "keys": ["test-api-key-12345"] },
             "maintenance": {
-              "scheduler": { "enabled": true, "schedule": "0 4 * * 0", "timezone": "Europe/Amsterdam" }
+              "scheduler": { "enabled": true, "schedule": "0 4 * * 0" }
             }
           }
           EOF

--- a/API.md
+++ b/API.md
@@ -750,7 +750,7 @@ Database-onderhoud kan automatisch worden uitgevoerd via de ingebouwde scheduler
 - `scheduler.enabled`: Schakel automatisch onderhoud in/uit
 - `scheduler.schedule`: Cron-expressie (zie backup-sectie voor voorbeelden)
 
-De scheduler draait VACUUM ANALYZE op tabellen die aan de threshold-criteria voldoen. Alle jobs gebruiken de Europe/Amsterdam-tijdzone.
+De scheduler draait VACUUM ANALYZE op tabellen die aan de threshold-criteria voldoen. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via `TZ` environment variable).
 
 ---
 
@@ -801,8 +801,7 @@ Backups kunnen automatisch worden uitgevoerd via de ingebouwde scheduler. Config
 - `enabled`: Schakel automatische backups in/uit
 - `schedule`: Cron-expressie voor het backup-schema
 
-> [!IMPORTANT]
-> Alle geplande taken (backup én onderhoud) gebruiken de Europe/Amsterdam-tijdzone (hardcoded, niet configureerbaar).
+De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als environment variable.
 
 **Cron-expressieformaat:** `minuut uur dag maand weekdag`
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,16 @@ Of direct met `docker run`:
 
 ```bash
 docker run -d -p 8080:8080 \
+  -e TZ=Europe/Amsterdam \
   -v $(pwd)/config.json:/app/config.json:ro \
   -v $(pwd)/backups:/backups \
   --name zwfm-aerontoolbox \
   --restart unless-stopped \
   ghcr.io/oszuidwest/zwfm-aerontoolbox:latest
 ```
+
+> [!NOTE]
+> De `TZ` environment variable bepaalt de tijdzone voor geplande taken (backups en onderhoud).
 
 ### Binary
 

--- a/config.example.json
+++ b/config.example.json
@@ -34,8 +34,7 @@
     "timeout_minutes": 30,
     "scheduler": {
       "enabled": false,
-      "schedule": "0 4 * * 0",
-      "timezone": ""
+      "schedule": "0 4 * * 0"
     }
   },
   "backup": {
@@ -49,8 +48,7 @@
     "pg_restore_path": "",
     "scheduler": {
       "enabled": false,
-      "schedule": "0 3 * * *",
-      "timezone": ""
+      "schedule": "0 3 * * *"
     },
     "s3": {
       "enabled": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,11 +58,10 @@ type MaintenanceConfig struct {
 	Scheduler                SchedulerConfig `json:"scheduler"`
 }
 
-// SchedulerConfig contains settings for scheduled operations.
+// SchedulerConfig contains settings for individual scheduled operations.
 type SchedulerConfig struct {
 	Enabled  bool   `json:"enabled"`
 	Schedule string `json:"schedule" validate:"required_if=Enabled true"`
-	Timezone string `json:"timezone" validate:"omitempty,timezone"`
 }
 
 // S3Config contains settings for S3-compatible storage synchronization.
@@ -295,14 +294,6 @@ func newConfigValidator() *validator.Validate {
 	_ = v.RegisterValidation("identifier", func(fl validator.FieldLevel) bool {
 		return types.IsValidIdentifier(fl.Field().String())
 	})
-	_ = v.RegisterValidation("timezone", func(fl validator.FieldLevel) bool {
-		tz := fl.Field().String()
-		if tz == "" {
-			return true
-		}
-		_, err := time.LoadLocation(tz)
-		return err == nil
-	})
 
 	v.RegisterStructValidation(validateS3Config, S3Config{})
 
@@ -365,8 +356,6 @@ func tagMessage(tag, param string) string {
 		return fmt.Sprintf("must be one of [%s]", param)
 	case "identifier":
 		return "contains invalid characters (only letters, numbers and underscores allowed)"
-	case "timezone":
-		return "is not a valid timezone"
 	default:
 		return fmt.Sprintf("is invalid (%s)", tag)
 	}

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -22,17 +22,14 @@ type Scheduler struct {
 }
 
 // NewScheduler creates a scheduler and registers all enabled scheduled jobs.
+// The scheduler uses the system's local timezone (set via TZ environment variable).
 func NewScheduler(svc *AeronService) (*Scheduler, error) {
 	cfg := svc.Config()
 
-	// Default to Europe/Amsterdam timezone for scheduled jobs
-	loc, err := time.LoadLocation("Europe/Amsterdam")
-	if err != nil {
-		loc = time.Local
-	}
+	slog.Info("Scheduler using system timezone", "timezone", time.Local.String())
 
 	c := cron.New(
-		cron.WithLocation(loc),
+		cron.WithLocation(time.Local),
 		cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)),
 	)
 


### PR DESCRIPTION
## Summary

Use system timezone for scheduler instead of config-based timezone.

The scheduler now uses `time.Local` (system timezone) which can be controlled via the `TZ` environment variable in Docker deployments. This is the standard and simpler approach.

## Before (hardcoded)
```go
loc, err := time.LoadLocation("Europe/Amsterdam")
```

## After (system timezone)
```go
cron.WithLocation(time.Local)
```

## Docker usage
```dockerfile
ENV TZ=Europe/Amsterdam
```

## Changes

- Use `time.Local` directly in scheduler
- Remove unnecessary config option
- Update documentation

## Test plan

- [x] Build passes
- [x] Linting passes
- [x] Verify scheduler uses system timezone
- [x] Verify TZ env var works in Docker

Closes #48