### PR TITLE
style: code style fixes

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -181,15 +181,16 @@ func (s *Server) handleEntityByID(entityType types.EntityType) http.HandlerFunc 
 				return
 			}
 			respondJSON(w, http.StatusOK, artist)
-		} else {
-			track, err := s.service.Media.GetTrack(r.Context(), entityID)
-			if err != nil {
-				statusCode := errorCode(err)
-				respondError(w, statusCode, err.Error())
-				return
-			}
-			respondJSON(w, http.StatusOK, track)
+			return
 		}
+
+		track, err := s.service.Media.GetTrack(r.Context(), entityID)
+		if err != nil {
+			statusCode := errorCode(err)
+			respondError(w, statusCode, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, track)
 	}
 }
 
@@ -250,7 +251,8 @@ func (s *Server) handleGetImage(entityType types.EntityType) http.HandlerFunc {
 		w.Header().Set("Content-Length", strconv.Itoa(len(imageData)))
 
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(imageData); err != nil { //nolint:gosec // G705: imageData is from internal storage, content type is detected and set explicitly
+		//nolint:gosec // G705: imageData is from internal storage, content type is detected and set explicitly
+		if _, err := w.Write(imageData); err != nil {
 			slog.Debug("Failed to write image to client", "error", err)
 		}
 	}
@@ -305,7 +307,11 @@ func (s *Server) handleDeleteImage(entityType types.EntityType) http.HandlerFunc
 
 		err := s.service.Media.DeleteImage(r.Context(), entityType, entityID)
 		if err != nil {
-			slog.Error("Failed to delete image", "entityType", entityType, "id", entityID, "error", err) //nolint:gosec // G706: entityID is validated, logged as structured slog value
+			//nolint:gosec // G706: entityID is validated, logged as structured slog value
+			slog.Error("Failed to delete image",
+				"entityType", entityType,
+				"id", entityID,
+				"error", err)
 			respondError(w, errorCode(err), err.Error())
 			return
 		}
@@ -363,7 +369,10 @@ func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
 		opts := parsePlaylistOptions(query)
 		playlist, err := s.service.Media.GetPlaylist(r.Context(), &opts)
 		if err != nil {
-			slog.Error("Failed to retrieve playlist", "block_id", opts.BlockID, "error", err) //nolint:gosec // G706: block_id is logged as a structured slog value
+			//nolint:gosec // G706: block_id is logged as a structured slog value
+			slog.Error("Failed to retrieve playlist",
+				"block_id", opts.BlockID,
+				"error", err)
 			respondError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
@@ -375,7 +384,10 @@ func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
 	date := query.Get("date")
 	result, err := s.service.Media.GetPlaylistWithTracks(r.Context(), date)
 	if err != nil {
-		slog.Error("Failed to retrieve playlist with tracks", "date", date, "error", err) //nolint:gosec // G706: date is logged as a structured slog value
+		//nolint:gosec // G706: date is logged as a structured slog value
+		slog.Error("Failed to retrieve playlist with tracks",
+			"date", date,
+			"error", err)
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/database/playlist.go
+++ b/internal/database/playlist.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
@@ -76,7 +77,7 @@ func BuildPlaylistQuery(schema string, opts *PlaylistOptions) (query string, par
 
 	nextParam := func() string {
 		paramCount++
-		return fmt.Sprintf("$%d", paramCount)
+		return "$" + strconv.Itoa(paramCount)
 	}
 
 	if opts.BlockID != "" {

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -246,7 +247,9 @@ func (r *Repository) GetPlaylistBlocks(ctx context.Context, date string) ([]Play
 }
 
 // GetPlaylistWithTracks retrieves all blocks with their associated tracks for a date.
-func (r *Repository) GetPlaylistWithTracks(ctx context.Context, date string) ([]PlaylistBlock, map[string][]PlaylistItem, error) {
+func (r *Repository) GetPlaylistWithTracks(
+	ctx context.Context, date string,
+) ([]PlaylistBlock, map[string][]PlaylistItem, error) {
 	blocks, err := r.GetPlaylistBlocks(ctx, date)
 	if err != nil {
 		return nil, nil, err
@@ -276,7 +279,7 @@ func (r *Repository) GetPlaylistWithTracks(ctx context.Context, date string) ([]
 	placeholders := make([]string, len(blockIDs))
 	for i, id := range blockIDs {
 		paramCount++
-		placeholders[i] = fmt.Sprintf("$%d", paramCount)
+		placeholders[i] = "$" + strconv.Itoa(paramCount)
 		params = append(params, id)
 	}
 
@@ -287,7 +290,9 @@ func (r *Repository) GetPlaylistWithTracks(ctx context.Context, date string) ([]
 
 	columns := fmt.Sprintf(playlistItemColumns, types.VoicetrackUserID)
 	joins := fmt.Sprintf(playlistItemJoins, r.schema, r.schema, r.schema)
-	query := fmt.Sprintf("SELECT %s, COALESCE(pi.blockid::text, '') as blockid %s WHERE %s AND pi.blockid IN (%s) ORDER BY pi.blockid, pi.startdatetime",
+	query := fmt.Sprintf(
+		"SELECT %s, COALESCE(pi.blockid::text, '') as blockid %s WHERE %s AND pi.blockid IN (%s)"+
+			" ORDER BY pi.blockid, pi.startdatetime",
 		columns, joins, dateFilter, strings.Join(placeholders, ","))
 
 	var tempItems []playlistItemWithBlockID

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -100,7 +100,9 @@ func (o *Optimizer) convertPNGToJPEG(data []byte) (optimized []byte, format, enc
 
 // processImage resizes and encodes an image, returning optimized data if smaller.
 // If the optimized version is not smaller, it returns the original data with its original format.
-func (o *Optimizer) processImage(sourceImage image.Image, originalData []byte, originalFormat, targetFormat string) (optimized []byte, format, encoder string, err error) {
+func (o *Optimizer) processImage(
+	sourceImage image.Image, originalData []byte, originalFormat, targetFormat string,
+) (optimized []byte, format, encoder string, err error) {
 	bounds := sourceImage.Bounds()
 	width, height := bounds.Dx(), bounds.Dy()
 

--- a/internal/notify/healthalert.go
+++ b/internal/notify/healthalert.go
@@ -62,7 +62,9 @@ func formatHealthAlert(r *HealthAlertResult) (subject, body string) {
 	var b strings.Builder
 	b.WriteString("Database health check meldt problemen\n\n")
 	fmt.Fprintf(&b, "Tijdstip:     %s\n", r.CheckedAt.Format(timeFormat))
-	fmt.Fprintf(&b, "Connecties:   %d / %d (%.0f%%)\n\n", r.ActiveConnections, r.MaxConnections, r.ConnectionUsagePct) //nolint:misspell // Dutch word
+	//nolint:misspell // Dutch word
+	fmt.Fprintf(&b, "Connecties:   %d / %d (%.0f%%)\n\n",
+		r.ActiveConnections, r.MaxConnections, r.ConnectionUsagePct)
 
 	if len(r.LongRunningQueries) > 0 {
 		fmt.Fprintf(&b, "Langlopende queries: %d\n", len(r.LongRunningQueries))
@@ -92,7 +94,9 @@ func formatHealthRecovery(r *HealthAlertResult) (subject, body string) {
 	b.WriteString("Database health check hersteld\n\n")
 	b.WriteString("Alle eerder gemelde problemen zijn opgelost.\n\n")
 	fmt.Fprintf(&b, "Tijdstip:     %s\n", r.CheckedAt.Format(timeFormat))
-	fmt.Fprintf(&b, "Connecties:   %d / %d (%.0f%%)\n", r.ActiveConnections, r.MaxConnections, r.ConnectionUsagePct) //nolint:misspell // Dutch word
+	//nolint:misspell // Dutch word
+	fmt.Fprintf(&b, "Connecties:   %d / %d (%.0f%%)\n",
+		r.ActiveConnections, r.MaxConnections, r.ConnectionUsagePct)
 
 	return subject, b.String()
 }

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -177,7 +177,9 @@ func (s *NotificationService) SendTestEmail(ctx context.Context) error {
 	}
 
 	subject := "[TEST] Aeron Toolbox - E-mailnotificatie test"
-	body := fmt.Sprintf("Dit is een test-e-mail van Aeron Toolbox.\n\nTijdstip: %s\n\nAls u deze e-mail ontvangt, zijn de notificatie-instellingen correct geconfigureerd.",
+	body := fmt.Sprintf(
+		"Dit is een test-e-mail van Aeron Toolbox.\n\nTijdstip: %s\n\n"+
+			"Als u deze e-mail ontvangt, zijn de notificatie-instellingen correct geconfigureerd.",
 		time.Now().Format(timeFormat))
 
 	return client.SendMail(ctx, s.recipients, subject, body)

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -57,7 +57,9 @@ type S3SyncStatus struct {
 }
 
 // newBackupService creates a BackupService with resolved tool paths and optional S3 client.
-func newBackupService(repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService) (*BackupService, error) {
+func newBackupService(
+	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
+) (*BackupService, error) {
 	svc := &BackupService{
 		repo:   repo,
 		config: cfg,
@@ -200,7 +202,8 @@ func (s *BackupService) compressionLevel(requested int) (int, error) {
 
 // validateBackupFile checks backup file integrity using pg_restore --list.
 func (s *BackupService) validateBackupFile(ctx context.Context, filePath string) error {
-	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list", filePath) //nolint:gosec // pgRestorePath is from validated config
+	//nolint:gosec // pgRestorePath is from validated config
+	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list", filePath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		errMsg := strings.TrimSpace(string(output))
@@ -219,8 +222,11 @@ func generateBackupFilename() string {
 }
 
 // executePgDump runs pg_dump and returns file info on success, cleaning up on failure.
-func (s *BackupService) executePgDump(ctx context.Context, pgDumpPath, filename, fullPath string, args []string) (os.FileInfo, time.Duration, error) {
-	cmd := exec.CommandContext(ctx, pgDumpPath, args...) //nolint:gosec // G204: pgDumpPath is resolved from config/PATH, not user HTTP input
+func (s *BackupService) executePgDump(
+	ctx context.Context, pgDumpPath, filename, fullPath string, args []string,
+) (os.FileInfo, time.Duration, error) {
+	//nolint:gosec // G204: pgDumpPath is resolved from config/PATH, not user HTTP input
+	cmd := exec.CommandContext(ctx, pgDumpPath, args...)
 	cmd.Env = append(os.Environ(), "PGPASSWORD="+s.config.Database.Password)
 
 	start := time.Now()
@@ -262,7 +268,8 @@ func (s *BackupService) executePgDump(ctx context.Context, pgDumpPath, filename,
 
 // Public methods.
 
-// Start initiates a database backup in the background. Returns an error if validation fails or a backup is already running.
+// Start initiates a database backup in the background. Returns an error if
+// validation fails or a backup is already running.
 func (s *BackupService) Start(req BackupRequest) error {
 	if err := s.checkEnabled(); err != nil {
 		return err

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -195,20 +195,47 @@ func (s *FileMonitorService) executeRun() *FileMonitorStatus {
 	// Always nil: goroutines embed errors in FileCheckResult and never return them.
 	_ = g.Wait()
 
-	var newAlerts []notify.FileAlertResult
-	var newRecoveries []notify.FileAlertResult
+	newAlerts, newRecoveries := s.processAlertStates(checks, results, now)
 
-	// Acquire lock only for alert state updates.
+	// Send batched notifications outside the lock.
+	s.dispatchNotifications(newAlerts, newRecoveries)
+
+	staleCount := 0
+	for _, r := range results {
+		if r.IsStale {
+			staleCount++
+		}
+	}
+
+	slog.Info("File monitor check completed", "total", len(results), "stale", staleCount)
+
+	return &FileMonitorStatus{
+		LastCheckAt: &now,
+		Checks:      results,
+	}
+}
+
+// processAlertStates evaluates check results against alert state under the
+// state lock. It handles the grace run (first run after restart, observe-only),
+// active-window suppression, and alert/recovery transitions. Returns new alerts
+// and recoveries for notification dispatch (which must happen outside the lock).
+func (s *FileMonitorService) processAlertStates(
+	checks []config.FileMonitorCheckConfig,
+	results []FileCheckResult,
+	now time.Time,
+) (newAlerts, newRecoveries []notify.FileAlertResult) {
 	s.stateMu.Lock()
-	isGraceRun := !s.graceRunDone
+	defer s.stateMu.Unlock()
+
+	if !s.graceRunDone {
+		// Grace run: observe only — don't update alert state or send notifications.
+		// This avoids false alerts immediately after a restart.
+		s.graceRunDone = true
+		slog.Info("File monitor grace run completed, alerts will be sent from next check")
+		return nil, nil
+	}
 
 	for i, check := range checks {
-		if isGraceRun {
-			// Grace run: observe only — don't update alert state or send notifications.
-			// This avoids false alerts immediately after a restart.
-			continue
-		}
-
 		// Outside an active window the result still reflects raw staleness
 		// (transparent in /status) but does not flip alert state, send mail,
 		// or trigger a recovery. Suppressing recovery is essential — without
@@ -237,35 +264,24 @@ func (s *FileMonitorService) executeRun() *FileMonitorStatus {
 		}
 	}
 
-	if isGraceRun {
-		s.graceRunDone = true
-		slog.Info("File monitor grace run completed, alerts will be sent from next check")
-	}
+	return newAlerts, newRecoveries
+}
 
-	s.stateMu.Unlock()
-
-	// Send batched notifications outside the lock.
+// dispatchNotifications sends batched alert and recovery notifications.
+func (s *FileMonitorService) dispatchNotifications(
+	newAlerts, newRecoveries []notify.FileAlertResult,
+) {
 	if len(newAlerts) > 0 {
-		slog.Info("File monitor alert dispatch started", "count", len(newAlerts), "paths", alertPaths(newAlerts))
+		slog.Info("File monitor alert dispatch started",
+			"count", len(newAlerts),
+			"paths", alertPaths(newAlerts))
 		s.notify.SendFileAlerts(newAlerts)
 	}
 	if len(newRecoveries) > 0 {
-		slog.Info("File monitor recovery dispatch started", "count", len(newRecoveries), "paths", alertPaths(newRecoveries))
+		slog.Info("File monitor recovery dispatch started",
+			"count", len(newRecoveries),
+			"paths", alertPaths(newRecoveries))
 		s.notify.SendFileRecoveries(newRecoveries)
-	}
-
-	staleCount := 0
-	for _, r := range results {
-		if r.IsStale {
-			staleCount++
-		}
-	}
-
-	slog.Info("File monitor check completed", "total", len(results), "stale", staleCount)
-
-	return &FileMonitorStatus{
-		LastCheckAt: &now,
-		Checks:      results,
 	}
 }
 
@@ -466,7 +482,9 @@ func (s *FileMonitorService) startOrJoinFlight(path string, now time.Time) (*sta
 }
 
 // timeoutResult builds a synthetic stale-with-timeout result for a hung stat.
-func (s *FileMonitorService) timeoutResult(check config.FileMonitorCheckConfig, flight *statInFlight, timeout time.Duration) FileCheckResult {
+func (s *FileMonitorService) timeoutResult(
+	check config.FileMonitorCheckConfig, flight *statInFlight, timeout time.Duration,
+) FileCheckResult {
 	slog.Warn("File monitor: stat timed out (single-flight goroutine still pending OS reply)",
 		"name", check.DisplayName(),
 		"path", check.Path,
@@ -483,7 +501,9 @@ func (s *FileMonitorService) timeoutResult(check config.FileMonitorCheckConfig, 
 }
 
 // buildResult turns an os.Stat outcome into a FileCheckResult.
-func (s *FileMonitorService) buildResult(check config.FileMonitorCheckConfig, info os.FileInfo, err error, now time.Time) FileCheckResult {
+func (s *FileMonitorService) buildResult(
+	check config.FileMonitorCheckConfig, info os.FileInfo, err error, now time.Time,
+) FileCheckResult {
 	result := FileCheckResult{
 		Name:          check.Name,
 		Path:          check.Path,
@@ -541,7 +561,9 @@ func (s *FileMonitorService) buildResult(check config.FileMonitorCheckConfig, in
 }
 
 // toAlertResult converts a check result to a notification alert result.
-func toAlertResult(check config.FileMonitorCheckConfig, result *FileCheckResult, checkedAt time.Time) notify.FileAlertResult {
+func toAlertResult(
+	check config.FileMonitorCheckConfig, result *FileCheckResult, checkedAt time.Time,
+) notify.FileAlertResult {
 	alert := notify.FileAlertResult{
 		Name:          check.Name,
 		Path:          check.Path,

--- a/internal/service/maintenance.go
+++ b/internal/service/maintenance.go
@@ -279,7 +279,7 @@ func (s *MaintenanceService) getTableHealth(ctx context.Context) ([]TableHealth,
 	cfg := s.config.Maintenance
 	tables := make([]TableHealth, 0, len(rows))
 	for _, row := range rows {
-		tables = append(tables, convertTableRow(row, &cfg))
+		tables = append(tables, convertTableRow(&row, &cfg))
 	}
 
 	return tables, nil
@@ -287,7 +287,7 @@ func (s *MaintenanceService) getTableHealth(ctx context.Context) ([]TableHealth,
 
 // convertTableRow maps a raw database statistics row to a TableHealth struct,
 // computing derived fields like dead-tuple ratio and maintenance flags.
-func convertTableRow(row tableHealthRow, cfg *config.MaintenanceConfig) TableHealth {
+func convertTableRow(row *tableHealthRow, cfg *config.MaintenanceConfig) TableHealth {
 	table := TableHealth{
 		Name:            row.TableName,
 		RowCount:        row.LiveTuples,

--- a/internal/service/maintenance.go
+++ b/internal/service/maintenance.go
@@ -22,7 +22,9 @@ type MaintenanceService struct {
 }
 
 // newMaintenanceService creates a new MaintenanceService instance.
-func newMaintenanceService(repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService) *MaintenanceService {
+func newMaintenanceService(
+	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
+) *MaintenanceService {
 	return &MaintenanceService{
 		repo:   repo,
 		config: cfg,
@@ -277,42 +279,49 @@ func (s *MaintenanceService) getTableHealth(ctx context.Context) ([]TableHealth,
 	cfg := s.config.Maintenance
 	tables := make([]TableHealth, 0, len(rows))
 	for _, row := range rows {
-		table := TableHealth{
-			Name:            row.TableName,
-			RowCount:        row.LiveTuples,
-			DeadTuples:      row.DeadTuples,
-			ModSinceAnalyze: row.ModSinceAnalyze,
-			LastVacuum:      row.LastVacuum,
-			LastAutovacuum:  row.LastAutovacuum,
-			LastAnalyze:     row.LastAnalyze,
-			LastAutoanalyze: row.LastAutoanalyze,
-			SeqScans:        row.SeqScan,
-			IdxScans:        row.IdxScan,
-			TotalSizeRaw:    row.TotalSize,
-			TotalSize:       util.FormatBytes(row.TotalSize),
-			TableSizeRaw:    row.TableSize,
-			TableSize:       util.FormatBytes(row.TableSize),
-			IndexSizeRaw:    row.IndexSize,
-			IndexSize:       util.FormatBytes(row.IndexSize),
-			ToastSizeRaw:    row.ToastSize,
-			ToastSize:       util.FormatBytes(row.ToastSize),
-		}
-
-		if row.LiveTuples > 0 {
-			table.DeadTupleRatio = float64(row.DeadTuples) / float64(row.LiveTuples+row.DeadTuples) * 100
-		}
-
-		table.NeedsVacuum = table.DeadTupleRatio > cfg.GetBloatThreshold() ||
-			table.DeadTuples > cfg.GetDeadTupleThreshold()
-
-		neverAnalyzed := table.LastAnalyze == nil && table.LastAutoanalyze == nil && table.RowCount > 0
-		staleStats := table.RowCount > 0 && table.ModSinceAnalyze > (table.RowCount*int64(cfg.GetStaleStatsThreshold())/100)
-		table.NeedsAnalyze = neverAnalyzed || staleStats
-
-		tables = append(tables, table)
+		tables = append(tables, convertTableRow(row, &cfg))
 	}
 
 	return tables, nil
+}
+
+// convertTableRow maps a raw database statistics row to a TableHealth struct,
+// computing derived fields like dead-tuple ratio and maintenance flags.
+func convertTableRow(row tableHealthRow, cfg *config.MaintenanceConfig) TableHealth {
+	table := TableHealth{
+		Name:            row.TableName,
+		RowCount:        row.LiveTuples,
+		DeadTuples:      row.DeadTuples,
+		ModSinceAnalyze: row.ModSinceAnalyze,
+		LastVacuum:      row.LastVacuum,
+		LastAutovacuum:  row.LastAutovacuum,
+		LastAnalyze:     row.LastAnalyze,
+		LastAutoanalyze: row.LastAutoanalyze,
+		SeqScans:        row.SeqScan,
+		IdxScans:        row.IdxScan,
+		TotalSizeRaw:    row.TotalSize,
+		TotalSize:       util.FormatBytes(row.TotalSize),
+		TableSizeRaw:    row.TableSize,
+		TableSize:       util.FormatBytes(row.TableSize),
+		IndexSizeRaw:    row.IndexSize,
+		IndexSize:       util.FormatBytes(row.IndexSize),
+		ToastSizeRaw:    row.ToastSize,
+		ToastSize:       util.FormatBytes(row.ToastSize),
+	}
+
+	if row.LiveTuples > 0 {
+		table.DeadTupleRatio = float64(row.DeadTuples) / float64(row.LiveTuples+row.DeadTuples) * 100
+	}
+
+	table.NeedsVacuum = table.DeadTupleRatio > cfg.GetBloatThreshold() ||
+		table.DeadTuples > cfg.GetDeadTupleThreshold()
+
+	neverAnalyzed := table.LastAnalyze == nil && table.LastAutoanalyze == nil && table.RowCount > 0
+	staleStats := table.RowCount > 0 &&
+		table.ModSinceAnalyze > (table.RowCount*int64(cfg.GetStaleStatsThreshold())/100)
+	table.NeedsAnalyze = neverAnalyzed || staleStats
+
+	return table
 }
 
 // Recommendations.
@@ -355,8 +364,10 @@ func (s *MaintenanceService) checkTableHealth(t *TableHealth, recs []string) []s
 		recs = append(recs, fmt.Sprintf("Table '%s' has never been vacuumed", t.Name))
 	}
 
-	if lastVac := lastVacuumTime(t); lastVac != nil && time.Since(*lastVac) > cfg.GetVacuumStaleness() && t.RowCount > minRows {
-		recs = append(recs, fmt.Sprintf("Table '%s' has not been vacuumed in over %d days", t.Name, cfg.GetVacuumStalenessDays()))
+	if lastVac := lastVacuumTime(t); lastVac != nil &&
+		time.Since(*lastVac) > cfg.GetVacuumStaleness() && t.RowCount > minRows {
+		recs = append(recs, fmt.Sprintf(
+			"Table '%s' has not been vacuumed in over %d days", t.Name, cfg.GetVacuumStalenessDays()))
 	}
 
 	if t.LastAnalyze == nil && t.LastAutoanalyze == nil && t.RowCount > minRows {
@@ -366,12 +377,17 @@ func (s *MaintenanceService) checkTableHealth(t *TableHealth, recs []string) []s
 	if t.RowCount > 0 && t.ModSinceAnalyze > 0 {
 		threshold := t.RowCount * int64(cfg.GetStaleStatsThreshold()) / 100
 		if t.ModSinceAnalyze > threshold {
-			recs = append(recs, fmt.Sprintf("Table '%s' has %d modifications since last ANALYZE - statistics stale", t.Name, t.ModSinceAnalyze))
+			recs = append(recs, fmt.Sprintf(
+				"Table '%s' has %d modifications since last ANALYZE - statistics stale",
+				t.Name, t.ModSinceAnalyze))
 		}
 	}
 
-	if t.SeqScans > 1000 && t.IdxScans > 0 && float64(t.SeqScans)/float64(t.IdxScans) > cfg.GetSeqScanRatioThreshold() {
-		recs = append(recs, fmt.Sprintf("Table '%s' has high sequential scans (%d) vs index scans (%d) - possible missing index", t.Name, t.SeqScans, t.IdxScans))
+	if t.SeqScans > 1000 && t.IdxScans > 0 &&
+		float64(t.SeqScans)/float64(t.IdxScans) > cfg.GetSeqScanRatioThreshold() {
+		recs = append(recs, fmt.Sprintf(
+			"Table '%s' has high sequential scans (%d) vs index scans (%d) - possible missing index",
+			t.Name, t.SeqScans, t.IdxScans))
 	}
 
 	if t.ToastSizeRaw > cfg.GetToastSizeWarningBytes() {

--- a/internal/service/media.go
+++ b/internal/service/media.go
@@ -72,7 +72,11 @@ type ImageUploadResult struct {
 
 // UploadImage downloads, resizes, optimizes, and stores an image for an artist or track.
 func (s *MediaService) UploadImage(ctx context.Context, params *ImageUploadParams) (*ImageUploadResult, error) {
-	slog.Debug("Image upload started", "entityType", params.EntityType, "id", params.ID, "hasURL", params.ImageURL != "", "hasData", len(params.ImageData) > 0)
+	slog.Debug("Image upload started",
+		"entityType", params.EntityType,
+		"id", params.ID,
+		"hasURL", params.ImageURL != "",
+		"hasData", len(params.ImageData) > 0)
 
 	if err := validateImageUploadParams(params); err != nil {
 		return nil, err
@@ -113,13 +117,19 @@ func (s *MediaService) UploadImage(ctx context.Context, params *ImageUploadParam
 		Quality:       s.config.Image.Quality,
 		RejectSmaller: s.config.Image.RejectSmaller,
 	}
-	slog.Debug("Image processing started", "inputSize", len(imageData), "targetWidth", imgConfig.TargetWidth, "targetHeight", imgConfig.TargetHeight)
+	slog.Debug("Image processing started",
+		"inputSize", len(imageData),
+		"targetWidth", imgConfig.TargetWidth,
+		"targetHeight", imgConfig.TargetHeight)
 	processingResult, err := image.Process(imageData, imgConfig)
 	if err != nil {
 		slog.Error("Image processing failed", "error", err)
 		return nil, types.NewValidationError("image", fmt.Sprintf("processing failed: %v", err))
 	}
-	slog.Debug("Image processing completed", "originalSize", processingResult.Original.Size, "optimizedSize", processingResult.Optimized.Size, "savings", processingResult.Savings)
+	slog.Debug("Image processing completed",
+		"originalSize", processingResult.Original.Size,
+		"optimizedSize", processingResult.Optimized.Size,
+		"savings", processingResult.Savings)
 
 	table := types.Table(params.EntityType)
 	if err := s.repo.UpdateImage(ctx, table, params.ID, processingResult.Data); err != nil {
@@ -205,7 +215,9 @@ func DefaultPlaylistOptions() database.PlaylistOptions {
 }
 
 // GetPlaylist retrieves played tracks for a date or block with filtering and pagination.
-func (s *MediaService) GetPlaylist(ctx context.Context, opts *database.PlaylistOptions) ([]database.PlaylistItem, error) {
+func (s *MediaService) GetPlaylist(
+	ctx context.Context, opts *database.PlaylistOptions,
+) ([]database.PlaylistItem, error) {
 	return s.repo.GetPlaylist(ctx, opts)
 }
 
@@ -242,7 +254,8 @@ func (s *MediaService) GetPlaylistWithTracks(ctx context.Context, date string) (
 // validateEntityType ensures the entity type is either artist or track.
 func validateEntityType(entityType types.EntityType) error {
 	if entityType != types.EntityTypeArtist && entityType != types.EntityTypeTrack {
-		return types.NewValidationError("entityType", fmt.Sprintf("invalid type: use '%s' or '%s'", types.EntityTypeArtist, types.EntityTypeTrack))
+		return types.NewValidationError("entityType",
+			fmt.Sprintf("invalid type: use '%s' or '%s'", types.EntityTypeArtist, types.EntityTypeTrack))
 	}
 	return nil
 }

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -55,7 +55,8 @@ func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 
 	// Register file monitor job if enabled (cadence from FileMonitor.Interval()).
 	if cfg.FileMonitor.Enabled {
-		if err := s.addJob(fmt.Sprintf("@every %s", cfg.FileMonitor.Interval()), "file-monitor", s.runFileMonitor); err != nil {
+		schedule := fmt.Sprintf("@every %s", cfg.FileMonitor.Interval())
+		if err := s.addJob(schedule, "file-monitor", s.runFileMonitor); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/util/validators.go
+++ b/internal/util/validators.go
@@ -92,7 +92,8 @@ func ValidateImageData(data []byte) error {
 // ValidateImageFormat validates that an image format is supported.
 func ValidateImageFormat(format string) error {
 	if !slices.Contains(types.SupportedFormats, format) {
-		return types.NewValidationError("image", fmt.Sprintf("file format %s is not supported (use: %v)", format, types.SupportedFormats))
+		return types.NewValidationError("image",
+			fmt.Sprintf("file format %s is not supported (use: %v)", format, types.SupportedFormats))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **else-after-return**: Removed unnecessary `else` in `handleEntityByID` (`handlers.go:184`). The `if` branch ends with `respondJSON` + `return`, so the `else` was dedented to a flat flow.
- **`fmt.Sprintf` to `strconv`**: Replaced `fmt.Sprintf("$%d", paramCount)` with `"$" + strconv.Itoa(paramCount)` in `playlist.go:79` and `repository.go:279`. Added `strconv` to imports; `fmt` remains used in both files.
- **Split long functions**:
  - `filemonitor.go`: Extracted `processAlertStates()` (alert-state lock, grace run, window suppression, state transitions) and `dispatchNotifications()` (batched send) from `executeRun()`. Each helper has a clear single responsibility.
  - `maintenance.go`: Extracted `convertTableRow()` from `getTableHealth()` to isolate row-to-struct mapping with derived field computation (dead-tuple ratio, needs-vacuum/analyze flags).
- **Long lines**: Broke 30 lines exceeding 120 chars across slog calls, function signatures, `fmt.Sprintf` format strings, and nolint comments. 3 remaining (struct tag, const URL, jitter expression) cannot be cleanly wrapped.

### Skipped with reason

- **`media.go:89` and `media.go:106` else-after-return**: These are `if`/`else` branches that both assign local variables (`name`, `title`, `imageData`) used by shared code below. The outer `if` blocks do **not** end with `return` — the inner `if err != nil { return }` is a nested error guard. Flattening would duplicate the shared tail or require restructuring that hurts readability. Not a genuine else-after-return pattern.
- **`BuildPlaylistQuery` split**: At 77 lines the function is borderline. The `nextParam` closure (shared between condition building and LIMIT/OFFSET) makes extraction awkward — extracting `buildWhereClause` would require passing the closure or a mutable counter, adding complexity without genuine clarity gains.
- **Nil slice initializations** (`filemonitor.go:198-199`, `maintenance.go:322`, `config.go:460`): None are returned to callers or JSON-marshalled. The slices are either local temporaries guarded by `len > 0` or used only for `strings.Join`. Changing them to `make([]T, 0)` would be purely cosmetic with no behavioral difference.
- **3 remaining long lines** (`config.go:27` struct tag, `graph.go:26` const URL, `backoff.go:40` jitter expression): These are single tokens or expressions that cannot be split without harming readability.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 3 test packages green, including `internal/service` which covers file monitor alert logic)