### PR TITLE
refactor: reduce duplication and improve reuse across codebase

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/database"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/notify"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/service"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
@@ -315,7 +316,7 @@ func (s *Server) handleDeleteImage(entityType types.EntityType) http.HandlerFunc
 	}
 }
 
-func parsePlaylistOptions(query url.Values) service.PlaylistOptions {
+func parsePlaylistOptions(query url.Values) database.PlaylistOptions {
 	opts := service.DefaultPlaylistOptions()
 	opts.BlockID = query.Get("block_id")
 
@@ -382,13 +383,7 @@ func (s *Server) handleTestEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := notify.NewGraphClient(emailCfg)
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create Graph client: %v", err))
-		return
-	}
-
-	if err := client.ValidateAuth(); err != nil {
+	if err := s.service.Notify.ValidateAuth(); err != nil {
 		respondError(w, http.StatusBadGateway, fmt.Sprintf("Authentication failed: %v", err))
 		return
 	}

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -39,6 +39,15 @@ func (r *Repository) Ping(ctx context.Context) error {
 	return r.db.PingContext(ctx)
 }
 
+// resolveTable returns the qualified table name, label, and ID column for the given table.
+func (r *Repository) resolveTable(table types.Table) (qualifiedName, label, idCol string, err error) {
+	qualifiedName, err = types.QualifiedTable(r.schema, table)
+	if err != nil {
+		return "", "", "", types.NewValidationError("table", fmt.Sprintf("invalid table configuration: %v", err))
+	}
+	return qualifiedName, string(table), types.IDColumnForTable(table), nil
+}
+
 // Artist operations.
 
 // GetArtist retrieves complete artist details by UUID.
@@ -61,12 +70,10 @@ func (r *Repository) GetTrack(ctx context.Context, id string) (*TrackDetails, er
 
 // GetImage retrieves the image for an entity.
 func (r *Repository) GetImage(ctx context.Context, table types.Table, id string) ([]byte, error) {
-	qualifiedTableName, err := types.QualifiedTable(r.schema, table)
+	qualifiedTableName, label, idCol, err := r.resolveTable(table)
 	if err != nil {
-		return nil, types.NewValidationError("table", fmt.Sprintf("invalid table configuration: %v", err))
+		return nil, err
 	}
-	label := string(table)
-	idCol := types.IDColumnForTable(table)
 
 	query := fmt.Sprintf("SELECT picture FROM %s WHERE %s = $1", qualifiedTableName, idCol)
 
@@ -88,12 +95,10 @@ func (r *Repository) GetImage(ctx context.Context, table types.Table, id string)
 
 // UpdateImage stores new image data for the specified entity.
 func (r *Repository) UpdateImage(ctx context.Context, table types.Table, id string, imageData []byte) error {
-	qualifiedTableName, err := types.QualifiedTable(r.schema, table)
+	qualifiedTableName, label, idCol, err := r.resolveTable(table)
 	if err != nil {
-		return types.NewValidationError("table", fmt.Sprintf("invalid table configuration: %v", err))
+		return err
 	}
-	label := string(table)
-	idCol := types.IDColumnForTable(table)
 
 	query := fmt.Sprintf("UPDATE %s SET picture = $1 WHERE %s = $2", qualifiedTableName, idCol)
 
@@ -106,12 +111,10 @@ func (r *Repository) UpdateImage(ctx context.Context, table types.Table, id stri
 
 // DeleteImage removes the image for an entity.
 func (r *Repository) DeleteImage(ctx context.Context, table types.Table, id string) error {
-	qualifiedTableName, err := types.QualifiedTable(r.schema, table)
+	qualifiedTableName, label, idCol, err := r.resolveTable(table)
 	if err != nil {
-		return types.NewValidationError("table", fmt.Sprintf("invalid table configuration: %v", err))
+		return err
 	}
-	label := string(table)
-	idCol := types.IDColumnForTable(table)
 
 	query := fmt.Sprintf("UPDATE %s SET picture = NULL WHERE %s = $1", qualifiedTableName, idCol)
 
@@ -134,14 +137,30 @@ func (r *Repository) DeleteImage(ctx context.Context, table types.Table, id stri
 
 // Count operations.
 
+// ImageCounts contains total and with-image counts for a table.
+type ImageCounts struct {
+	Total      int `db:"total"`
+	WithImages int `db:"with_images"`
+}
+
+// CountImages returns total entity count and count with images in a single query.
+func (r *Repository) CountImages(ctx context.Context, table types.Table) (*ImageCounts, error) {
+	qualifiedTableName, label, _, err := r.resolveTable(table)
+	if err != nil {
+		return nil, err
+	}
+	query := fmt.Sprintf("SELECT COUNT(*) AS total, COUNT(picture) AS with_images FROM %s", qualifiedTableName)
+
+	var counts ImageCounts
+	if err := r.db.GetContext(ctx, &counts, query); err != nil {
+		return nil, types.NewOperationError(fmt.Sprintf("count %s", label), err)
+	}
+	return &counts, nil
+}
+
 // CountWithImages counts entities that have images.
 func (r *Repository) CountWithImages(ctx context.Context, table types.Table) (int, error) {
 	return r.countItems(ctx, table, true)
-}
-
-// CountWithoutImages counts entities that don't have images.
-func (r *Repository) CountWithoutImages(ctx context.Context, table types.Table) (int, error) {
-	return r.countItems(ctx, table, false)
 }
 
 func (r *Repository) countItems(ctx context.Context, table types.Table, hasImage bool) (int, error) {
@@ -150,16 +169,16 @@ func (r *Repository) countItems(ctx context.Context, table types.Table, hasImage
 		condition = "IS NOT NULL"
 	}
 
-	qualifiedTableName, err := types.QualifiedTable(r.schema, table)
+	qualifiedTableName, label, _, err := r.resolveTable(table)
 	if err != nil {
-		return 0, types.NewValidationError("table", fmt.Sprintf("invalid table configuration: %v", err))
+		return 0, err
 	}
 	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE picture %s", qualifiedTableName, condition)
 
 	var count int
 	err = r.db.GetContext(ctx, &count, query)
 	if err != nil {
-		return 0, types.NewOperationError(fmt.Sprintf("count %s", table), err)
+		return 0, types.NewOperationError(fmt.Sprintf("count %s", label), err)
 	}
 
 	return count, nil
@@ -167,16 +186,15 @@ func (r *Repository) countItems(ctx context.Context, table types.Table, hasImage
 
 // DeleteAllImages removes all images for entities in the specified table.
 func (r *Repository) DeleteAllImages(ctx context.Context, table types.Table) (int64, error) {
-	qualifiedTableName, err := types.QualifiedTable(r.schema, table)
+	qualifiedTableName, label, _, err := r.resolveTable(table)
 	if err != nil {
-		return 0, types.NewValidationError("table", fmt.Sprintf("invalid table configuration: %v", err))
+		return 0, err
 	}
 
 	query := fmt.Sprintf("UPDATE %s SET picture = NULL WHERE picture IS NOT NULL", qualifiedTableName)
 
 	result, err := r.db.ExecContext(ctx, query)
 	if err != nil {
-		label := string(table)
 		return 0, types.NewOperationError(fmt.Sprintf("delete %s images", label), err)
 	}
 

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -64,12 +64,8 @@ func getImageInfo(data []byte) (format string, width, height int, err error) {
 }
 
 // OptimizeImage processes and optimizes image data according to the configured settings.
-func (o *Optimizer) OptimizeImage(data []byte) (optimized []byte, format, encoder string, err error) {
-	_, format, err = image.DecodeConfig(bytes.NewReader(data))
-	if err != nil {
-		return nil, "", "", err
-	}
-
+// The format parameter is the already-detected image format (e.g. "jpeg", "png").
+func (o *Optimizer) OptimizeImage(data []byte, format string) (optimized []byte, outFormat, encoder string, err error) {
 	switch format {
 	case "jpeg", "jpg":
 		return o.optimizeJPEG(data)
@@ -220,7 +216,7 @@ func createSkippedResult(imageData []byte, originalInfo *Info) *ProcessingResult
 // optimizeImageData runs the optimization pipeline and returns processing results.
 func optimizeImageData(imageData []byte, originalInfo *Info, config Config) (*ProcessingResult, error) {
 	optimizer := NewOptimizer(config)
-	optimizedData, optFormat, optEncoder, err := optimizer.OptimizeImage(imageData)
+	optimizedData, optFormat, optEncoder, err := optimizer.OptimizeImage(imageData, originalInfo.Format)
 	if err != nil {
 		return nil, types.NewValidationError("image", fmt.Sprintf("optimization failed: %v", err))
 	}

--- a/internal/notify/healthalert.go
+++ b/internal/notify/healthalert.go
@@ -47,34 +47,13 @@ func (s *NotificationService) NotifyHealthCheckError(err error) {
 
 // NotifyHealthAlert sends a failure or recovery email based on the health check result.
 func (s *NotificationService) NotifyHealthAlert(r *HealthAlertResult) {
-	if !IsConfigured(&s.config.Notifications.Email) || r == nil {
+	if r == nil {
 		return
 	}
-
-	hasIssues := r.HasIssues()
-
-	s.stateMu.Lock()
-	prevActive := s.prevHealthAlertActive
-
-	if hasIssues {
-		s.prevHealthAlertActive = true
-		s.stateMu.Unlock()
-
-		subject, body := formatHealthAlert(r)
-		s.sendAsync(subject, body)
-		return
-	}
-
-	if prevActive {
-		s.prevHealthAlertActive = false
-		s.stateMu.Unlock()
-
-		subject, body := formatHealthRecovery(r)
-		s.sendAsync(subject, body)
-		return
-	}
-
-	s.stateMu.Unlock()
+	s.notifyOnTransition(&s.prevHealthAlertActive, r.HasIssues(),
+		func() (string, string) { return formatHealthAlert(r) },
+		func() (string, string) { return formatHealthRecovery(r) },
+	)
 }
 
 func formatHealthAlert(r *HealthAlertResult) (subject, body string) {

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -34,8 +34,9 @@ type S3SyncResult struct {
 
 // NotificationService handles email notifications for backup, health check, and S3 sync events.
 type NotificationService struct {
-	config *config.Config
-	runner *async.Runner
+	config     *config.Config
+	runner     *async.Runner
+	recipients []string // parsed once at construction
 
 	// Lazy Graph client (cached by config key)
 	client    *GraphClient
@@ -59,12 +60,13 @@ type NotificationService struct {
 
 // New creates a new NotificationService.
 func New(cfg *config.Config) *NotificationService {
+	emailCfg := &cfg.Notifications.Email
 	svc := &NotificationService{
-		config: cfg,
-		runner: async.New(),
+		config:     cfg,
+		runner:     async.New(),
+		recipients: ParseRecipients(emailCfg.Recipients),
 	}
 
-	emailCfg := &cfg.Notifications.Email
 	if IsConfigured(emailCfg) {
 		svc.expiryChecker = NewSecretExpiryChecker(emailCfg)
 		slog.Info("E-mailnotificaties geconfigureerd")
@@ -75,29 +77,33 @@ func New(cfg *config.Config) *NotificationService {
 	return svc
 }
 
-// NotifyBackupResult sends a failure or recovery email based on the backup result.
-func (s *NotificationService) NotifyBackupResult(r *BackupResult) {
-	if !IsConfigured(&s.config.Notifications.Email) || r == nil {
+// notifyOnTransition sends a failure email on first failure, and a recovery email on first success
+// after a failure. The prevFailed pointer tracks the state for this notification type.
+func (s *NotificationService) notifyOnTransition(
+	prevFailed *bool,
+	isFailing bool,
+	formatFail func() (string, string),
+	formatRecover func() (string, string),
+) {
+	if !IsConfigured(&s.config.Notifications.Email) {
 		return
 	}
 
 	s.stateMu.Lock()
-	prevFailed := s.prevBackupFailed
+	prev := *prevFailed
 
-	if !r.Success {
-		s.prevBackupFailed = true
+	if isFailing {
+		*prevFailed = true
 		s.stateMu.Unlock()
-
-		subject, body := s.formatBackupFailure(r)
+		subject, body := formatFail()
 		s.sendAsync(subject, body)
 		return
 	}
 
-	if prevFailed {
-		s.prevBackupFailed = false
+	if prev {
+		*prevFailed = false
 		s.stateMu.Unlock()
-
-		subject, body := s.formatBackupRecovery(r)
+		subject, body := formatRecover()
 		s.sendAsync(subject, body)
 		return
 	}
@@ -105,34 +111,26 @@ func (s *NotificationService) NotifyBackupResult(r *BackupResult) {
 	s.stateMu.Unlock()
 }
 
+// NotifyBackupResult sends a failure or recovery email based on the backup result.
+func (s *NotificationService) NotifyBackupResult(r *BackupResult) {
+	if r == nil {
+		return
+	}
+	s.notifyOnTransition(&s.prevBackupFailed, !r.Success,
+		func() (string, string) { return s.formatBackupFailure(r) },
+		func() (string, string) { return s.formatBackupRecovery(r) },
+	)
+}
+
 // NotifyS3SyncResult sends a failure or recovery email based on the S3 sync result.
 func (s *NotificationService) NotifyS3SyncResult(filename string, r *S3SyncResult) {
-	if !IsConfigured(&s.config.Notifications.Email) || r == nil {
+	if r == nil {
 		return
 	}
-
-	s.stateMu.Lock()
-	prevFailed := s.prevS3Failed
-
-	if !r.Synced {
-		s.prevS3Failed = true
-		s.stateMu.Unlock()
-
-		subject, body := s.formatS3Failure(filename, r)
-		s.sendAsync(subject, body)
-		return
-	}
-
-	if prevFailed {
-		s.prevS3Failed = false
-		s.stateMu.Unlock()
-
-		subject, body := s.formatS3Recovery(filename)
-		s.sendAsync(subject, body)
-		return
-	}
-
-	s.stateMu.Unlock()
+	s.notifyOnTransition(&s.prevS3Failed, !r.Synced,
+		func() (string, string) { return s.formatS3Failure(filename, r) },
+		func() (string, string) { return s.formatS3Recovery(filename) },
+	)
 }
 
 // LastError returns the last notification send error and when it occurred.
@@ -161,6 +159,15 @@ func (s *NotificationService) StartExpiryChecker() {
 	}
 }
 
+// ValidateAuth verifies that the notification credentials are valid.
+func (s *NotificationService) ValidateAuth() error {
+	client, err := s.getOrCreateClient()
+	if err != nil {
+		return fmt.Errorf("client init: %w", err)
+	}
+	return client.ValidateAuth()
+}
+
 // SendTestEmail sends a synchronous test email to validate the notification setup.
 // The context controls cancellation of the request.
 func (s *NotificationService) SendTestEmail(ctx context.Context) error {
@@ -169,12 +176,11 @@ func (s *NotificationService) SendTestEmail(ctx context.Context) error {
 		return fmt.Errorf("client init: %w", err)
 	}
 
-	recipients := ParseRecipients(s.config.Notifications.Email.Recipients)
 	subject := "[TEST] Aeron Toolbox - E-mailnotificatie test"
 	body := fmt.Sprintf("Dit is een test-e-mail van Aeron Toolbox.\n\nTijdstip: %s\n\nAls u deze e-mail ontvangt, zijn de notificatie-instellingen correct geconfigureerd.",
 		time.Now().Format(timeFormat))
 
-	return client.SendMail(ctx, recipients, subject, body)
+	return client.SendMail(ctx, s.recipients, subject, body)
 }
 
 // Close stops the notification service runner.
@@ -228,8 +234,7 @@ func (s *NotificationService) send(subject, body string) {
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 
-	recipients := ParseRecipients(s.config.Notifications.Email.Recipients)
-	if err := client.SendMail(ctx, recipients, subject, body); err != nil {
+	if err := client.SendMail(ctx, s.recipients, subject, body); err != nil {
 		slog.Error("Notificatie e-mail verzenden mislukt", "error", err, "subject", subject)
 		s.trackError(err)
 		return

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -130,6 +130,11 @@ type BackupListResponse struct {
 
 // Helpers.
 
+const (
+	backupPrefix = "aeron-backup-"
+	backupSuffix = ".dump"
+)
+
 var safeBackupFilenamePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-.]+$`)
 
 // resolveToolPath returns the absolute path to an external tool, checking custom paths first.
@@ -161,7 +166,7 @@ func validateBackupFilename(filename string) error {
 	if !safeBackupFilenamePattern.MatchString(filename) {
 		return types.NewValidationError("filename", "invalid filename")
 	}
-	if !strings.HasPrefix(filename, "aeron-backup-") || !strings.HasSuffix(filename, ".dump") {
+	if !strings.HasPrefix(filename, backupPrefix) || !strings.HasSuffix(filename, backupSuffix) {
 		return types.NewValidationError("filename", "not a valid backup file")
 	}
 	return nil
@@ -210,7 +215,7 @@ func (s *BackupService) validateBackupFile(ctx context.Context, filePath string)
 // generateBackupFilename creates a timestamped filename with .dump extension.
 func generateBackupFilename() string {
 	timestamp := time.Now().Format("2006-01-02-150405")
-	return fmt.Sprintf("aeron-backup-%s.dump", timestamp)
+	return fmt.Sprintf("%s%s%s", backupPrefix, timestamp, backupSuffix)
 }
 
 // executePgDump runs pg_dump and returns file info on success, cleaning up on failure.
@@ -465,7 +470,7 @@ func (s *BackupService) List() (*BackupListResponse, error) {
 		}
 
 		name := entry.Name()
-		if !strings.HasPrefix(name, "aeron-backup-") || !strings.HasSuffix(name, ".dump") {
+		if !strings.HasPrefix(name, backupPrefix) || !strings.HasSuffix(name, backupSuffix) {
 			continue
 		}
 

--- a/internal/service/maintenance.go
+++ b/internal/service/maintenance.go
@@ -96,15 +96,6 @@ type tableHealthRow struct {
 	ToastSize       int64      `db:"toast_size"`
 }
 
-// longRunningQueryRow is the database scan target for long-running query detection.
-// Fields must match types.LongRunningQuery exactly (direct type conversion is used).
-type longRunningQueryRow struct {
-	PID      int    `db:"pid"`
-	Duration string `db:"duration"`
-	Query    string `db:"query"`
-	State    string `db:"state"`
-}
-
 // Health operations.
 
 // GetHealth retrieves comprehensive database health information.
@@ -244,14 +235,9 @@ func (s *MaintenanceService) getLongRunningQueries(ctx context.Context) ([]types
 		ORDER BY query_start ASC
 	`
 
-	var rows []longRunningQueryRow
-	if err := s.repo.DB().SelectContext(ctx, &rows, query, threshold); err != nil {
+	var queries []types.LongRunningQuery
+	if err := s.repo.DB().SelectContext(ctx, &queries, query, threshold); err != nil {
 		return nil, err
-	}
-
-	queries := make([]types.LongRunningQuery, 0, len(rows))
-	for _, row := range rows {
-		queries = append(queries, types.LongRunningQuery(row))
 	}
 
 	return queries, nil

--- a/internal/service/media.go
+++ b/internal/service/media.go
@@ -151,22 +151,15 @@ func (s *MediaService) GetStatistics(ctx context.Context, entityType types.Entit
 		return nil, err
 	}
 
-	table := types.Table(entityType)
-
-	withImages, err := s.repo.CountWithImages(ctx, table)
-	if err != nil {
-		return nil, err
-	}
-
-	withoutImages, err := s.repo.CountWithoutImages(ctx, table)
+	counts, err := s.repo.CountImages(ctx, types.Table(entityType))
 	if err != nil {
 		return nil, err
 	}
 
 	return &ImageStats{
-		Total:         withImages + withoutImages,
-		WithImages:    withImages,
-		WithoutImages: withoutImages,
+		Total:         counts.Total,
+		WithImages:    counts.WithImages,
+		WithoutImages: counts.Total - counts.WithImages,
 	}, nil
 }
 
@@ -203,41 +196,17 @@ func (s *MediaService) DeleteAllImages(ctx context.Context, entityType types.Ent
 
 // Playlist operations.
 
-// PlaylistOptions configures playlist queries with filtering and pagination.
-type PlaylistOptions struct {
-	BlockID     string
-	Date        string
-	ExportTypes []int
-	Limit       int
-	Offset      int
-	SortBy      string
-	SortDesc    bool
-	TrackImage  *bool
-	ArtistImage *bool
-}
-
 // DefaultPlaylistOptions returns playlist query options with sensible defaults.
-func DefaultPlaylistOptions() PlaylistOptions {
-	return PlaylistOptions{
+func DefaultPlaylistOptions() database.PlaylistOptions {
+	return database.PlaylistOptions{
 		ExportTypes: []int{},
 		SortBy:      "starttime",
 	}
 }
 
 // GetPlaylist retrieves played tracks for a date or block with filtering and pagination.
-func (s *MediaService) GetPlaylist(ctx context.Context, opts *PlaylistOptions) ([]database.PlaylistItem, error) {
-	dbOpts := &database.PlaylistOptions{
-		BlockID:     opts.BlockID,
-		Date:        opts.Date,
-		ExportTypes: opts.ExportTypes,
-		Limit:       opts.Limit,
-		Offset:      opts.Offset,
-		SortBy:      opts.SortBy,
-		SortDesc:    opts.SortDesc,
-		TrackImage:  opts.TrackImage,
-		ArtistImage: opts.ArtistImage,
-	}
-	return s.repo.GetPlaylist(ctx, dbOpts)
+func (s *MediaService) GetPlaylist(ctx context.Context, opts *database.PlaylistOptions) ([]database.PlaylistItem, error) {
+	return s.repo.GetPlaylist(ctx, opts)
 }
 
 // PlaylistBlockWithTracks represents a playlist block with its associated tracks.

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -24,10 +24,10 @@ const (
 
 // LongRunningQuery represents a query that has been running longer than the configured threshold.
 type LongRunningQuery struct {
-	PID      int    `json:"pid"`
-	Duration string `json:"duration"`
-	Query    string `json:"query"`
-	State    string `json:"state"`
+	PID      int    `db:"pid" json:"pid"`
+	Duration string `db:"duration" json:"duration"`
+	Query    string `db:"query" json:"query"`
+	State    string `db:"state" json:"state"`
 }
 
 // VoicetrackUserID is the UUID used in Aeron to identify voice tracks.

--- a/internal/util/validators.go
+++ b/internal/util/validators.go
@@ -39,11 +39,11 @@ func ValidateEntityID(id, entityLabel string) error {
 	return nil
 }
 
-// newSafeHTTPClient creates an HTTP client with SSRF protection.
-func newSafeHTTPClient() *safeurl.WrappedClient {
-	config := safeurl.GetConfigBuilder().Build()
-	return safeurl.Client(config)
-}
+// safeHTTPClient returns a reusable HTTP client with SSRF protection.
+var safeHTTPClient = sync.OnceValue(func() *safeurl.WrappedClient {
+	cfg := safeurl.GetConfigBuilder().Build()
+	return safeurl.Client(cfg)
+})
 
 // ValidateURL validates a URL for allowed schemes and hostname presence.
 func ValidateURL(urlString string) error {
@@ -103,7 +103,7 @@ func ValidateAndDownloadImage(urlString string, maxSize int64) ([]byte, error) {
 		return nil, err
 	}
 
-	client := newSafeHTTPClient()
+	client := safeHTTPClient()
 
 	resp, err := client.Get(urlString)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Eliminate duplicate `PlaylistOptions`** — removed `service.PlaylistOptions`, use `database.PlaylistOptions` directly instead of copying fields one by one
- **Extract `notifyOnTransition` helper** — the lock/check-prev/send state machine was repeated 3× across backup, S3, and health notifications
- **Add `resolveTable` helper** — consolidates the repeated `QualifiedTable` + `IDColumnForTable` + error-wrap boilerplate in 5 repository methods
- **Merge `longRunningQueryRow` into `types.LongRunningQuery`** — add `db:` tags to the shared type, remove the private duplicate and conversion loop
- **Single-query `GetStatistics`** — replace 2 sequential `COUNT(*)` queries with one `SELECT COUNT(*), COUNT(picture)` query
- **Reuse SSRF HTTP client** — `sync.OnceValue` singleton instead of creating a new client per image download
- **Cache parsed recipients** — parse the comma-separated recipients string once at `NotificationService` construction
- **Pass image format through pipeline** — skip redundant `image.DecodeConfig` call in `OptimizeImage`
- **Extract backup filename constants** — `backupPrefix` / `backupSuffix` used in 3 places
- **Remove throwaway `GraphClient` in `handleTestEmail`** — use the cached client via `NotificationService.ValidateAuth()`

Net result: **-47 lines** across 10 files, all tests passing, zero linter issues.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `go vet ./...` no issues
- [x] `golangci-lint run` 0 issues
- [x] CI integration tests pass