### PR TITLE
fix: bump Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oszuidwest/zwfm-aerontoolbox
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/doyensec/safeurl v0.2.2


### PR DESCRIPTION
## Summary

- Bumps the minimum Go version in `go.mod` from `1.26.1` to `1.26.2`.
- Resolves `govulncheck` failures caused by known vulnerabilities in the Go standard library present in versions before 1.26.2.
- Affected packages: `crypto/x509`, `crypto/tls`, and `html/template`.

## Details

Go 1.26.2 is a security patch release that addresses vulnerabilities in:

- **`crypto/x509`**: Certificate handling issues that could allow bypass of certificate verification.
- **`crypto/tls`**: TLS protocol weaknesses that may expose encrypted connections to attack.
- **`html/template`**: Template injection vulnerabilities that could lead to cross-site scripting (XSS).

Keeping the declared Go toolchain version at or above 1.26.2 ensures `govulncheck` does not flag these stdlib vulnerabilities in CI.

## Test plan

- [ ] Verify `govulncheck` passes after this change.
- [ ] Confirm existing CI checks (build, lint, tests) continue to pass.