### PR TITLE
chore: remove Windows support handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,6 @@ jobs:
             goarch: arm
             goarm: '7'
             suffix: ''
-          # Windows builds
-          - goos: windows
-            goarch: amd64
-            suffix: '.exe'
-          - goos: windows
-            goarch: arm64
-            suffix: '.exe'
           # macOS builds
           - goos: darwin
             goarch: amd64

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run -d -p 8080:8080 \
 
 ### Binary
 
-Download een kant-en-klare binary voor jouw platform via de [releases-pagina](https://github.com/oszuidwest/zwfm-aerontoolbox/releases).
+Download een kant-en-klare Linux- of macOS-binary via de [releases-pagina](https://github.com/oszuidwest/zwfm-aerontoolbox/releases).
 
 ### Vanaf broncode
 

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -266,10 +265,6 @@ func TestMissingFile_FileExistsFalse(t *testing.T) {
 }
 
 func TestPermissionDenied_FileExistsNull(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission-based test not reliable on Windows")
-	}
-
 	dir := t.TempDir()
 	path := filepath.Join(dir, "restricted.mp3")
 	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {


### PR DESCRIPTION
## Summary
- remove Windows amd64/arm64 targets from the release build matrix
- update README binary install text to mention Linux and macOS release binaries only

## Tests
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release yaml ok'"
- go test ./...