### PR TITLE
chore: add documentation and security linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,21 @@ version: "2"
 
 linters:
   enable:
+    # Existing
     - gocritic
     - gocyclo
+    # Doc/Comment
+    - godot
+    - godoclint
+    - dupword
+    - misspell
+    # Code quality
+    - errorlint
+    - gosec
+    - nilerr
+    - unparam
+    - unconvert
+    - bodyclose
   settings:
     gocritic:
       enabled-tags:
@@ -12,3 +25,5 @@ linters:
         - performance
     gocyclo:
       min-complexity: 20
+    godot:
+      scope: toplevel

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -1,4 +1,3 @@
-// Package api provides the HTTP API server for the Aeron radio automation system.
 package api
 
 import (

--- a/internal/api/maintenance.go
+++ b/internal/api/maintenance.go
@@ -1,4 +1,3 @@
-// Package api provides the HTTP API server for the Aeron radio automation system.
 package api
 
 import (

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -1,4 +1,3 @@
-// Package api provides the HTTP API server for the Aeron radio automation system.
 package api
 
 import (

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,4 +1,3 @@
-// Package api provides the HTTP API server for the Aeron radio automation system.
 package api
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -265,7 +266,7 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(configPath) //nolint:gosec // config path is validated via CLI flag or default
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -321,8 +322,8 @@ func validate(config *Config) error {
 
 // formatErrors converts validator errors to user-friendly messages.
 func formatErrors(err error) error {
-	ve, ok := err.(validator.ValidationErrors)
-	if !ok {
+	var ve validator.ValidationErrors
+	if !errors.As(err, &ve) {
 		return err
 	}
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,9 +1,9 @@
-// Package database provides PostgreSQL data access for the Aeron database.
 package database
 
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 
@@ -109,9 +109,11 @@ const trackDetailsQuery = `
 
 func getEntityByID[T any](ctx context.Context, db DB, query, id, label, operation string) (*T, error) {
 	var entity T
-	if err := db.GetContext(ctx, &entity, query, id); err == sql.ErrNoRows {
+	err := db.GetContext(ctx, &entity, query, id)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, types.NewNotFoundError(label, id)
-	} else if err != nil {
+	}
+	if err != nil {
 		return nil, &types.OperationError{Operation: operation, Err: err}
 	}
 	return &entity, nil

--- a/internal/database/playlist.go
+++ b/internal/database/playlist.go
@@ -1,4 +1,3 @@
-// Package database provides PostgreSQL data access for the Aeron database.
 package database
 
 import (

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -4,6 +4,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -38,7 +39,7 @@ func (r *Repository) Ping(ctx context.Context) error {
 	return r.db.PingContext(ctx)
 }
 
-// --- Artist operations ---
+// Artist operations.
 
 // GetArtist retrieves complete artist details by UUID.
 func (r *Repository) GetArtist(ctx context.Context, id string) (*ArtistDetails, error) {
@@ -47,7 +48,7 @@ func (r *Repository) GetArtist(ctx context.Context, id string) (*ArtistDetails, 
 	return getEntityByID[ArtistDetails](ctx, r.db, query, id, "artist", "fetch artist")
 }
 
-// --- Track operations ---
+// Track operations.
 
 // GetTrack retrieves complete track details by UUID.
 func (r *Repository) GetTrack(ctx context.Context, id string) (*TrackDetails, error) {
@@ -56,7 +57,7 @@ func (r *Repository) GetTrack(ctx context.Context, id string) (*TrackDetails, er
 	return getEntityByID[TrackDetails](ctx, r.db, query, id, "track", "fetch track")
 }
 
-// --- Image operations ---
+// Image operations.
 
 // GetImage retrieves the image for an entity.
 func (r *Repository) GetImage(ctx context.Context, table types.Table, id string) ([]byte, error) {
@@ -72,7 +73,7 @@ func (r *Repository) GetImage(ctx context.Context, table types.Table, id string)
 	var imageData []byte
 	err = r.db.GetContext(ctx, &imageData, query, id)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, types.NewNotFoundError(label, id)
 	}
 	if err != nil {
@@ -131,7 +132,7 @@ func (r *Repository) DeleteImage(ctx context.Context, table types.Table, id stri
 	return nil
 }
 
-// --- Count operations ---
+// Count operations.
 
 // CountWithImages counts entities that have images.
 func (r *Repository) CountWithImages(ctx context.Context, table types.Table) (int, error) {
@@ -182,7 +183,7 @@ func (r *Repository) DeleteAllImages(ctx context.Context, table types.Table) (in
 	return result.RowsAffected()
 }
 
-// --- Playlist operations ---
+// Playlist operations.
 
 // GetPlaylist retrieves playlist items based on options.
 func (r *Repository) GetPlaylist(ctx context.Context, opts *PlaylistOptions) ([]PlaylistItem, error) {

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -1,4 +1,3 @@
-// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (
@@ -104,7 +103,7 @@ func (s *BackupService) Close() {
 	s.runner.Close()
 }
 
-// --- Types ---
+// Types.
 
 // BackupRequest represents the request body for backup operations.
 type BackupRequest struct {
@@ -126,7 +125,7 @@ type BackupListResponse struct {
 	TotalCount int          `json:"total_count"`
 }
 
-// --- Helpers ---
+// Helpers.
 
 var safeBackupFilenamePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-.]+$`)
 
@@ -193,7 +192,7 @@ func (s *BackupService) compressionLevel(requested int) (int, error) {
 
 // validateBackupFile checks backup file integrity using pg_restore --list.
 func (s *BackupService) validateBackupFile(ctx context.Context, filePath string) error {
-	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list", filePath)
+	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list", filePath) //nolint:gosec // pgRestorePath is from validated config
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		errMsg := strings.TrimSpace(string(output))
@@ -253,7 +252,7 @@ func (s *BackupService) executePgDump(ctx context.Context, pgDumpPath, filename,
 	return fileInfo, duration, nil
 }
 
-// --- Public methods ---
+// Public methods.
 
 // Start initiates a database backup in the background. Returns an error if validation fails or a backup is already running.
 func (s *BackupService) Start(req BackupRequest) error {
@@ -558,7 +557,7 @@ func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
 	return result, nil
 }
 
-// --- Background cleanup ---
+// Background cleanup.
 
 // cleanupOldBackups removes files exceeding retention days or max backup count.
 func (s *BackupService) cleanupOldBackups() {

--- a/internal/service/maintenance.go
+++ b/internal/service/maintenance.go
@@ -1,4 +1,3 @@
-// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (
@@ -51,7 +50,7 @@ func (s *MaintenanceService) Close() {
 	s.runner.Close()
 }
 
-// --- Types ---
+// Maintenance types.
 
 // DatabaseHealth represents the overall health status of the database.
 type DatabaseHealth struct {
@@ -145,7 +144,7 @@ type maintenanceContext struct {
 	schema       string
 }
 
-// --- Health operations ---
+// Health operations.
 
 // GetHealth retrieves comprehensive database health information.
 func (s *MaintenanceService) GetHealth(ctx context.Context) (*DatabaseHealth, error) {
@@ -331,7 +330,7 @@ func lastVacuumTime(t *TableHealth) *time.Time {
 	return t.LastAutovacuum
 }
 
-// --- Maintenance operations ---
+// Maintenance operations.
 
 // newMaintenanceContext loads current table health data for maintenance operations.
 func (s *MaintenanceService) newMaintenanceContext(ctx context.Context) (*maintenanceContext, error) {
@@ -413,7 +412,7 @@ func (s *MaintenanceService) executeAnalyze(ctx context.Context, tableName strin
 	return err
 }
 
-// --- Async operations ---
+// Async operations.
 
 // maintenanceTask defines parameters for a generic maintenance operation.
 type maintenanceTask struct {

--- a/internal/service/media.go
+++ b/internal/service/media.go
@@ -1,4 +1,3 @@
-// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (
@@ -26,21 +25,21 @@ func newMediaService(repo *database.Repository, cfg *config.Config) *MediaServic
 	}
 }
 
-// --- Artist operations ---
+// Artist operations.
 
 // GetArtist retrieves an artist by ID.
 func (s *MediaService) GetArtist(ctx context.Context, id string) (*database.ArtistDetails, error) {
 	return s.repo.GetArtist(ctx, id)
 }
 
-// --- Track operations ---
+// Track operations.
 
 // GetTrack retrieves a track by ID.
 func (s *MediaService) GetTrack(ctx context.Context, id string) (*database.TrackDetails, error) {
 	return s.repo.GetTrack(ctx, id)
 }
 
-// --- Image operations ---
+// Image operations.
 
 // GetImage retrieves the image for an entity.
 func (s *MediaService) GetImage(ctx context.Context, entityType types.EntityType, id string) ([]byte, error) {
@@ -137,7 +136,7 @@ func (s *MediaService) UploadImage(ctx context.Context, params *ImageUploadParam
 	}, nil
 }
 
-// --- Statistics operations ---
+// Statistics operations.
 
 // ImageStats represents statistics about images in the database.
 type ImageStats struct {
@@ -202,7 +201,7 @@ func (s *MediaService) DeleteAllImages(ctx context.Context, entityType types.Ent
 	return &DeleteResult{CountBefore: count, DeletedCount: deleted}, nil
 }
 
-// --- Playlist operations ---
+// Playlist operations.
 
 // PlaylistOptions configures playlist queries with filtering and pagination.
 type PlaylistOptions struct {
@@ -269,7 +268,7 @@ func (s *MediaService) GetPlaylistWithTracks(ctx context.Context, date string) (
 	return result, nil
 }
 
-// --- Validation helpers ---
+// Validation helpers.
 
 // validateEntityType ensures the entity type is either artist or track.
 func validateEntityType(entityType types.EntityType) error {

--- a/internal/service/s3.go
+++ b/internal/service/s3.go
@@ -1,4 +1,3 @@
-// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (
@@ -25,7 +24,7 @@ type s3Service struct {
 }
 
 // newS3Service creates an S3 client for backup synchronization, or returns nil if disabled.
-func newS3Service(cfg *config.S3Config) (*s3Service, error) {
+func newS3Service(cfg *config.S3Config) (*s3Service, error) { //nolint:unparam // error return kept for future use
 	if !cfg.Enabled {
 		return nil, nil
 	}
@@ -65,7 +64,7 @@ func ptrOrNil(s string) *string {
 
 // upload transfers a backup file to S3 storage.
 func (s *s3Service) upload(ctx context.Context, filename, localPath string) (err error) {
-	file, err := os.Open(localPath)
+	file, err := os.Open(localPath) //nolint:gosec // localPath is constructed from validated backup filename
 	if err != nil {
 		return types.NewOperationError("S3 upload", fmt.Errorf("open file: %w", err))
 	}

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -1,4 +1,3 @@
-// Package service provides business logic for the Aeron Toolbox.
 package service
 
 import (

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -142,7 +143,7 @@ func serveUntilShutdown(server *api.Server, port string, scheduler *service.Sche
 	serverErr := make(chan error, 1)
 	go func() {
 		slog.Info("API server started", "port", port)
-		if err := server.Start(port); err != nil && err != http.ErrServerClosed {
+		if err := server.Start(port); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErr <- err
 		}
 	}()


### PR DESCRIPTION
## Summary
- Enable additional golangci-lint checks for documentation and code quality: godot, godoclint, dupword, misspell, errorlint, gosec, nilerr, unparam, unconvert, bodyclose
- Fix all issues found by the new linters including:
  - Using `errors.As` and `errors.Is` instead of direct type assertions/comparisons
  - Removing duplicate package comments (only one file per package should have the doc)
  - Adding periods to section comments
  - Adding `//nolint:gosec` comments with justifications for safe usages

## Test plan
- [x] `golangci-lint run --timeout=5m` passes with 0 issues
- [x] `go build` succeeds
- [x] `go vet ./...` passes