### PR TITLE
fix: resolve deadcode lint failures for run() and IsConfigured()

### DIFF
--- a/internal/config/timewindow.go
+++ b/internal/config/timewindow.go
@@ -68,7 +68,7 @@ func parseHHMM(s string) (int, error) {
 // Active reports whether t (in its own location) falls inside the window.
 // An unconfigured window is treated as always-active.
 func (w TimeWindow) Active(t time.Time) bool {
-	if !w.configured {
+	if !w.IsConfigured() {
 		return true
 	}
 	cur := t.Hour()*60 + t.Minute()

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -174,19 +174,6 @@ func newFileMonitorService(cfg *config.Config, notifySvc *notify.NotificationSer
 	}, nil
 }
 
-// run checks all configured files, sends alert/recovery notifications, and
-// publishes the result via lastCheck. It does NOT touch run-state; for the
-// trigger path, TriggerCheck's wrapper publishes lastCheck atomically with
-// run-state via publishCompleted to avoid torn snapshots.
-// Tests use this directly to drive the service synchronously without going
-// through the async runner.
-func (s *FileMonitorService) run() {
-	status := s.executeRun()
-	s.publishedMu.Lock()
-	s.lastCheck = status
-	s.publishedMu.Unlock()
-}
-
 // executeRun performs the check cycle and returns the result without
 // publishing it. Separated from Run() so the trigger path can publish the
 // result together with run-state under a single lock.

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -17,6 +17,15 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
+// run drives the service synchronously for testing. It is the test-only
+// alternative to TriggerCheck, which is asynchronous and involves the runner.
+func (s *FileMonitorService) run() {
+	status := s.executeRun()
+	s.publishedMu.Lock()
+	s.lastCheck = status
+	s.publishedMu.Unlock()
+}
+
 // newTestService creates a FileMonitorService for testing. Variadic for
 // brevity at call sites (all tests pass an inline literal). The notification
 // service has no email configured so it never sends. Constructor errors fail


### PR DESCRIPTION
## Summary

- `FileMonitorService.run()` was defined in production code but only called from tests; moved to `filemonitor_test.go` where it belongs
- `TimeWindow.IsConfigured()` was only called from tests; `Active()` now calls it instead of accessing `w.configured` directly, making it reachable from the production call graph

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] CI deadcode checks pass for both flagged functions