### PR TITLE
fix: address open issues #109, #110, #111, #112

### DIFF
--- a/internal/config/timewindow.go
+++ b/internal/config/timewindow.go
@@ -9,12 +9,12 @@ import (
 
 // TimeWindow represents a HH:MM-HH:MM window in local time.
 //
-// A window with EndMin < StartMin wraps around midnight (e.g. 22:00-06:00
-// is active from 22:00 until 06:00 the next morning). Configured == false
-// distinguishes the zero value ("no window set, always active") from a
-// parsed window — StartMin == EndMin would otherwise be ambiguous, so it
-// is rejected at parse time and operators must omit the field for
-// always-active behaviour.
+// A window whose end is earlier than its start wraps around midnight (e.g.
+// 22:00-06:00 is active from 22:00 until 06:00 the next morning). An
+// unconfigured window (zero value) is always active; this is distinct from a
+// parsed window — equal start and end would otherwise be ambiguous, so it is
+// rejected at parse time and operators must omit the field for always-active
+// behaviour.
 type TimeWindow struct {
 	startMin, endMin int
 	configured       bool

--- a/internal/config/timewindow.go
+++ b/internal/config/timewindow.go
@@ -16,8 +16,8 @@ import (
 // is rejected at parse time and operators must omit the field for
 // always-active behaviour.
 type TimeWindow struct {
-	StartMin, EndMin int
-	Configured       bool
+	startMin, endMin int
+	configured       bool
 }
 
 // ParseTimeWindow parses "HH:MM-HH:MM". An empty string returns an
@@ -43,7 +43,7 @@ func ParseTimeWindow(s string) (TimeWindow, error) {
 	if start == end {
 		return TimeWindow{}, fmt.Errorf("invalid window %q: start and end are equal; omit the field for always-active", s)
 	}
-	return TimeWindow{StartMin: start, EndMin: end, Configured: true}, nil
+	return TimeWindow{startMin: start, endMin: end, configured: true}, nil
 }
 
 func parseHHMM(s string) (int, error) {
@@ -68,12 +68,18 @@ func parseHHMM(s string) (int, error) {
 // Active reports whether t (in its own location) falls inside the window.
 // An unconfigured window is treated as always-active.
 func (w TimeWindow) Active(t time.Time) bool {
-	if !w.Configured {
+	if !w.configured {
 		return true
 	}
 	cur := t.Hour()*60 + t.Minute()
-	if w.StartMin < w.EndMin {
-		return cur >= w.StartMin && cur < w.EndMin
+	if w.startMin < w.endMin {
+		return cur >= w.startMin && cur < w.endMin
 	}
-	return cur >= w.StartMin || cur < w.EndMin
+	return cur >= w.startMin || cur < w.endMin
+}
+
+// IsConfigured reports whether this time window was explicitly parsed from a
+// non-empty string. An unconfigured window is treated as always-active.
+func (w TimeWindow) IsConfigured() bool {
+	return w.configured
 }

--- a/internal/config/timewindow_test.go
+++ b/internal/config/timewindow_test.go
@@ -33,7 +33,7 @@ func TestParseTimeWindow_Cases(t *testing.T) {
 		{name: "leading whitespace tolerated", input: " 06:00 - 22:00 ", checks: []struct {
 			hh, mm int
 			want   bool
-		}{{6, 0, true}}},
+		}{{5, 59, false}, {6, 0, true}, {22, 0, false}}},
 		{name: "missing dash", input: "06:00", wantErr: true},
 		{name: "extra dash", input: "06:00-12:00-18:00", wantErr: true},
 		{name: "non-numeric hour", input: "ab:00-22:00", wantErr: true},

--- a/internal/config/timewindow_test.go
+++ b/internal/config/timewindow_test.go
@@ -8,18 +8,32 @@ import (
 
 func TestParseTimeWindow_Cases(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantErr   bool
-		wantStart int
-		wantEnd   int
-		wantConf  bool
+		name    string
+		input   string
+		wantErr bool
+		// checks are spot-checked Active() boundaries for valid windows.
+		checks []struct {
+			hh, mm int
+			want   bool
+		}
 	}{
-		{name: "empty is unconfigured", input: "", wantConf: false},
-		{name: "normal day window", input: "06:00-22:00", wantStart: 6 * 60, wantEnd: 22 * 60, wantConf: true},
-		{name: "wraparound night window", input: "22:00-06:00", wantStart: 22 * 60, wantEnd: 6 * 60, wantConf: true},
-		{name: "minute precision", input: "06:30-22:45", wantStart: 6*60 + 30, wantEnd: 22*60 + 45, wantConf: true},
-		{name: "leading whitespace tolerated", input: " 06:00 - 22:00 ", wantStart: 6 * 60, wantEnd: 22 * 60, wantConf: true},
+		{name: "empty is unconfigured", input: ""},
+		{name: "normal day window", input: "06:00-22:00", checks: []struct {
+			hh, mm int
+			want   bool
+		}{{5, 59, false}, {6, 0, true}, {22, 0, false}}},
+		{name: "wraparound night window", input: "22:00-06:00", checks: []struct {
+			hh, mm int
+			want   bool
+		}{{21, 59, false}, {22, 0, true}, {0, 0, true}, {5, 59, true}, {6, 0, false}}},
+		{name: "minute precision", input: "06:30-22:45", checks: []struct {
+			hh, mm int
+			want   bool
+		}{{6, 29, false}, {6, 30, true}, {22, 44, true}, {22, 45, false}}},
+		{name: "leading whitespace tolerated", input: " 06:00 - 22:00 ", checks: []struct {
+			hh, mm int
+			want   bool
+		}{{6, 0, true}}},
 		{name: "missing dash", input: "06:00", wantErr: true},
 		{name: "extra dash", input: "06:00-12:00-18:00", wantErr: true},
 		{name: "non-numeric hour", input: "ab:00-22:00", wantErr: true},
@@ -44,11 +58,24 @@ func TestParseTimeWindow_Cases(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseTimeWindow(%q) unexpected error: %v", tc.input, err)
 			}
-			if w.Configured != tc.wantConf {
-				t.Errorf("Configured = %v, want %v", w.Configured, tc.wantConf)
+			if tc.input == "" {
+				if w.IsConfigured() {
+					t.Error("expected IsConfigured()=false for empty input")
+				}
+				ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+				if !w.Active(ts) {
+					t.Error("unconfigured window should be active at any time")
+				}
+				return
 			}
-			if w.Configured && (w.StartMin != tc.wantStart || w.EndMin != tc.wantEnd) {
-				t.Errorf("Start/End = %d/%d, want %d/%d", w.StartMin, w.EndMin, tc.wantStart, tc.wantEnd)
+			if !w.IsConfigured() {
+				t.Error("expected IsConfigured()=true for non-empty valid input")
+			}
+			for _, c := range tc.checks {
+				ts := time.Date(2026, 1, 1, c.hh, c.mm, 0, 0, time.UTC)
+				if got := w.Active(ts); got != c.want {
+					t.Errorf("Active(%02d:%02d) = %v, want %v", c.hh, c.mm, got, c.want)
+				}
 			}
 		})
 	}
@@ -82,11 +109,14 @@ func TestTimeWindow_Active_Wraparound(t *testing.T) {
 }
 
 func TestTimeWindow_UnconfiguredIsAlwaysActive(t *testing.T) {
-	var w TimeWindow // zero value: Configured=false
+	var w TimeWindow // zero value: unconfigured
+	if w.IsConfigured() {
+		t.Error("zero-value TimeWindow should be unconfigured")
+	}
 	for _, hh := range []int{0, 6, 12, 22, 23} {
 		ts := time.Date(2026, 1, 1, hh, 0, 0, 0, time.UTC)
 		if !w.Active(ts) {
-			t.Errorf("zero-value TimeWindow should be active at %02d:00", hh)
+			t.Errorf("unconfigured window should be active at %02d:00", hh)
 		}
 	}
 }

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -512,6 +512,9 @@ func (s *FileMonitorService) buildResult(check config.FileMonitorCheckConfig, in
 			exists := false
 			result.FileExists = &exists
 			result.ErrorKind = FileCheckErrorKindNotFound
+			// Error intentionally left empty: FileExists=false already encodes the
+			// absence, and the path itself identifies the missing file. The other
+			// branches set Error because the file may exist but be unreadable.
 			slog.Warn("File monitor: file not found", "name", label, "path", check.Path)
 		case errors.Is(err, os.ErrPermission):
 			result.Error = err.Error()

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -33,11 +33,15 @@ var nowFunc = time.Now
 // A radio config typically lists a handful of files, so 8 is plenty.
 const statCheckParallelism = 8
 
+// FileCheckErrorKind categorises why a file check failed.
+type FileCheckErrorKind string
+
 const (
-	fileCheckErrorKindNotFound    = "not_found"
-	fileCheckErrorKindPermission  = "permission_denied"
-	fileCheckErrorKindStatError   = "stat_error"
-	fileCheckErrorKindStatTimeout = "stat_timeout"
+	FileCheckErrorKindNone        FileCheckErrorKind = ""
+	FileCheckErrorKindNotFound    FileCheckErrorKind = "not_found"
+	FileCheckErrorKindPermission  FileCheckErrorKind = "permission_denied"
+	FileCheckErrorKindStatError   FileCheckErrorKind = "stat_error"
+	FileCheckErrorKindStatTimeout FileCheckErrorKind = "stat_timeout"
 )
 
 type fileMonitorNotifier interface {
@@ -139,16 +143,16 @@ type FileMonitorStatus struct {
 // ErrorKind classifies the failure mode for downstream consumers:
 // "" (success), "not_found", "permission_denied", "stat_timeout", "stat_error".
 type FileCheckResult struct {
-	Name           string     `json:"name,omitempty"`
-	Path           string     `json:"path"`
-	MaxAgeMinutes  int        `json:"max_age_minutes"`
-	FileExists     *bool      `json:"file_exists"`
-	FileAgeMinutes *float64   `json:"file_age_minutes,omitempty"`
-	LastModified   *time.Time `json:"last_modified,omitempty"`
-	IsStale        bool       `json:"is_stale"`
-	InAlert        bool       `json:"in_alert"`
-	Error          string     `json:"error,omitempty"`
-	ErrorKind      string     `json:"error_kind,omitempty"`
+	Name           string             `json:"name,omitempty"`
+	Path           string             `json:"path"`
+	MaxAgeMinutes  int                `json:"max_age_minutes"`
+	FileExists     *bool              `json:"file_exists"`
+	FileAgeMinutes *float64           `json:"file_age_minutes,omitempty"`
+	LastModified   *time.Time         `json:"last_modified,omitempty"`
+	IsStale        bool               `json:"is_stale"`
+	InAlert        bool               `json:"in_alert"`
+	Error          string             `json:"error,omitempty"`
+	ErrorKind      FileCheckErrorKind `json:"error_kind,omitempty"`
 }
 
 func newFileMonitorService(cfg *config.Config, notifySvc *notify.NotificationService) (*FileMonitorService, error) {
@@ -486,7 +490,7 @@ func (s *FileMonitorService) timeoutResult(check config.FileMonitorCheckConfig, 
 		Path:          check.Path,
 		MaxAgeMinutes: check.MaxAgeMinutes,
 		IsStale:       true,
-		ErrorKind:     fileCheckErrorKindStatTimeout,
+		ErrorKind:     FileCheckErrorKindStatTimeout,
 		Error:         fmt.Sprintf("stat timeout after %s", timeout),
 	}
 }
@@ -507,16 +511,16 @@ func (s *FileMonitorService) buildResult(check config.FileMonitorCheckConfig, in
 		case errors.Is(err, os.ErrNotExist):
 			exists := false
 			result.FileExists = &exists
-			result.ErrorKind = fileCheckErrorKindNotFound
+			result.ErrorKind = FileCheckErrorKindNotFound
 			slog.Warn("File monitor: file not found", "name", label, "path", check.Path)
 		case errors.Is(err, os.ErrPermission):
 			result.Error = err.Error()
-			result.ErrorKind = fileCheckErrorKindPermission
+			result.ErrorKind = FileCheckErrorKindPermission
 			slog.Warn("File monitor: permission denied", "name", label, "path", check.Path, "error", err)
 		default:
 			// FileExists stays nil — we cannot determine existence.
 			result.Error = err.Error()
-			result.ErrorKind = fileCheckErrorKindStatError
+			result.ErrorKind = FileCheckErrorKindStatError
 			slog.Warn("File monitor: file stat error", "name", label, "path", check.Path, "error", err)
 		}
 		return result

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -120,6 +120,8 @@ func TestAlertAndRecovery(t *testing.T) {
 	svc := newTestService(t,
 		config.FileMonitorCheckConfig{Name: "News", Path: path, MaxAgeMinutes: 10},
 	)
+	notifier := &captureFileMonitorNotifier{}
+	svc.notify = notifier
 
 	// Grace run.
 	svc.run()
@@ -129,11 +131,17 @@ func TestAlertAndRecovery(t *testing.T) {
 	if !svc.Status().Checks[0].InAlert {
 		t.Fatal("expected InAlert=true after second run")
 	}
+	if len(notifier.alerts) != 1 {
+		t.Fatalf("expected exactly 1 alert call, got %d", len(notifier.alerts))
+	}
 
 	// Third run: file still stale → stays in alert (no duplicate alert).
 	svc.run()
 	if !svc.Status().Checks[0].InAlert {
 		t.Error("expected InAlert=true to persist for still-stale file")
+	}
+	if len(notifier.alerts) != 1 {
+		t.Fatalf("expected still exactly 1 alert call after duplicate run, got %d", len(notifier.alerts))
 	}
 
 	// Touch the file → should recover.
@@ -145,6 +153,79 @@ func TestAlertAndRecovery(t *testing.T) {
 	}
 	if svc.Status().Checks[0].IsStale {
 		t.Error("expected IsStale=false after file recovery")
+	}
+	if len(notifier.recoveries) != 1 {
+		t.Fatalf("expected exactly 1 recovery call, got %d", len(notifier.recoveries))
+	}
+}
+
+func TestAlertSuppressedAcrossWindowGap(t *testing.T) {
+	// 1. Inside window: file goes stale → alert fires exactly once.
+	pinNow(t, timeAt(10, 0))
+
+	path := filepath.Join(t.TempDir(), "news.mp3")
+	makeStale(t, path, 60*time.Minute)
+
+	svc := newTestService(t,
+		config.FileMonitorCheckConfig{
+			Name: "Daytime news", Path: path, MaxAgeMinutes: 10,
+			ActiveWindow: "08:00-20:00",
+		},
+	)
+	notifier := &captureFileMonitorNotifier{}
+	svc.notify = notifier
+
+	svc.run() // grace
+	svc.run() // real → alert
+	if !svc.Status().Checks[0].InAlert {
+		t.Fatal("expected InAlert=true after entering alert inside window")
+	}
+	if len(notifier.alerts) != 1 {
+		t.Fatalf("expected 1 alert dispatch, got %d", len(notifier.alerts))
+	}
+
+	// 2. Window closes → run outside window, no state mutation, no duplicate.
+	pinNow(t, timeAt(22, 0))
+	makeStale(t, path, 60*time.Minute)
+	svc.run()
+
+	r := svc.Status().Checks[0]
+	if !r.IsStale {
+		t.Error("expected IsStale=true outside window (transparency)")
+	}
+	if r.InAlert {
+		t.Error("expected InAlert=false outside window")
+	}
+	if len(notifier.alerts) != 1 {
+		t.Fatalf("expected still 1 alert dispatch after outside-window run, got %d", len(notifier.alerts))
+	}
+
+	// 3. Window reopens while file is still stale → no duplicate alert.
+	pinNow(t, timeAt(10, 0))
+	makeStale(t, path, 60*time.Minute)
+	svc.run()
+
+	r = svc.Status().Checks[0]
+	if !r.InAlert {
+		t.Error("expected InAlert=true once window reopens with still-stale file")
+	}
+	if len(notifier.alerts) != 1 {
+		t.Fatalf("expected no duplicate alert after window reopens, got %d", len(notifier.alerts))
+	}
+
+	// 4. File becomes fresh inside window → recovery fires exactly once.
+	makeFresh(t, path)
+	svc.run()
+
+	r = svc.Status().Checks[0]
+	if r.IsStale {
+		t.Error("expected IsStale=false after recovery")
+	}
+	if r.InAlert {
+		t.Error("expected InAlert=false after recovery")
+	}
+	if len(notifier.recoveries) != 1 {
+		t.Fatalf("expected 1 recovery dispatch, got %d", len(notifier.recoveries))
 	}
 }
 
@@ -171,8 +252,8 @@ func TestMissingFile_FileExistsFalse(t *testing.T) {
 	if result.Error != "" {
 		t.Errorf("expected no error string for ENOENT, got %q", result.Error)
 	}
-	if result.ErrorKind != fileCheckErrorKindNotFound {
-		t.Errorf("expected ErrorKind=%q, got %q", fileCheckErrorKindNotFound, result.ErrorKind)
+	if result.ErrorKind != FileCheckErrorKindNotFound {
+		t.Errorf("expected ErrorKind=%q, got %q", FileCheckErrorKindNotFound, result.ErrorKind)
 	}
 }
 
@@ -213,8 +294,8 @@ func TestPermissionDenied_FileExistsNull(t *testing.T) {
 	if !result.IsStale {
 		t.Error("expected stat error to be treated as stale")
 	}
-	if result.ErrorKind != fileCheckErrorKindPermission {
-		t.Errorf("expected ErrorKind=%q, got %q", fileCheckErrorKindPermission, result.ErrorKind)
+	if result.ErrorKind != FileCheckErrorKindPermission {
+		t.Errorf("expected ErrorKind=%q, got %q", FileCheckErrorKindPermission, result.ErrorKind)
 	}
 }
 
@@ -237,8 +318,8 @@ func TestGenericStatError_UsesStatErrorKind(t *testing.T) {
 	if result.FileExists != nil {
 		t.Errorf("expected file_exists=null for generic stat error, got %v", *result.FileExists)
 	}
-	if result.ErrorKind != fileCheckErrorKindStatError {
-		t.Errorf("expected ErrorKind=%q, got %q", fileCheckErrorKindStatError, result.ErrorKind)
+	if result.ErrorKind != FileCheckErrorKindStatError {
+		t.Errorf("expected ErrorKind=%q, got %q", FileCheckErrorKindStatError, result.ErrorKind)
 	}
 }
 
@@ -332,8 +413,8 @@ func TestStatTimeout_TriggersStaleWithTimeoutKind(t *testing.T) {
 	if !result.IsStale {
 		t.Error("expected IsStale=true on stat timeout")
 	}
-	if result.ErrorKind != fileCheckErrorKindStatTimeout {
-		t.Errorf("expected ErrorKind=%q, got %q", fileCheckErrorKindStatTimeout, result.ErrorKind)
+	if result.ErrorKind != FileCheckErrorKindStatTimeout {
+		t.Errorf("expected ErrorKind=%q, got %q", FileCheckErrorKindStatTimeout, result.ErrorKind)
 	}
 	if result.Error == "" {
 		t.Error("expected Error message to mention timeout")
@@ -1077,8 +1158,8 @@ func TestActiveWindow_StatTimeoutOutsideWindowDoesNotAlert(t *testing.T) {
 	if r.InAlert {
 		t.Error("InAlert must stay false outside the active window on stat timeout")
 	}
-	if r.ErrorKind != fileCheckErrorKindStatTimeout {
-		t.Errorf("expected ErrorKind=%q, got %q", fileCheckErrorKindStatTimeout, r.ErrorKind)
+	if r.ErrorKind != FileCheckErrorKindStatTimeout {
+		t.Errorf("expected ErrorKind=%q, got %q", FileCheckErrorKindStatTimeout, r.ErrorKind)
 	}
 	if got := svc.AlertingCount(); got != 0 {
 		t.Errorf("AlertingCount() = %d, want 0 outside window", got)

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -344,6 +344,9 @@ func TestFreshFile_NotStale(t *testing.T) {
 	if result.InAlert {
 		t.Error("expected InAlert=false for fresh file")
 	}
+	if result.ErrorKind != FileCheckErrorKindNone {
+		t.Errorf("expected ErrorKind=%q for fresh file, got %q", FileCheckErrorKindNone, result.ErrorKind)
+	}
 }
 
 func TestStaleCount(t *testing.T) {
@@ -1232,6 +1235,20 @@ func TestActiveWindow_RecoveryRespectsWindow(t *testing.T) {
 	}
 	if got := notifier.recoveries[0][0].Path; got != path {
 		t.Errorf("recovery dispatch path = %q, want %q", got, path)
+	}
+
+	// 4) File goes stale again after recovery — a fresh alert must fire exactly
+	// once. This guards the invariant that alertState is cleared by the recovery
+	// dispatch, so the next stale detection starts a new alert cycle.
+	makeStale(t, path, 60*time.Minute)
+	svc.run()
+
+	r = svc.Status().Checks[0]
+	if !r.InAlert {
+		t.Error("expected InAlert=true after file goes stale again post-recovery")
+	}
+	if len(notifier.alerts) != 2 {
+		t.Fatalf("expected 2 alert dispatches after second stale cycle, got %d", len(notifier.alerts))
 	}
 }
 


### PR DESCRIPTION
This PR bundles fixes for four recently opened issues:

- **#109** refactor(config): unexport `TimeWindow` fields and expose `IsConfigured() bool` instead. Parse tests are rewritten to behaviour-based assertions via `Active()`.
- **#110** refactor(filemonitor): introduce named type `FileCheckErrorKind` with exported constants, replacing the untyped `string` field.
- **#111** test(filemonitor): strengthen `TestAlertAndRecovery` with exact count assertions on the capture notifier (1 alert, no duplicate, 1 recovery).
- **#112** test(filemonitor): add `TestAlertSuppressedAcrossWindowGap` covering the state-machine invariant that no duplicate alert fires when the window reopens while the file is still stale.

All changes are test-covered and `go test ./...` / `go build ./...` pass cleanly.