### PR TITLE
feat(file-monitor): configurable fixed polling interval (PR1/4)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1014,7 +1014,10 @@ Validatie gebeurt via `pg_restore --list` die de TOC en interne checksums contro
 
 De bestandscontrole (file monitor) bewaakt bestanden op schijf en signaleert wanneer ze ouder zijn dan een geconfigureerde maximumleeftijd. Dit is nuttig voor het detecteren van falende downloads of updates van externe processen (bijv. nieuwsbulletins, weerbericht-MP3's).
 
-De controle draait automatisch op een interval dat is afgeleid van de kleinste `max_age_minutes` uit alle geconfigureerde checks. Na een herstart wordt de eerste controle als "grace run" beschouwd: resultaten worden geobserveerd maar er worden geen meldingen verstuurd, om valse alarmen te voorkomen.
+De controle draait automatisch op een vast interval. Standaard is dat 60 seconden; pas dit aan via `file_monitor.interval_seconds`. Na een herstart wordt de eerste controle als "grace run" beschouwd: resultaten worden geobserveerd maar er worden geen meldingen verstuurd, om valse alarmen te voorkomen.
+
+> [!IMPORTANT]
+> **Breaking change:** het veld `interval_minutes` in de status-respons is vervangen door `interval_seconds`. Externe consumers moeten de nieuwe veldnaam gebruiken.
 
 ### Status bestandscontrole
 
@@ -1027,7 +1030,7 @@ Toont de resultaten van de meest recente bestandscontrole.
 ```json
 {
   "last_check_at": "2024-01-15T10:30:00Z",
-  "interval_minutes": 10,
+  "interval_seconds": 60,
   "checks": [
     {
       "name": "Nieuws bulletin",
@@ -1082,7 +1085,7 @@ De volgende voorbeelden tonen individuele items uit de `checks`-array voor speci
 
 **Velden:**
 - `last_check_at`: Tijdstip van de laatste controle
-- `interval_minutes`: Automatisch berekend controle-interval (kleinste `max_age_minutes`)
+- `interval_seconds`: Geconfigureerde polling-cadence in seconden (standaard 60)
 - `checks`: Array met resultaten per bestand
   - `name`: Optionele weergavenaam (uit configuratie)
   - `path`: Bestandspad op schijf
@@ -1386,6 +1389,7 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   },
   "file_monitor": {
     "enabled": false,
+    "interval_seconds": 60,
     "checks": [
       {
         "name": "Nieuws bulletin",
@@ -1408,12 +1412,13 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
 
 **Bestandscontrole-instellingen:**
 - `file_monitor.enabled`: Schakel de bestandscontrole in
+- `file_monitor.interval_seconds`: Polling-cadence in seconden (standaard 60; `0` of weglaten = default)
 - `file_monitor.checks`: Array van te bewaken bestanden (minstens 1 vereist wanneer ingeschakeld)
   - `name`: Optionele weergavenaam voor meldingen
   - `path`: Absoluut pad naar het bestand
   - `max_age_minutes`: Maximale leeftijd in minuten (minimaal 1)
 
-Het controle-interval wordt automatisch afgeleid van de kleinste `max_age_minutes` waarde. Er is geen apart schedule nodig.
+Het controle-interval staat los van `max_age_minutes` en is via `interval_seconds` configureerbaar (standaard 60 s).
 
 Zie [config.example.json](config.example.json) voor alle beschikbare opties.
 

--- a/config.example.json
+++ b/config.example.json
@@ -64,6 +64,7 @@
   },
   "file_monitor": {
     "enabled": false,
+    "interval_seconds": 60,
     "checks": [
       {
         "name": "Nieuws bulletin",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,8 +110,9 @@ type GraphConfig struct {
 
 // FileMonitorConfig contains settings for monitoring file freshness on disk.
 type FileMonitorConfig struct {
-	Enabled bool                     `json:"enabled"`
-	Checks  []FileMonitorCheckConfig `json:"checks" validate:"required_if=Enabled true,dive"`
+	Enabled         bool                     `json:"enabled"`
+	IntervalSeconds int                      `json:"interval_seconds" validate:"gte=0"`
+	Checks          []FileMonitorCheckConfig `json:"checks" validate:"required_if=Enabled true,dive"`
 }
 
 // FileMonitorCheckConfig defines a single file to monitor for staleness.
@@ -129,19 +130,16 @@ func (c *FileMonitorCheckConfig) DisplayName() string {
 	return c.Path
 }
 
-// CheckIntervalMinutes returns the smallest max_age_minutes across all checks.
-// This is used as the scheduler interval so the most urgent file is checked on time.
-func (c *FileMonitorConfig) CheckIntervalMinutes() int {
-	if len(c.Checks) == 0 {
-		return 0
+// DefaultFileMonitorIntervalSeconds is the default polling cadence when interval_seconds is unset.
+const DefaultFileMonitorIntervalSeconds = 60
+
+// Interval returns the polling cadence for the file monitor scheduler.
+// When IntervalSeconds is unset (0) or negative, it falls back to DefaultFileMonitorIntervalSeconds.
+func (c *FileMonitorConfig) Interval() time.Duration {
+	if c.IntervalSeconds <= 0 {
+		return DefaultFileMonitorIntervalSeconds * time.Second
 	}
-	m := c.Checks[0].MaxAgeMinutes
-	for _, check := range c.Checks[1:] {
-		if check.MaxAgeMinutes < m {
-			m = check.MaxAgeMinutes
-		}
-	}
-	return m
+	return time.Duration(c.IntervalSeconds) * time.Second
 }
 
 // LogConfig contains logging configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestFileMonitorValidation_EnabledWithEmptyChecks(t *testing.T) {
@@ -73,42 +74,26 @@ func TestFileMonitorValidation_MissingPath(t *testing.T) {
 	}
 }
 
-func TestFileMonitorCheckIntervalMinutes(t *testing.T) {
-	tests := []struct {
-		name     string
-		checks   []FileMonitorCheckConfig
-		expected int
-	}{
-		{
-			name:     "empty checks",
-			checks:   nil,
-			expected: 0,
-		},
-		{
-			name: "single check",
-			checks: []FileMonitorCheckConfig{
-				{Path: "/a", MaxAgeMinutes: 30},
-			},
-			expected: 30,
-		},
-		{
-			name: "multiple checks returns minimum",
-			checks: []FileMonitorCheckConfig{
-				{Path: "/a", MaxAgeMinutes: 60},
-				{Path: "/b", MaxAgeMinutes: 10},
-				{Path: "/c", MaxAgeMinutes: 30},
-			},
-			expected: 10,
-		},
+func TestInterval_DefaultIsSixtySeconds(t *testing.T) {
+	cfg := &FileMonitorConfig{}
+	if got, want := cfg.Interval(), 60*time.Second; got != want {
+		t.Errorf("Interval() = %s, want %s", got, want)
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &FileMonitorConfig{Checks: tt.checks}
-			if got := cfg.CheckIntervalMinutes(); got != tt.expected {
-				t.Errorf("CheckIntervalMinutes() = %d, want %d", got, tt.expected)
-			}
-		})
+func TestInterval_RespectsConfig(t *testing.T) {
+	cfg := &FileMonitorConfig{IntervalSeconds: 90}
+	if got, want := cfg.Interval(), 90*time.Second; got != want {
+		t.Errorf("Interval() = %s, want %s", got, want)
+	}
+}
+
+func TestInterval_ZeroFallsBackToDefault(t *testing.T) {
+	for _, n := range []int{0, -5} {
+		cfg := &FileMonitorConfig{IntervalSeconds: n}
+		if got, want := cfg.Interval(), 60*time.Second; got != want {
+			t.Errorf("Interval() with IntervalSeconds=%d = %s, want %s", n, got, want)
+		}
 	}
 }
 

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -31,7 +31,7 @@ type FileMonitorService struct {
 // FileMonitorStatus contains the results of the most recent file monitor check.
 type FileMonitorStatus struct {
 	LastCheckAt     *time.Time        `json:"last_check_at,omitempty"`
-	IntervalMinutes int               `json:"interval_minutes"`
+	IntervalSeconds int               `json:"interval_seconds"`
 	Checks          []FileCheckResult `json:"checks"`
 	staleCount      int
 }
@@ -130,7 +130,7 @@ func (s *FileMonitorService) Run() {
 	}
 	status := &FileMonitorStatus{
 		LastCheckAt:     &now,
-		IntervalMinutes: s.config.FileMonitor.CheckIntervalMinutes(),
+		IntervalSeconds: int(s.config.FileMonitor.Interval().Seconds()),
 		Checks:          results,
 		staleCount:      staleCount,
 	}
@@ -148,7 +148,7 @@ func (s *FileMonitorService) Status() *FileMonitorStatus {
 
 	if s.lastCheck == nil {
 		return &FileMonitorStatus{
-			IntervalMinutes: s.config.FileMonitor.CheckIntervalMinutes(),
+			IntervalSeconds: int(s.config.FileMonitor.Interval().Seconds()),
 			Checks:          []FileCheckResult{},
 		}
 	}

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -52,10 +52,9 @@ func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 		}
 	}
 
-	// Register file monitor job if enabled (interval auto-derived from checks)
+	// Register file monitor job if enabled (cadence from FileMonitor.Interval()).
 	if cfg.FileMonitor.Enabled {
-		interval := cfg.FileMonitor.CheckIntervalMinutes()
-		schedule := fmt.Sprintf("@every %dm", interval)
+		schedule := fmt.Sprintf("@every %s", cfg.FileMonitor.Interval())
 		if err := s.addJob(config.SchedulerConfig{Enabled: true, Schedule: schedule}, "file-monitor", s.runFileMonitor); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

PR1 van vier opeenvolgend mergebare PR's uit `BESTANDSCONTROLE-VERBETERPLAN.md` (sectie 1).

- Vervangt de dynamische scheduler-interval (afgeleid van `min(max_age_minutes)`) door een vaste cadans via `file_monitor.interval_seconds`, default `60`.
- Lost trage detectie op: een check met `max_age=60` werd voorheen pas in de eerstvolgende tick *ná* 60 min als stale gezien — detectie kon tot 2× zo laat als de drempel zijn.
- Verwijdert `FileMonitorConfig.CheckIntervalMinutes()`; nieuwe helper `Interval() time.Duration`.

## Breaking change

Statusrespons (`GET /api/file-monitor/status`):
- `interval_minutes` → `interval_seconds`

`config.json` blijft backwards compatible: `interval_seconds` is optioneel en valt terug op 60 s wanneer 0/afwezig.

## Test plan

- [x] `go vet ./...`
- [x] `gofmt -s -l .` (clean)
- [x] `go test ./...` (config + service packages groen)
- [x] `go build .`
- [x] `golangci-lint run` (0 issues)
- [ ] Reviewer leest 6 gewijzigde bestanden en bevestigt plan-conformiteit
- [ ] Open vraag uit het plan: akkoord met default `60s`, of liever `30s`?

## Vervolg

- PR2: stat-timeout + single-flight + parallelle checks
- PR3: handmatige trigger + `run_id`/`completed_run_id` in status
- PR4: optioneel actief tijdvenster + window-aware `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)