### PR TITLE
Use middleware guard for file monitor endpoints

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -33,6 +33,7 @@ env:
   ARTIST_ID: "9e37ff1f-7823-43ce-93d0-12fc1c2edb8b"
   BLOF_ID: "add55a6e-2068-4114-b82a-e0729881f0be"
   FAKE_UUID: "00000000-0000-4000-8000-000000000001"
+  TEST_IMAGE_URL: "https://placehold.co/1500x1500/png"
 
 jobs:
   build:
@@ -520,7 +521,7 @@ jobs:
           RESPONSE=$(curl -s -X POST -H "X-API-Key: ${{ env.API_KEY }}" \
             "http://localhost:${{ env.API_PORT }}/api/artists/${{ env.ARTIST_ID }}/image" \
             -H 'Content-Type: application/json' \
-            -d '{"url":"https://picsum.photos/1500"}' -m 15)
+            -d "{\"url\":\"${{ env.TEST_IMAGE_URL }}\"}" -m 30)
           SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
           if [ "$SUCCESS" = "true" ]; then
             echo "Afbeelding succesvol geupload via URL"
@@ -1595,7 +1596,7 @@ jobs:
           RESPONSE=$(curl -s -X POST -H "X-API-Key: ${{ env.API_KEY }}" \
             "http://localhost:${{ env.API_PORT }}/api/artists/${{ env.FAKE_UUID }}/image" \
             -H 'Content-Type: application/json' \
-            -d '{"url":"https://picsum.photos/500"}')
+            -d "{\"url\":\"${{ env.TEST_IMAGE_URL }}\"}")
           SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
           if [ "$SUCCESS" = "false" ]; then
             echo "Correct: upload naar niet-bestaande artiest wordt geweigerd"
@@ -1611,7 +1612,7 @@ jobs:
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "X-API-Key: ${{ env.API_KEY }}" \
             "http://localhost:${{ env.API_PORT }}/api/artists/not-a-uuid/image" \
             -H 'Content-Type: application/json' \
-            -d '{"url":"https://picsum.photos/500"}')
+            -d "{\"url\":\"${{ env.TEST_IMAGE_URL }}\"}")
           echo "HTTP status: $HTTP_CODE (verwacht: 400)"
           if [ "$HTTP_CODE" = "400" ]; then
             echo "Correct: ongeldige UUID geeft 400 Bad Request"
@@ -1671,17 +1672,17 @@ jobs:
           curl -s -X POST -H "X-API-Key: ${{ env.API_KEY }}" \
             "http://localhost:${{ env.API_PORT }}/api/artists/${{ env.ARTIST_ID }}/image" \
             -H 'Content-Type: application/json' \
-            -d '{"url":"https://picsum.photos/1500"}' > /tmp/r1.json &
+            -d "{\"url\":\"${{ env.TEST_IMAGE_URL }}\"}" -m 30 > /tmp/r1.json &
 
           curl -s -X POST -H "X-API-Key: ${{ env.API_KEY }}" \
             "http://localhost:${{ env.API_PORT }}/api/artists/${ARTIST_ID2}/image" \
             -H 'Content-Type: application/json' \
-            -d '{"url":"https://picsum.photos/1500"}' > /tmp/r2.json &
+            -d "{\"url\":\"${{ env.TEST_IMAGE_URL }}\"}" -m 30 > /tmp/r2.json &
 
           curl -s -X POST -H "X-API-Key: ${{ env.API_KEY }}" \
             "http://localhost:${{ env.API_PORT }}/api/tracks/${TRACK_ID}/image" \
             -H 'Content-Type: application/json' \
-            -d '{"url":"https://picsum.photos/1500"}' > /tmp/r3.json &
+            -d "{\"url\":\"${{ env.TEST_IMAGE_URL }}\"}" -m 30 > /tmp/r3.json &
 
           wait
           echo "Upload 1: $(cat /tmp/r1.json | jq -r '.success')"

--- a/internal/api/filemonitor.go
+++ b/internal/api/filemonitor.go
@@ -3,7 +3,7 @@ package api
 import "net/http"
 
 // FileMonitorCheckResponse is returned by POST /file-monitor/check. RunID is
-// the monotone server-side ID of the run just started; clients use it to
+// the monotonic server-side ID of the run just started; clients use it to
 // correlate later /status snapshots (run is done when completed_run_id >= RunID
 // && running == false).
 type FileMonitorCheckResponse struct {
@@ -13,18 +13,10 @@ type FileMonitorCheckResponse struct {
 }
 
 func (s *Server) handleFileMonitorStatus(w http.ResponseWriter, r *http.Request) {
-	if !s.service.Config().FileMonitor.Enabled {
-		respondError(w, http.StatusNotFound, "file monitor is not enabled")
-		return
-	}
 	respondJSON(w, http.StatusOK, s.service.FileMonitor.Status())
 }
 
 func (s *Server) handleFileMonitorCheck(w http.ResponseWriter, r *http.Request) {
-	if !s.service.Config().FileMonitor.Enabled {
-		respondError(w, http.StatusNotFound, "file monitor is not enabled")
-		return
-	}
 	runID, err := s.service.FileMonitor.TriggerCheck()
 	if err != nil {
 		respondError(w, errorCode(err), err.Error())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,19 @@ func New(svc *service.AeronService, version string) *Server {
 
 // Start initializes and starts the HTTP server on the specified port.
 func (s *Server) Start(port string) error {
+	router := s.router()
+
+	s.server = &http.Server{
+		Addr:              ":" + port,
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	return s.server.ListenAndServe()
+}
+
+// router builds the HTTP handler tree.
+func (s *Server) router() http.Handler {
 	router := chi.NewRouter()
 
 	cop := http.NewCrossOriginProtection()
@@ -84,20 +97,18 @@ func (s *Server) Start(port string) error {
 				})
 			})
 
-			r.Get("/file-monitor/status", s.handleFileMonitorStatus)
-			r.Post("/file-monitor/check", s.handleFileMonitorCheck)
+			// File monitor endpoints (guarded: 404 when file monitor is disabled)
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireFileMonitorEnabled)
+				r.Get("/file-monitor/status", s.handleFileMonitorStatus)
+				r.Post("/file-monitor/check", s.handleFileMonitorCheck)
+			})
 
 			r.Post("/notifications/test-email", s.handleTestEmail)
 		})
 	})
 
-	s.server = &http.Server{
-		Addr:              ":" + port,
-		Handler:           router,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	return s.server.ListenAndServe()
+	return router
 }
 
 // Shutdown gracefully shuts down the server.
@@ -153,6 +164,16 @@ func (s *Server) requireBackupEnabled(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !s.service.Config().Backup.Enabled {
 			respondError(w, http.StatusNotFound, "backup is not enabled")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) requireFileMonitorEnabled(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.service.Config().FileMonitor.Enabled {
+			respondError(w, http.StatusNotFound, "file monitor is not enabled")
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/service"
+)
+
+func TestFileMonitorRoutesDisabledReturnNotFound(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.FileMonitor.Enabled = false
+
+	svc, err := service.New(nil, cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	t.Cleanup(svc.Close)
+
+	handler := New(svc, "test").router()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{
+			name:   "status",
+			method: http.MethodGet,
+			path:   "/api/file-monitor/status",
+		},
+		{
+			name:   "check",
+			method: http.MethodPost,
+			path:   "/api/file-monitor/check",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, http.NoBody)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status code = %d, want %d; body: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+			}
+
+			var got Response
+			if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if got.Success {
+				t.Fatal("success = true, want false")
+			}
+			if got.Error != "file monitor is not enabled" {
+				t.Fatalf("error = %q, want %q", got.Error, "file monitor is not enabled")
+			}
+		})
+	}
+}
+
+func TestFileMonitorRoutesEnabledPassThrough(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.FileMonitor.Enabled = true
+
+	svc, err := service.New(nil, cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	t.Cleanup(svc.Close)
+
+	handler := New(svc, "test").router()
+	req := httptest.NewRequest(http.MethodGet, "/api/file-monitor/status", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got Response
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.Success {
+		t.Fatalf("success = false, want true; error: %s", got.Error)
+	}
+}

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -370,7 +370,7 @@ func (s *FileMonitorService) Close() {
 
 // TriggerCheck starts a file monitor run in the background. It is the single
 // entry point for both manual API triggers and scheduled cron ticks so the two
-// can never run concurrently. Returns the monotone run_id of the run just
+// can never run concurrently. Returns the monotonic run_id of the run just
 // started, or a ConflictError if a run is already in progress.
 func (s *FileMonitorService) TriggerCheck() (uint64, error) {
 	if !s.runner.TryStart() {


### PR DESCRIPTION
Closes #120

## Summary
- add route-level file monitor enabled middleware alongside the backup guard
- group file monitor status/check routes under that guard
- remove duplicated enabled checks from file monitor handlers
- add router coverage for disabled file monitor responses

## Tests
- go test ./...