### PR TITLE
feat(file-monitor): tijdvenster + window-aware /health (PR4/4)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1113,12 +1113,16 @@ Wanneer de bestandscontrole is ingeschakeld, toont het health-endpoint (`GET /ap
   "file_monitor": {
     "enabled": true,
     "checks_total": 2,
-    "checks_stale": 1
+    "checks_stale": 1,
+    "checks_alerting": 1
   }
 }
 ```
 
-De overall status wordt `"degraded"` wanneer een of meer bestanden verouderd zijn.
+- `checks_stale`: ruwe telling van bestanden die te oud of onbereikbaar zijn (inclusief bestanden buiten hun `active_window`).
+- `checks_alerting`: window-bewuste telling — sluit bestanden uit die buiten hun `active_window` vallen. Dit veld stuurt de overall `"degraded"`-status aan.
+
+De overall status wordt `"degraded"` zodra `checks_alerting > 0` is. Een bestand dat 's nachts veroudert maar pas overdag wordt vernieuwd, zet `/api/health` dus niet op `degraded` zolang het buiten zijn venster valt.
 
 ---
 
@@ -1394,7 +1398,8 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
       {
         "name": "Nieuws bulletin",
         "path": "/data/news.mp3",
-        "max_age_minutes": 30
+        "max_age_minutes": 30,
+        "active_window": "06:00-22:00"
       },
       {
         "name": "Weer",
@@ -1417,8 +1422,13 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   - `name`: Optionele weergavenaam voor meldingen
   - `path`: Absoluut pad naar het bestand
   - `max_age_minutes`: Maximale leeftijd in minuten (minimaal 1)
+  - `stat_timeout_seconds`: Maximale tijd in seconden voor `os.Stat` (standaard 5; `0` of weglaten = default). Beschermt tegen bevroren NFS/SMB-mounts.
+  - `active_window`: Optioneel tijdvenster `"HH:MM-HH:MM"` waarin alerts en `/health degraded` actief zijn. Buiten het venster blijft `is_stale` zichtbaar in `/status`, maar wordt geen alert/recovery-mail verstuurd en blijft `/health` healthy. Een eindtijd vóór de starttijd betekent dat het venster over middernacht heen loopt (bijv. `"22:00-06:00"` is actief van 22:00 tot 06:00 's ochtends). Gelijke start- en eindtijd is ongeldig — laat het veld weg voor altijd-actief.
 
 Het controle-interval staat los van `max_age_minutes` en is via `interval_seconds` configureerbaar (standaard 60 s).
+
+> [!IMPORTANT]
+> `active_window` wordt geïnterpreteerd in de lokale tijdzone die door de `TZ` environment variable wordt gestuurd. Stel `TZ` consistent in op productie zodat het venster doet wat de operator verwacht.
 
 Zie [config.example.json](config.example.json) voor alle beschikbare opties.
 

--- a/config.example.json
+++ b/config.example.json
@@ -69,7 +69,8 @@
       {
         "name": "Nieuws bulletin",
         "path": "/data/news.mp3",
-        "max_age_minutes": 30
+        "max_age_minutes": 30,
+        "active_window": "06:00-22:00"
       },
       {
         "name": "Weer",

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -42,10 +42,16 @@ type HealthResponse struct {
 }
 
 // FileMonitorHealth represents file monitor status in the health response.
+//
+// ChecksStale is the raw count from the most recent run (includes stale
+// files outside their configured ActiveWindow) and is preserved for
+// transparency. ChecksAlerting is window-aware — outside-window stales are
+// excluded — and is what drives the overall degraded status.
 type FileMonitorHealth struct {
-	Enabled     bool `json:"enabled"`
-	ChecksTotal int  `json:"checks_total"`
-	ChecksStale int  `json:"checks_stale"`
+	Enabled        bool `json:"enabled"`
+	ChecksTotal    int  `json:"checks_total"`
+	ChecksStale    int  `json:"checks_stale"`
+	ChecksAlerting int  `json:"checks_alerting"`
 }
 
 // NotificationHealth represents notification system status in the health response.
@@ -126,11 +132,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	fmCfg := s.service.Config().FileMonitor
 	if fmCfg.Enabled {
 		fmh := &FileMonitorHealth{
-			Enabled:     true,
-			ChecksTotal: len(fmCfg.Checks),
-			ChecksStale: s.service.FileMonitor.StaleCount(),
+			Enabled:        true,
+			ChecksTotal:    len(fmCfg.Checks),
+			ChecksStale:    s.service.FileMonitor.StaleCount(),
+			ChecksAlerting: s.service.FileMonitor.AlertingCount(),
 		}
-		if fmh.ChecksStale > 0 {
+		if fmh.ChecksAlerting > 0 {
 			overallStatus = "degraded"
 		}
 		resp.FileMonitor = fmh

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,12 +116,16 @@ type FileMonitorConfig struct {
 }
 
 // FileMonitorCheckConfig defines a single file to monitor for staleness.
+//
+// ActiveWindow is validated by validateFileMonitorConfig (struct-level) so the
+// parser's specific reason — equal start/end, range, format — survives into
+// the error message instead of collapsing to a generic tag string.
 type FileMonitorCheckConfig struct {
 	Name           string `json:"name"`
 	Path           string `json:"path" validate:"required,absolute_path"`
 	MaxAgeMinutes  int    `json:"max_age_minutes" validate:"required,gte=1"`
 	StatTimeoutSec int    `json:"stat_timeout_seconds" validate:"gte=0"`
-	ActiveWindow   string `json:"active_window" validate:"omitempty,time_window"`
+	ActiveWindow   string `json:"active_window"`
 }
 
 // DisplayName returns the check name if set, otherwise the file path.
@@ -377,15 +381,6 @@ func newConfigValidator() *validator.Validate {
 		return filepath.IsAbs(fl.Field().String())
 	})
 
-	_ = v.RegisterValidation("time_window", func(fl validator.FieldLevel) bool {
-		s := fl.Field().String()
-		if s == "" {
-			return true
-		}
-		_, err := ParseTimeWindow(s)
-		return err == nil
-	})
-
 	v.RegisterStructValidation(validateS3Config, S3Config{})
 	v.RegisterStructValidation(validateFileMonitorConfig, FileMonitorConfig{})
 
@@ -403,10 +398,26 @@ func validateS3Config(sl validator.StructLevel) {
 	}
 }
 
-// validateFileMonitorConfig checks that at least one check is configured when file monitor
-// is enabled, and that no two checks share the same path.
+// validateFileMonitorConfig checks that at least one check is configured when
+// file monitor is enabled, that no two checks share the same path, and that
+// each ActiveWindow parses cleanly. The window check runs even when the
+// monitor is disabled so format/range typos surface during config load
+// rather than only after the operator flips the feature on. The parser
+// error string is forwarded verbatim via the tag param so the user sees the
+// concrete reason (e.g. "start and end are equal") instead of a generic
+// "must be HH:MM-HH:MM".
 func validateFileMonitorConfig(sl validator.StructLevel) {
 	fm := sl.Current().Interface().(FileMonitorConfig)
+
+	for i, c := range fm.Checks {
+		if c.ActiveWindow == "" {
+			continue
+		}
+		if _, err := ParseTimeWindow(c.ActiveWindow); err != nil {
+			sl.ReportError(fm.Checks[i].ActiveWindow, "active_window", "ActiveWindow", "invalid_time_window", err.Error())
+		}
+	}
+
 	if !fm.Enabled {
 		return
 	}
@@ -476,8 +487,8 @@ func tagMessage(tag, param string) string {
 		return "contains invalid characters (only letters, numbers and underscores allowed)"
 	case "guid":
 		return "must be a valid GUID (e.g., 12345678-1234-1234-1234-123456789abc)"
-	case "time_window":
-		return "must be HH:MM-HH:MM (omit for always-active)"
+	case "invalid_time_window":
+		return param
 	default:
 		return fmt.Sprintf("is invalid (%s)", tag)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -409,12 +409,20 @@ func validateS3Config(sl validator.StructLevel) {
 func validateFileMonitorConfig(sl validator.StructLevel) {
 	fm := sl.Current().Interface().(FileMonitorConfig)
 
+	// Encode the slice index in the reported field name (e.g.
+	// "checks[1].active_window") so multiple bad windows produce distinct,
+	// locatable error labels. ReportError otherwise registers at the parent
+	// struct level — every bad check would collapse onto a single
+	// "filemonitor.active_window" key, defeating the point of telling the
+	// operator which entry to fix.
 	for i, c := range fm.Checks {
 		if c.ActiveWindow == "" {
 			continue
 		}
 		if _, err := ParseTimeWindow(c.ActiveWindow); err != nil {
-			sl.ReportError(fm.Checks[i].ActiveWindow, "active_window", "ActiveWindow", "invalid_time_window", err.Error())
+			fieldName := fmt.Sprintf("checks[%d].active_window", i)
+			structFieldName := fmt.Sprintf("Checks[%d].ActiveWindow", i)
+			sl.ReportError(fm.Checks[i].ActiveWindow, fieldName, structFieldName, "invalid_time_window", err.Error())
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,7 @@ type FileMonitorCheckConfig struct {
 	Path           string `json:"path" validate:"required,absolute_path"`
 	MaxAgeMinutes  int    `json:"max_age_minutes" validate:"required,gte=1"`
 	StatTimeoutSec int    `json:"stat_timeout_seconds" validate:"gte=0"`
+	ActiveWindow   string `json:"active_window" validate:"omitempty,time_window"`
 }
 
 // DisplayName returns the check name if set, otherwise the file path.
@@ -376,6 +377,15 @@ func newConfigValidator() *validator.Validate {
 		return filepath.IsAbs(fl.Field().String())
 	})
 
+	_ = v.RegisterValidation("time_window", func(fl validator.FieldLevel) bool {
+		s := fl.Field().String()
+		if s == "" {
+			return true
+		}
+		_, err := ParseTimeWindow(s)
+		return err == nil
+	})
+
 	v.RegisterStructValidation(validateS3Config, S3Config{})
 	v.RegisterStructValidation(validateFileMonitorConfig, FileMonitorConfig{})
 
@@ -466,6 +476,8 @@ func tagMessage(tag, param string) string {
 		return "contains invalid characters (only letters, numbers and underscores allowed)"
 	case "guid":
 		return "must be a valid GUID (e.g., 12345678-1234-1234-1234-123456789abc)"
+	case "time_window":
+		return "must be HH:MM-HH:MM (omit for always-active)"
 	default:
 		return fmt.Sprintf("is invalid (%s)", tag)
 	}

--- a/internal/config/timewindow.go
+++ b/internal/config/timewindow.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TimeWindow represents a HH:MM-HH:MM window in local time.
+//
+// A window with EndMin < StartMin wraps around midnight (e.g. 22:00-06:00
+// is active from 22:00 until 06:00 the next morning). Configured == false
+// distinguishes the zero value ("no window set, always active") from a
+// parsed window — StartMin == EndMin would otherwise be ambiguous, so it
+// is rejected at parse time and operators must omit the field for
+// always-active behaviour.
+type TimeWindow struct {
+	StartMin, EndMin int
+	Configured       bool
+}
+
+// ParseTimeWindow parses "HH:MM-HH:MM". An empty string returns an
+// unconfigured (always-active) window with no error. Equal start and end
+// minutes are rejected — operators should omit the field instead, since
+// there is no sensible interpretation of a zero-length window.
+func ParseTimeWindow(s string) (TimeWindow, error) {
+	if s == "" {
+		return TimeWindow{}, nil
+	}
+	parts := strings.Split(s, "-")
+	if len(parts) != 2 {
+		return TimeWindow{}, fmt.Errorf("invalid window %q, expected HH:MM-HH:MM", s)
+	}
+	start, err := parseHHMM(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return TimeWindow{}, err
+	}
+	end, err := parseHHMM(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return TimeWindow{}, err
+	}
+	if start == end {
+		return TimeWindow{}, fmt.Errorf("invalid window %q: start and end are equal; omit the field for always-active", s)
+	}
+	return TimeWindow{StartMin: start, EndMin: end, Configured: true}, nil
+}
+
+func parseHHMM(s string) (int, error) {
+	hh, mm, ok := strings.Cut(s, ":")
+	if !ok {
+		return 0, fmt.Errorf("invalid time %q, expected HH:MM", s)
+	}
+	h, err := strconv.Atoi(hh)
+	if err != nil {
+		return 0, fmt.Errorf("invalid time %q, expected HH:MM", s)
+	}
+	m, err := strconv.Atoi(mm)
+	if err != nil {
+		return 0, fmt.Errorf("invalid time %q, expected HH:MM", s)
+	}
+	if h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, fmt.Errorf("time %q out of range (HH 0-23, MM 0-59)", s)
+	}
+	return h*60 + m, nil
+}
+
+// Active reports whether t (in its own location) falls inside the window.
+// An unconfigured window is treated as always-active.
+func (w TimeWindow) Active(t time.Time) bool {
+	if !w.Configured {
+		return true
+	}
+	cur := t.Hour()*60 + t.Minute()
+	if w.StartMin < w.EndMin {
+		return cur >= w.StartMin && cur < w.EndMin
+	}
+	return cur >= w.StartMin || cur < w.EndMin
+}

--- a/internal/config/timewindow_test.go
+++ b/internal/config/timewindow_test.go
@@ -159,6 +159,31 @@ func TestFileMonitorValidation_ActiveWindow(t *testing.T) {
 	}
 }
 
+func TestFileMonitorValidation_ActiveWindow_IncludesIndex(t *testing.T) {
+	// Multiple bad windows must produce distinct, indexed error labels —
+	// otherwise an operator with two typos sees the same "active_window"
+	// key twice and cannot tell which checks[] entry needs editing. The
+	// label is the only way to locate the bad row when the parser message
+	// alone (e.g. "out of range") is shared between checks.
+	cfg := minimalConfig()
+	cfg.FileMonitor.Enabled = true
+	cfg.FileMonitor.Checks = []FileMonitorCheckConfig{
+		{Path: "/data/news.mp3", MaxAgeMinutes: 30, ActiveWindow: "12:00-12:00"},
+		{Path: "/data/weather.mp3", MaxAgeMinutes: 60, ActiveWindow: "24:00-06:00"},
+	}
+	err := validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for two bad windows")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "checks[0].active_window") {
+		t.Errorf("error %q missing checks[0].active_window label", msg)
+	}
+	if !strings.Contains(msg, "checks[1].active_window") {
+		t.Errorf("error %q missing checks[1].active_window label", msg)
+	}
+}
+
 func TestFileMonitorValidation_ActiveWindow_EvenWhenDisabled(t *testing.T) {
 	// Operators must see window-format errors during config load even with
 	// the monitor turned off, otherwise enabling it later would fail with

--- a/internal/config/timewindow_test.go
+++ b/internal/config/timewindow_test.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTimeWindow_Cases(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantStart int
+		wantEnd   int
+		wantConf  bool
+	}{
+		{name: "empty is unconfigured", input: "", wantConf: false},
+		{name: "normal day window", input: "06:00-22:00", wantStart: 6 * 60, wantEnd: 22 * 60, wantConf: true},
+		{name: "wraparound night window", input: "22:00-06:00", wantStart: 22 * 60, wantEnd: 6 * 60, wantConf: true},
+		{name: "minute precision", input: "06:30-22:45", wantStart: 6*60 + 30, wantEnd: 22*60 + 45, wantConf: true},
+		{name: "leading whitespace tolerated", input: " 06:00 - 22:00 ", wantStart: 6 * 60, wantEnd: 22 * 60, wantConf: true},
+		{name: "missing dash", input: "06:00", wantErr: true},
+		{name: "extra dash", input: "06:00-12:00-18:00", wantErr: true},
+		{name: "non-numeric hour", input: "ab:00-22:00", wantErr: true},
+		{name: "missing minutes", input: "0600-2200", wantErr: true},
+		{name: "hour out of range", input: "24:00-06:00", wantErr: true},
+		{name: "minute out of range", input: "06:60-22:00", wantErr: true},
+		{name: "negative hour", input: "-1:00-22:00", wantErr: true},
+		{name: "equal start and end", input: "12:00-12:00", wantErr: true},
+		{name: "midnight equal", input: "00:00-00:00", wantErr: true},
+		{name: "trailing junk in time", input: "06:00:00-22:00", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := ParseTimeWindow(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTimeWindow(%q) = %+v, want error", tc.input, w)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTimeWindow(%q) unexpected error: %v", tc.input, err)
+			}
+			if w.Configured != tc.wantConf {
+				t.Errorf("Configured = %v, want %v", w.Configured, tc.wantConf)
+			}
+			if w.Configured && (w.StartMin != tc.wantStart || w.EndMin != tc.wantEnd) {
+				t.Errorf("Start/End = %d/%d, want %d/%d", w.StartMin, w.EndMin, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestTimeWindow_Active_Wraparound(t *testing.T) {
+	// Night window: active 22:00 → next-day 06:00.
+	w, err := ParseTimeWindow("22:00-06:00")
+	if err != nil {
+		t.Fatalf("ParseTimeWindow: %v", err)
+	}
+
+	cases := []struct {
+		hh, mm int
+		want   bool
+	}{
+		{21, 59, false}, // just before window opens
+		{22, 0, true},   // window opens
+		{23, 30, true},  // late night
+		{0, 0, true},    // midnight
+		{5, 59, true},   // last minute inside
+		{6, 0, false},   // window closes
+		{12, 0, false},  // midday outside
+	}
+	for _, tc := range cases {
+		ts := time.Date(2026, 1, 1, tc.hh, tc.mm, 0, 0, time.UTC)
+		if got := w.Active(ts); got != tc.want {
+			t.Errorf("Active(%02d:%02d) = %v, want %v", tc.hh, tc.mm, got, tc.want)
+		}
+	}
+}
+
+func TestTimeWindow_UnconfiguredIsAlwaysActive(t *testing.T) {
+	var w TimeWindow // zero value: Configured=false
+	for _, hh := range []int{0, 6, 12, 22, 23} {
+		ts := time.Date(2026, 1, 1, hh, 0, 0, 0, time.UTC)
+		if !w.Active(ts) {
+			t.Errorf("zero-value TimeWindow should be active at %02d:00", hh)
+		}
+	}
+}
+
+func TestTimeWindow_Active_NormalDay(t *testing.T) {
+	// Day window: active 06:00 → 22:00.
+	w, err := ParseTimeWindow("06:00-22:00")
+	if err != nil {
+		t.Fatalf("ParseTimeWindow: %v", err)
+	}
+
+	cases := []struct {
+		hh, mm int
+		want   bool
+	}{
+		{0, 0, false},
+		{5, 59, false},
+		{6, 0, true}, // boundary inclusive on start
+		{12, 0, true},
+		{21, 59, true},
+		{22, 0, false}, // boundary exclusive on end
+		{23, 0, false},
+	}
+	for _, tc := range cases {
+		ts := time.Date(2026, 1, 1, tc.hh, tc.mm, 0, 0, time.UTC)
+		if got := w.Active(ts); got != tc.want {
+			t.Errorf("Active(%02d:%02d) = %v, want %v", tc.hh, tc.mm, got, tc.want)
+		}
+	}
+}
+
+func TestFileMonitorValidation_ActiveWindow(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.FileMonitor.Enabled = true
+	cfg.FileMonitor.Checks = []FileMonitorCheckConfig{
+		{Path: "/data/news.mp3", MaxAgeMinutes: 30, ActiveWindow: "06:00-22:00"},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("valid window rejected: %v", err)
+	}
+
+	cfg.FileMonitor.Checks[0].ActiveWindow = "12:00-12:00"
+	if err := validate(cfg); err == nil {
+		t.Error("expected validation error for equal start/end window")
+	}
+
+	cfg.FileMonitor.Checks[0].ActiveWindow = "garbage"
+	if err := validate(cfg); err == nil {
+		t.Error("expected validation error for unparsable window")
+	}
+
+	cfg.FileMonitor.Checks[0].ActiveWindow = ""
+	if err := validate(cfg); err != nil {
+		t.Errorf("empty (always-active) window should pass validation, got: %v", err)
+	}
+}

--- a/internal/config/timewindow_test.go
+++ b/internal/config/timewindow_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -127,18 +128,51 @@ func TestFileMonitorValidation_ActiveWindow(t *testing.T) {
 		t.Errorf("valid window rejected: %v", err)
 	}
 
-	cfg.FileMonitor.Checks[0].ActiveWindow = "12:00-12:00"
-	if err := validate(cfg); err == nil {
-		t.Error("expected validation error for equal start/end window")
+	// Specific reasons must survive into the user-facing message rather than
+	// being collapsed to a generic "must be HH:MM-HH:MM". Without the verbatim
+	// parser error, an operator hitting the equal-start/end case has no way
+	// to tell what changed about the format and what to do about it.
+	cases := []struct {
+		input   string
+		wantMsg string
+	}{
+		{"12:00-12:00", "start and end are equal"},
+		{"24:00-06:00", "out of range"},
+		{"garbage", "expected HH:MM"},
 	}
-
-	cfg.FileMonitor.Checks[0].ActiveWindow = "garbage"
-	if err := validate(cfg); err == nil {
-		t.Error("expected validation error for unparsable window")
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			cfg.FileMonitor.Checks[0].ActiveWindow = tc.input
+			err := validate(cfg)
+			if err == nil {
+				t.Fatalf("expected validation error for %q", tc.input)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error %q missing %q (parser reason was discarded)", err.Error(), tc.wantMsg)
+			}
+		})
 	}
 
 	cfg.FileMonitor.Checks[0].ActiveWindow = ""
 	if err := validate(cfg); err != nil {
 		t.Errorf("empty (always-active) window should pass validation, got: %v", err)
+	}
+}
+
+func TestFileMonitorValidation_ActiveWindow_EvenWhenDisabled(t *testing.T) {
+	// Operators must see window-format errors during config load even with
+	// the monitor turned off, otherwise enabling it later would fail with
+	// confusing context.
+	cfg := minimalConfig()
+	cfg.FileMonitor.Enabled = false
+	cfg.FileMonitor.Checks = []FileMonitorCheckConfig{
+		{Path: "/data/news.mp3", MaxAgeMinutes: 30, ActiveWindow: "12:00-12:00"},
+	}
+	err := validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error even when file_monitor is disabled")
+	}
+	if !strings.Contains(err.Error(), "start and end are equal") {
+		t.Errorf("error %q missing parser reason", err.Error())
 	}
 }

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -21,6 +21,12 @@ import (
 // hangs or controlled errors without touching the real file system.
 var osStat = os.Stat
 
+// nowFunc returns the current time. Wrapped here so windowing tests can pin
+// a deterministic clock without depending on time-of-day at run time.
+// ActiveWindow comparisons use the location of the returned time, matching
+// how operators configure local-time windows (TZ env, see scheduler.go).
+var nowFunc = time.Now
+
 // statCheckParallelism caps how many files are stat'd concurrently per Run().
 // A radio config typically lists a handful of files, so 8 is plenty.
 const statCheckParallelism = 8
@@ -46,6 +52,13 @@ type statInFlight struct {
 type FileMonitorService struct {
 	config *config.Config
 	notify *notify.NotificationService
+
+	// Parsed ActiveWindow per check path. Populated once in
+	// newFileMonitorService and never mutated afterwards, so reads from Run()
+	// require no synchronisation. An entry missing or zero-valued means
+	// "always active". Pre-parsing here keeps the hot path lock-free and lets
+	// the constructor reject invalid windows up-front (see PR4 plan §9).
+	windows map[string]config.TimeWindow
 
 	// Per-file alert state: path → currently in alert.
 	alertState   map[string]bool
@@ -116,14 +129,23 @@ type FileCheckResult struct {
 	ErrorKind      string     `json:"error_kind,omitempty"`
 }
 
-func newFileMonitorService(cfg *config.Config, notifySvc *notify.NotificationService) *FileMonitorService {
+func newFileMonitorService(cfg *config.Config, notifySvc *notify.NotificationService) (*FileMonitorService, error) {
+	windows := make(map[string]config.TimeWindow, len(cfg.FileMonitor.Checks))
+	for _, c := range cfg.FileMonitor.Checks {
+		w, err := config.ParseTimeWindow(c.ActiveWindow)
+		if err != nil {
+			return nil, fmt.Errorf("file monitor: check %q: %w", c.DisplayName(), err)
+		}
+		windows[c.Path] = w
+	}
 	return &FileMonitorService{
 		config:     cfg,
 		notify:     notifySvc,
+		windows:    windows,
 		alertState: make(map[string]bool),
 		inflight:   make(map[string]*statInFlight),
 		runner:     async.New(),
-	}
+	}, nil
 }
 
 // Run checks all configured files, sends alert/recovery notifications, and
@@ -141,7 +163,7 @@ func (s *FileMonitorService) Run() {
 // publishing it. Separated from Run() so the trigger path can publish the
 // result together with run-state under a single lock.
 func (s *FileMonitorService) executeRun() *FileMonitorStatus {
-	now := time.Now()
+	now := nowFunc()
 	checks := s.config.FileMonitor.Checks
 
 	// Stat each file with a per-flight timeout in parallel. Single-flight
@@ -168,6 +190,16 @@ func (s *FileMonitorService) executeRun() *FileMonitorStatus {
 		if isGraceRun {
 			// Grace run: observe only — don't update alert state or send notifications.
 			// This avoids false alerts immediately after a restart.
+			continue
+		}
+
+		// Outside an active window the result still reflects raw staleness
+		// (transparent in /status) but does not flip alert state, send mail,
+		// or trigger a recovery. Suppressing recovery is essential — without
+		// it a midnight refresh would mail "[OK] hersteld" for an alert the
+		// operator never received.
+		if !s.windows[check.Path].Active(now) {
+			results[i].InAlert = false
 			continue
 		}
 
@@ -257,7 +289,9 @@ func (s *FileMonitorService) Status() *FileMonitorStatus {
 	return snap
 }
 
-// StaleCount returns the number of files that were stale in the most recent check.
+// StaleCount returns the raw number of files that were stale in the most
+// recent check, regardless of any configured ActiveWindow. Use AlertingCount
+// for the window-aware count that drives /health degraded.
 func (s *FileMonitorService) StaleCount() int {
 	s.publishedMu.RLock()
 	defer s.publishedMu.RUnlock()
@@ -266,6 +300,27 @@ func (s *FileMonitorService) StaleCount() int {
 		return 0
 	}
 	return s.lastCheck.staleCount
+}
+
+// AlertingCount returns the number of checks currently in alert (InAlert==true)
+// in the most recent run. Stale-but-outside-window checks are excluded by
+// construction — Run() never flips InAlert for them — so this is the right
+// signal for /health degraded. Reads under publishedMu so it pairs
+// consistently with the Checks slice published by the same run.
+func (s *FileMonitorService) AlertingCount() int {
+	s.publishedMu.RLock()
+	defer s.publishedMu.RUnlock()
+
+	if s.lastCheck == nil {
+		return 0
+	}
+	n := 0
+	for _, c := range s.lastCheck.Checks {
+		if c.InAlert {
+			n++
+		}
+	}
+	return n
 }
 
 // Close waits for any running TriggerCheck() invocation to finish.

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -17,16 +17,24 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// newTestService creates a FileMonitorService for testing.
-// The notification service has no email configured so it never sends.
-func newTestService(checks []config.FileMonitorCheckConfig) *FileMonitorService {
+// newTestService creates a FileMonitorService for testing. Variadic for
+// brevity at call sites (all tests pass an inline literal). The notification
+// service has no email configured so it never sends. Constructor errors fail
+// the test — they would always indicate an invalid ActiveWindow in the test
+// fixture, never a runtime condition worth proceeding past.
+func newTestService(t *testing.T, checks ...config.FileMonitorCheckConfig) *FileMonitorService {
+	t.Helper()
 	cfg := &config.Config{}
 	cfg.FileMonitor = config.FileMonitorConfig{
 		Enabled: true,
 		Checks:  checks,
 	}
 	notifySvc := notify.New(cfg)
-	return newFileMonitorService(cfg, notifySvc)
+	svc, err := newFileMonitorService(cfg, notifySvc)
+	if err != nil {
+		t.Fatalf("newFileMonitorService: %v", err)
+	}
+	return svc
 }
 
 func TestGraceRun_NoAlertsOnFirstRun(t *testing.T) {
@@ -34,9 +42,9 @@ func TestGraceRun_NoAlertsOnFirstRun(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	writeAndAge(t, path, 60*time.Minute)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10},
+	)
 
 	// First run = grace run.
 	svc.Run()
@@ -61,9 +69,9 @@ func TestGraceRun_AlertOnSecondRun(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	writeAndAge(t, path, 60*time.Minute)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10},
+	)
 
 	// First run = grace run (no alerts).
 	svc.Run()
@@ -82,9 +90,9 @@ func TestGraceRun_NoPhantomRecovery(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	writeAndAge(t, path, 60*time.Minute)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10},
+	)
 
 	// Grace run: file is stale.
 	svc.Run()
@@ -109,9 +117,9 @@ func TestAlertAndRecovery(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	writeAndAge(t, path, 60*time.Minute)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10},
+	)
 
 	// Grace run.
 	svc.Run()
@@ -141,9 +149,9 @@ func TestAlertAndRecovery(t *testing.T) {
 }
 
 func TestMissingFile_FileExistsFalse(t *testing.T) {
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "Ghost", Path: "/nonexistent/path/file.mp3", MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "Ghost", Path: "/nonexistent/path/file.mp3", MaxAgeMinutes: 10},
+	)
 
 	// Grace run.
 	svc.Run()
@@ -183,9 +191,9 @@ func TestStatError_FileExistsNull(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // G302: directories need execute bit for cleanup
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "Restricted", Path: path, MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "Restricted", Path: path, MaxAgeMinutes: 10},
+	)
 
 	// Grace run.
 	svc.Run()
@@ -208,9 +216,9 @@ func TestFreshFile_NotStale(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 
 	svc.Run() // grace
 	svc.Run() // real
@@ -234,10 +242,10 @@ func TestStaleCount(t *testing.T) {
 	touchFile(t, fresh)
 	writeAndAge(t, stale, 120*time.Minute)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "Fresh", Path: fresh, MaxAgeMinutes: 30},
-		{Name: "Stale", Path: stale, MaxAgeMinutes: 10},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "Fresh", Path: fresh, MaxAgeMinutes: 30},
+		config.FileMonitorCheckConfig{Name: "Stale", Path: stale, MaxAgeMinutes: 10},
+	)
 
 	svc.Run() // grace
 	svc.Run() // real
@@ -284,9 +292,9 @@ func TestStatTimeout_TriggersStaleWithTimeoutKind(t *testing.T) {
 	path := "/hang/news.mp3"
 	hangingStat(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+	)
 
 	svc.Run()
 
@@ -306,9 +314,9 @@ func TestSingleFlight_RepeatedRunsCallStatAtMostOnce(t *testing.T) {
 	path := "/hang/news.mp3"
 	counters := hangingStat(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+	)
 
 	for i := 0; i < 10; i++ {
 		svc.Run()
@@ -324,10 +332,10 @@ func TestSingleFlight_DifferentPathsAreIndependent(t *testing.T) {
 	pathB := "/hang/b.mp3"
 	counters := hangingStat(t, pathA, pathB)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "A", Path: pathA, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-		{Name: "B", Path: pathB, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "A", Path: pathA, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+		config.FileMonitorCheckConfig{Name: "B", Path: pathB, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+	)
 
 	svc.Run()
 
@@ -343,9 +351,9 @@ func TestSingleFlight_JoinAfterTimeoutReturnsImmediately(t *testing.T) {
 	path := "/hang/news.mp3"
 	hangingStat(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+	)
 
 	// First Run() establishes the flight and waits the full StatTimeout.
 	svc.Run()
@@ -367,11 +375,11 @@ func TestParallelChecks_FastFailNotBlockedBySlowStat(t *testing.T) {
 	fastB := "/missing/b.mp3"
 	hangingStat(t, slow) // only slow hangs; fastA/fastB get ErrNotExist immediately
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "Slow", Path: slow, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-		{Name: "FastA", Path: fastA, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-		{Name: "FastB", Path: fastB, MaxAgeMinutes: 10, StatTimeoutSec: 1},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "Slow", Path: slow, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+		config.FileMonitorCheckConfig{Name: "FastA", Path: fastA, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+		config.FileMonitorCheckConfig{Name: "FastB", Path: fastB, MaxAgeMinutes: 10, StatTimeoutSec: 1},
+	)
 
 	start := time.Now()
 	svc.Run()
@@ -456,9 +464,9 @@ func TestTriggerCheck_RunsAndUpdatesStatus(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 	t.Cleanup(svc.Close)
 
 	runID, err := svc.TriggerCheck()
@@ -498,9 +506,9 @@ func TestTriggerCheck_ReturnsConflictWhenAlreadyRunning(t *testing.T) {
 	path := "/hang/news.mp3"
 	release := hangingStatReleasable(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 5},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 5},
+	)
 
 	runID1, err := svc.TriggerCheck()
 	if err != nil {
@@ -537,9 +545,9 @@ func TestStatus_ShowsRunningTrueDuringRun(t *testing.T) {
 	path := "/hang/news.mp3"
 	release := hangingStatReleasable(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 30},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 30},
+	)
 
 	runID, err := svc.TriggerCheck()
 	if err != nil {
@@ -578,9 +586,9 @@ func TestTriggerCheck_RunIDIsMonotonic(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 	defer svc.Close()
 
 	for want := uint64(1); want <= 3; want++ {
@@ -607,9 +615,9 @@ func TestCompletedRunID_LagsBehindRunIDDuringActiveRun(t *testing.T) {
 	path := "/hang/news.mp3"
 	release := hangingStatReleasable(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 30},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 30},
+	)
 
 	runID, err := svc.TriggerCheck()
 	if err != nil {
@@ -640,9 +648,9 @@ func TestScheduler_RunFileMonitor_TriggersCheck(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	fmSvc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	fmSvc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 	defer fmSvc.Close()
 
 	sch := &Scheduler{service: &AeronService{FileMonitor: fmSvc}}
@@ -664,9 +672,9 @@ func TestScheduler_RunFileMonitor_SkipsWhenAlreadyActive(t *testing.T) {
 	path := "/hang/news.mp3"
 	release := hangingStatReleasable(t, path)
 
-	fmSvc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 30},
-	})
+	fmSvc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10, StatTimeoutSec: 30},
+	)
 
 	sch := &Scheduler{service: &AeronService{FileMonitor: fmSvc}}
 
@@ -698,9 +706,9 @@ func TestTriggerCheck_NoConflictAfterStatusReportsIdle(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 	defer svc.Close()
 
 	// 200 back-to-back triggers; if Status().Running could ever lead the
@@ -734,9 +742,9 @@ func TestStatus_NoTornSnapshotUnderConcurrentReads(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 	defer svc.Close()
 
 	var tagMu sync.RWMutex
@@ -830,9 +838,9 @@ func TestStatus_CompletedRunIDMatchesLastCheck(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
 
-	svc := newTestService([]config.FileMonitorCheckConfig{
-		{Name: "News", Path: path, MaxAgeMinutes: 60},
-	})
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 60},
+	)
 	defer svc.Close()
 
 	lastCheckAtPerRun := make(map[uint64]time.Time)
@@ -881,5 +889,226 @@ func touchFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// pinNow overrides nowFunc for the duration of the test. The fixed time is
+// used both for the file-age comparison and the ActiveWindow check, so a
+// pinned clock + a file mod-time set via makeStale/makeFresh (which read the
+// pinned clock) gives reproducible windowing assertions independent of when
+// the test actually runs.
+func pinNow(t *testing.T, fixed time.Time) {
+	t.Helper()
+	prev := nowFunc
+	nowFunc = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFunc = prev })
+}
+
+// timeAt returns a fixed local-time clock for hour:minute on a known day.
+// Local time matches how the production code interprets ActiveWindow
+// (operators configure HH:MM in TZ-local time; see scheduler.go).
+//
+//nolint:unparam // minute kept in signature for future minute-precision tests
+func timeAt(hour, minute int) time.Time {
+	return time.Date(2026, 4, 1, hour, minute, 0, 0, time.Local)
+}
+
+// makeStale creates path with a mod time `age` before the currently pinned
+// clock so the resulting age is deterministic regardless of wall-clock time.
+// Must be called after pinNow.
+//
+//nolint:unparam // age kept explicit at call sites for readability
+func makeStale(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mod := nowFunc().Add(-age)
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// makeFresh sets path's mod time to the currently pinned clock.
+// Must be called after pinNow.
+func makeFresh(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mod := nowFunc()
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestActiveWindow_NoAlertOutsideWindow(t *testing.T) {
+	// Window 22:00-06:00 (overnight) — at 14:00 we are firmly outside it.
+	pinNow(t, timeAt(14, 0))
+
+	path := filepath.Join(t.TempDir(), "news.mp3")
+	makeStale(t, path, 60*time.Minute) // stale relative to a 10-minute max
+
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{
+			Name: "Nightly news", Path: path, MaxAgeMinutes: 10,
+			ActiveWindow: "22:00-06:00",
+		},
+	)
+
+	svc.Run() // grace
+	svc.Run() // real
+
+	r := svc.Status().Checks[0]
+	if !r.IsStale {
+		t.Error("file should still report IsStale=true outside window (transparency)")
+	}
+	if r.InAlert {
+		t.Error("InAlert must be false outside the active window")
+	}
+	if got := svc.AlertingCount(); got != 0 {
+		t.Errorf("AlertingCount() = %d, want 0 outside window", got)
+	}
+	if got := svc.StaleCount(); got != 1 {
+		t.Errorf("StaleCount() = %d, want 1 (raw stale is preserved)", got)
+	}
+}
+
+func TestActiveWindow_AlertWhenWindowOpens(t *testing.T) {
+	// Outside window: grace + real, no alert state should be touched.
+	pinNow(t, timeAt(2, 0))
+
+	path := filepath.Join(t.TempDir(), "news.mp3")
+	makeStale(t, path, 60*time.Minute)
+
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{
+			Name: "Daytime news", Path: path, MaxAgeMinutes: 10,
+			ActiveWindow: "08:00-20:00",
+		},
+	)
+
+	svc.Run()
+	svc.Run()
+	if svc.Status().Checks[0].InAlert {
+		t.Fatal("InAlert leaked outside window")
+	}
+
+	// Window opens; the file is still stale from before, so the next run
+	// should now flip InAlert and emit an alert.
+	pinNow(t, timeAt(9, 0))
+	// Re-stamp the mod time so it is still 60 minutes old relative to the
+	// new pinned clock (otherwise the file would now appear "in the future").
+	makeStale(t, path, 60*time.Minute)
+	svc.Run()
+
+	r := svc.Status().Checks[0]
+	if !r.InAlert {
+		t.Error("expected InAlert=true once the window opens with a stale file")
+	}
+	if got := svc.AlertingCount(); got != 1 {
+		t.Errorf("AlertingCount() = %d, want 1 inside window with stale file", got)
+	}
+}
+
+func TestActiveWindow_RecoveryRespectsWindow(t *testing.T) {
+	// Recovery mails must not fire outside the window. Otherwise an alert
+	// suppressed at 03:00 would still trigger a "[OK] hersteld" mail at 03:30,
+	// which would be the only thing the operator ever sees about that file.
+
+	// 1) Inside window: become alerting.
+	pinNow(t, timeAt(10, 0))
+
+	path := filepath.Join(t.TempDir(), "news.mp3")
+	makeStale(t, path, 60*time.Minute)
+
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{
+			Name: "Daytime news", Path: path, MaxAgeMinutes: 10,
+			ActiveWindow: "08:00-20:00",
+		},
+	)
+
+	svc.Run() // grace
+	svc.Run() // real → alert
+
+	if !svc.Status().Checks[0].InAlert {
+		t.Fatal("setup precondition: file should be alerting inside window")
+	}
+
+	// 2) File becomes fresh, but it is now outside the window.
+	pinNow(t, timeAt(22, 0))
+	makeFresh(t, path)
+	svc.Run()
+
+	r := svc.Status().Checks[0]
+	if r.IsStale {
+		t.Error("freshly-touched file should not be IsStale")
+	}
+	if r.InAlert {
+		t.Error("InAlert must stay suppressed outside window even on recovery tick")
+	}
+	// Internal alertState must NOT be cleared yet — otherwise re-entering the
+	// window with a fresh file would never produce a recovery mail. Smoke
+	// test: re-stale the file inside the window and verify the run still
+	// observes us as previously-alerting (i.e. no new "first alert" path).
+	pinNow(t, timeAt(11, 0))
+	makeStale(t, path, 60*time.Minute)
+	svc.Run()
+	if !svc.Status().Checks[0].InAlert {
+		t.Error("alertState should have been preserved across the outside-window tick")
+	}
+}
+
+func TestAlertingCount_ExcludesOutsideWindow(t *testing.T) {
+	// /health must stay healthy when the only stale file is outside its
+	// window. ChecksStale stays raw (1), ChecksAlerting becomes 0.
+	pinNow(t, timeAt(3, 0)) // outside 08:00-20:00
+
+	path := filepath.Join(t.TempDir(), "news.mp3")
+	makeStale(t, path, 60*time.Minute)
+
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{
+			Name: "Daytime news", Path: path, MaxAgeMinutes: 10,
+			ActiveWindow: "08:00-20:00",
+		},
+	)
+
+	svc.Run() // grace
+	svc.Run() // real
+
+	if got := svc.StaleCount(); got != 1 {
+		t.Errorf("StaleCount() = %d, want 1 (raw stale is preserved)", got)
+	}
+	if got := svc.AlertingCount(); got != 0 {
+		t.Errorf("AlertingCount() = %d, want 0 (window suppresses)", got)
+	}
+}
+
+func TestNewFileMonitorService_RejectsInvalidActiveWindow(t *testing.T) {
+	// Tests that bypass config.Load() (i.e. construct Config{} directly, like
+	// newTestService does) must still hit a hard failure on a bad window —
+	// otherwise an invalid string would silently degrade to "always active".
+	cfg := &config.Config{}
+	cfg.FileMonitor = config.FileMonitorConfig{
+		Enabled: true,
+		Checks: []config.FileMonitorCheckConfig{
+			{Name: "Bad", Path: "/data/x.mp3", MaxAgeMinutes: 10, ActiveWindow: "12:00-12:00"},
+		},
+	}
+	notifySvc := notify.New(cfg)
+	if _, err := newFileMonitorService(cfg, notifySvc); err == nil {
+		t.Fatal("expected newFileMonitorService to reject equal-start/end window, got nil")
+	}
+
+	cfg.FileMonitor.Checks[0].ActiveWindow = "garbage"
+	if _, err := newFileMonitorService(cfg, notifySvc); err == nil {
+		t.Fatal("expected newFileMonitorService to reject unparsable window, got nil")
+	}
+
+	cfg.FileMonitor.Checks[0].ActiveWindow = "06:00-22:00"
+	if _, err := newFileMonitorService(cfg, notifySvc); err != nil {
+		t.Fatalf("valid window should be accepted, got: %v", err)
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -34,11 +34,16 @@ func New(db *sqlx.DB, cfg *config.Config) (*AeronService, error) {
 		return nil, err
 	}
 
+	fileMonitorSvc, err := newFileMonitorService(cfg, notifySvc)
+	if err != nil {
+		return nil, err
+	}
+
 	return &AeronService{
 		Media:       newMediaService(repo, cfg),
 		Backup:      backupSvc,
 		Maintenance: newMaintenanceService(repo, cfg, notifySvc),
-		FileMonitor: newFileMonitorService(cfg, notifySvc),
+		FileMonitor: fileMonitorSvc,
 		Notify:      notifySvc,
 		repo:        repo,
 		config:      cfg,


### PR DESCRIPTION
## Samenvatting

PR4 in de file-monitor reeks (zie [BESTANDSCONTROLE-VERBETERPLAN.md §9](../blob/feat/file-monitor-active-window/BESTANDSCONTROLE-VERBETERPLAN.md)). Voegt een optioneel tijdvenster per check toe en maakt `/api/health` window-aware.

## Wat dit PR doet

- **`active_window` per check** (`"HH:MM-HH:MM"`, leeg = altijd actief, wraparound `22:00-06:00` toegestaan).
- **Buiten venster**: `is_stale` blijft zichtbaar in `/status` (transparantie), maar `in_alert` wordt geforceerd op `false`, `alertState` ongewijzigd, en zowel alert- als recovery-mails worden onderdrukt.
- **`/api/health` krijgt nieuw veld `checks_alerting`** (window-aware) dat de `degraded`-beslissing aanstuurt. `checks_stale` houdt zijn ruwe betekenis voor transparantie.
- **`newFileMonitorService` faalt nu hard op een ongeldig venster** (gelijke start/eind, out-of-range, parse-error). Tests die `Config` direct opbouwen — buiten `config.Load()` om — degraderen niet meer stil naar "altijd actief". `service.New` propageert de error analoog aan `newBackupService`.

## Implementatiekeuzes

- **Parser in `internal/config`**: `ParseTimeWindow` + `time_window` validator-tag. Geen package cycle.
- **Read-only window-cache op de service**: `windows map[string]config.TimeWindow` wordt eenmalig in `newFileMonitorService` gevuld en daarna nooit gemuteerd, dus geen extra lock nodig — past bij de bestaande PR3-afspraak dat `publishedMu` de enige published-state lock is.
- **Clock-injection seam**: nieuwe `var nowFunc = time.Now` (analoog aan `osStat`) zodat windowing-tests deterministisch een uur kunnen pinnen zonder afhankelijkheid van wall-clock-tijd.
- **`newTestService(t, ...checks)`**: variadic met `t.Helper()` + `t.Fatalf` op constructor-error. Alle 23 callsites bijgewerkt.

## Tests toegevoegd

`internal/config/timewindow_test.go`:
- `TestParseTimeWindow_Cases` (15 subtests: leeg, normaal, wraparound, ongeldig, out-of-range, gelijke start/eind, trailing junk, etc.)
- `TestTimeWindow_Active_Wraparound`
- `TestTimeWindow_Active_NormalDay`
- `TestTimeWindow_UnconfiguredIsAlwaysActive`
- `TestFileMonitorValidation_ActiveWindow`

`internal/service/filemonitor_test.go`:
- `TestActiveWindow_NoAlertOutsideWindow`
- `TestActiveWindow_AlertWhenWindowOpens` (stale buiten venster, blijft stale na opening → alert)
- `TestActiveWindow_RecoveryRespectsWindow` (recovery-mail-suppressie buiten venster, en behoud van `alertState` over outside-window-tick)
- `TestAlertingCount_ExcludesOutsideWindow` (`/health` healthy met `ChecksAlerting=0` terwijl `ChecksStale=1`)
- `TestNewFileMonitorService_RejectsInvalidActiveWindow`

## Documentatie

- `config.example.json`: voorbeeld `active_window` toegevoegd op de eerste check.
- `API.md`: `checks_alerting` uitgelegd in de health-sectie; `active_window` en `stat_timeout_seconds` toegevoegd aan de configuratie-tabel met TZ-caveat.

## Validatie

```
go vet ./...
gofmt -s -l .          # geen output
go test ./...          # alle tests groen
go build .
golangci-lint run      # 0 issues
```

## Reviewer-radar

- `publishedMu` blijft de enige published-state lock — `windows` is read-only na constructor, dus geen tweede lock geïntroduceerd.
- `/api/health` gebruikt `AlertingCount()` (nieuw, windowed), niet `StaleCount()`.
- Recovery-suppressie buiten venster wordt expliciet getest (`TestActiveWindow_RecoveryRespectsWindow`), niet alleen alert-suppressie.
- `started_at` blijft staan na afronding (zoals voorgesteld in plan); reviewer had dit al akkoord.

## Test plan

- [ ] CI groen (vet, gofmt, test, build, lint).
- [ ] Manuele test: config met `"active_window": "22:00-06:00"` op een stale bestand, run overdag → `/api/file-monitor/status` toont `is_stale=true, in_alert=false`, `/api/health` blijft `healthy`.
- [ ] Manuele test: zelfde config 's nachts → `in_alert=true`, `/health` wordt `degraded`.
- [ ] Manuele test: `"active_window": "12:00-12:00"` weigert config-load met duidelijke melding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)