### PR TITLE
fix: align API docs with actual response codes and messages

### DIFF
--- a/API.md
+++ b/API.md
@@ -231,7 +231,7 @@ Bekijk artiestgegevens inclusief afbeeldingsstatus.
 **Foutresponse:** `404 Not Found`
 ```json
 {
-  "error": "artist not found"
+  "error": "artist with ID '123e4567-e89b-12d3-a456-426614174000' not found"
 }
 ```
 
@@ -252,7 +252,7 @@ Bekijk de afbeelding van de artiest.
 **Foutresponse:** `404 Not Found`
 ```json
 {
-  "error": "artist image not found"
+  "error": "artist image with ID '123e4567-e89b-12d3-a456-426614174000' not found"
 }
 ```
 
@@ -286,9 +286,8 @@ Een artiestafbeelding uploaden of bijwerken.
 ```
 
 **Foutresponses:**
-- `400` Bad Request - Ongeldige invoer
+- `400` Bad Request - Ongeldige invoer of afbeeldingsvalidatie mislukt
 - `404` Not Found - Artiest niet gevonden
-- `422` Unprocessable Entity - Afbeeldingsvalidatie mislukt
 
 ### Artiestafbeelding verwijderen
 
@@ -311,7 +310,7 @@ Het verwijderen van een artiestafbeelding.
 **Foutresponse:** `404 Not Found`
 ```json
 {
-  "error": "artist image not found"
+  "error": "artist image with ID '123e4567-e89b-12d3-a456-426614174000' not found"
 }
 ```
 
@@ -336,7 +335,7 @@ Het verwijderen van alle artiestafbeeldingen uit de database.
 **Foutresponse:** `400 Bad Request`
 ```json
 {
-  "error": "missing confirmation header: X-Confirm-Bulk-Delete"
+  "error": "Missing confirmation header: X-Confirm-Bulk-Delete"
 }
 ```
 
@@ -406,7 +405,7 @@ Bekijk trackgegevens inclusief afbeeldingsstatus.
 **Foutresponse:** `404 Not Found`
 ```json
 {
-  "error": "track not found"
+  "error": "track with ID '456e7890-e89b-12d3-a456-426614174000' not found"
 }
 ```
 
@@ -427,7 +426,7 @@ Bekijk de albumhoes van de track.
 **Foutresponse:** `404 Not Found`
 ```json
 {
-  "error": "track image not found"
+  "error": "track image with ID '456e7890-e89b-12d3-a456-426614174000' not found"
 }
 ```
 
@@ -462,9 +461,8 @@ Een albumhoes uploaden of bijwerken.
 ```
 
 **Foutresponses:**
-- `400` Bad Request - Ongeldige invoer
+- `400` Bad Request - Ongeldige invoer of afbeeldingsvalidatie mislukt
 - `404` Not Found - Track niet gevonden
-- `422` Unprocessable Entity - Afbeeldingsvalidatie mislukt
 
 ### Trackafbeelding verwijderen
 
@@ -487,7 +485,7 @@ Het verwijderen van de albumhoes van een track.
 **Foutresponse:** `404 Not Found`
 ```json
 {
-  "error": "track image not found"
+  "error": "track image with ID '456e7890-e89b-12d3-a456-426614174000' not found"
 }
 ```
 
@@ -512,7 +510,7 @@ Het verwijderen van alle trackafbeeldingen uit de database.
 **Foutresponse:** `400 Bad Request`
 ```json
 {
-  "error": "missing confirmation header: X-Confirm-Bulk-Delete"
+  "error": "Missing confirmation header: X-Confirm-Bulk-Delete"
 }
 ```
 
@@ -824,10 +822,10 @@ De backup wordt asynchroon uitgevoerd. Controleer `GET /api/db/backup/status` vo
 
 **Foutresponses:**
 
-`400 Bad Request` - Backup niet ingeschakeld:
+`404 Not Found` - Backup niet ingeschakeld:
 ```json
 {
-  "error": "backup functionality is not enabled"
+  "error": "backup is not enabled"
 }
 ```
 
@@ -1050,6 +1048,13 @@ Toont de resultaten van de meest recente bestandscontrole, plus de huidige runst
 **Endpoint:** `GET /api/file-monitor/status`
 **Authenticatie:** Vereist
 
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "file monitor is not enabled"
+}
+```
+
 **Response:** `200 OK`
 ```json
 {
@@ -1170,6 +1175,13 @@ Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of sto
 
 **Endpoint:** `POST /api/file-monitor/check`
 **Authenticatie:** Vereist
+
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "file monitor is not enabled"
+}
+```
 
 **Response:** `202 Accepted`
 ```json

--- a/API.md
+++ b/API.md
@@ -79,8 +79,10 @@ Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoint
 
 ## Algemene response-headers
 
-Alle API-responses bevatten:
-- `Content-Type: application/json; charset=utf-8` (uitgezonderd afbeeldingsendpoints)
+JSON-responses bevatten:
+- `Content-Type: application/json; charset=utf-8`
+
+Succesvolle binaire responses, zoals afbeeldingsdownloads en backupdownloads, gebruiken het passende bestandstype in plaats van JSON. Foutresponses voor deze endpoints zijn wel JSON.
 
 ## Response-formaat
 
@@ -101,7 +103,7 @@ Of bij fouten:
 ```
 
 > [!NOTE]
-> In de JSON-voorbeelden hieronder wordt voor de leesbaarheid alleen de inhoud van het `data`-veld getoond, en bij foutresponses alleen het `error`-veld. JSON-responses gebruiken in werkelijkheid de complete wrapper (inclusief `"success"`).
+> In de JSON-voorbeelden hieronder wordt voor de leesbaarheid alleen de inhoud van het `data`-veld getoond, en bij foutresponses alleen het `error`-veld. JSON-responses gebruiken in werkelijkheid de complete wrapper (inclusief `"success"`). Succesvolle binaire responses gebruiken geen JSON-wrapper.
 
 ## Foutmeldingen
 

--- a/API.md
+++ b/API.md
@@ -101,7 +101,7 @@ Of bij fouten:
 ```
 
 > [!NOTE]
-> In de voorbeelden hieronder wordt voor de leesbaarheid alleen de inhoud van het `data`-veld getoond, maar in werkelijkheid wordt altijd de complete wrapper geretourneerd.
+> In de JSON-voorbeelden hieronder wordt voor de leesbaarheid alleen de inhoud van het `data`-veld getoond, en bij foutresponses alleen het `error`-veld. JSON-responses gebruiken in werkelijkheid de complete wrapper (inclusief `"success"`).
 
 ## Foutmeldingen
 
@@ -843,6 +843,13 @@ Toont de status van de laatste backupbewerking.
 **Endpoint:** `GET /api/db/backup/status`
 **Authenticatie:** Vereist
 
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "backup is not enabled"
+}
+```
+
 **Response tijdens backup:** `200 OK`
 ```json
 {
@@ -922,6 +929,13 @@ Bekijk een overzicht van alle beschikbare backups.
 **Endpoint:** `GET /api/db/backups`
 **Authenticatie:** Vereist
 
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "backup is not enabled"
+}
+```
+
 **Response:** `200 OK`
 ```json
 {
@@ -951,6 +965,13 @@ Een specifiek backupbestand downloaden.
 **Endpoint:** `GET /api/db/backups/{filename}`
 **Authenticatie:** Vereist
 
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "backup is not enabled"
+}
+```
+
 **Parameters:**
 - `filename` (padparameter, vereist): Naam van het backupbestand
 
@@ -972,6 +993,13 @@ Een specifiek backupbestand verwijderen.
 
 **Endpoint:** `DELETE /api/db/backups/{filename}`
 **Authenticatie:** Vereist
+
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "backup is not enabled"
+}
+```
 
 **Parameters:**
 - `filename` (padparameter, vereist): Naam van het backupbestand
@@ -1000,6 +1028,13 @@ De integriteit van een bestaand backupbestand valideren. Handig voor het control
 
 **Endpoint:** `GET /api/db/backups/{filename}/validate`
 **Authenticatie:** Vereist
+
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "backup is not enabled"
+}
+```
 
 **Parameters:**
 - `filename` (padparameter, vereist): Naam van het backupbestand

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -72,13 +72,16 @@ func (s *Server) Start(port string) error {
 					r.Get("/health", s.handleDatabaseHealth)
 				})
 
-				// Backup endpoints
-				r.Post("/backup", s.handleCreateBackup)
-				r.Get("/backup/status", s.handleBackupStatus)
-				r.Get("/backups", s.handleListBackups)
-				r.Get("/backups/{filename}", s.handleDownloadBackupFile)
-				r.Get("/backups/{filename}/validate", s.handleValidateBackup)
-				r.Delete("/backups/{filename}", s.handleDeleteBackup)
+				// Backup endpoints (guarded: 404 when backup is disabled)
+				r.Group(func(r chi.Router) {
+					r.Use(s.requireBackupEnabled)
+					r.Post("/backup", s.handleCreateBackup)
+					r.Get("/backup/status", s.handleBackupStatus)
+					r.Get("/backups", s.handleListBackups)
+					r.Get("/backups/{filename}", s.handleDownloadBackupFile)
+					r.Get("/backups/{filename}/validate", s.handleValidateBackup)
+					r.Delete("/backups/{filename}", s.handleDeleteBackup)
+				})
 			})
 
 			r.Get("/file-monitor/status", s.handleFileMonitorStatus)
@@ -142,6 +145,16 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) requireBackupEnabled(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.service.Config().Backup.Enabled {
+			respondError(w, http.StatusNotFound, "backup is not enabled")
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## Summary

- **Code fix**: Backup not-enabled returns 404 via handler-level middleware (was 500 via `ConfigError`), consistent with the file monitor pattern
- **Docs fix**: Corrected 6 mismatches between API.md and actual code behavior (error messages, status codes, missing responses)
- **Docs completeness**: Added 404 "backup is not enabled" response to all 6 backup endpoints (was only on `POST /api/db/backup`)
- **Docs clarity**: Clarified response wrapper disclaimer — scoped to JSON responses, explicitly covers both `data` and `error` field abbreviation, notes binary endpoints are excluded

### Changes

| Issue | Fix | Location |
|-------|-----|----------|
| Backup not-enabled returned 500 (ConfigError) | `requireBackupEnabled` middleware returns 404 | `server.go` |
| Docs claimed 422 for image validation | Changed to 400 (matches `ValidationError`) | `API.md` |
| Not-found errors lacked entity ID | Updated to `"... with ID '...' not found"` format | `API.md` |
| Bulk-delete error casing `"missing"` vs `"Missing"` | Corrected to match handler output | `API.md` |
| File monitor not-enabled 404 undocumented | Added to both endpoints | `API.md` |
| Backup not-enabled error message/code wrong | Updated to 404 + `"backup is not enabled"` | `API.md` |
| Backup 404 only documented on POST endpoint | Added to all 6 backup endpoints | `API.md` |
| Response wrapper disclaimer incomplete | Scoped to JSON, covers error examples, excludes binary | `API.md` |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] `go test ./...` passes
- [x] Verify backup endpoints return 404 when `backup.enabled: false`
- [x] Verify backup endpoints work normally when `backup.enabled: true`