### PR TITLE
ci: make deadcode gate fail on findings

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -103,7 +103,12 @@ jobs:
           args: --timeout=5m
 
       - name: Check for dead code
-        run: go tool deadcode ./...
+        run: |
+          deadcode_output=$(go tool deadcode ./...)
+          if [ -n "$deadcode_output" ]; then
+            echo "$deadcode_output"
+            exit 1
+          fi
 
       - name: Run govulncheck
         run: go tool govulncheck ./...


### PR DESCRIPTION
## Summary

- The existing `Check for dead code` step ran `go tool deadcode ./...` but never inspected the output. `deadcode` exits 0 even with findings, so the gate was a no-op.
- Wrap the call to capture output and `exit 1` on non-empty result, matching the pattern in `oszuidwest/.github-templates/.github/workflows/go-ci.yml`.

## Verification

\`\`\`sh
go tool deadcode ./...
# (no output, exit 0)
\`\`\`

No findings on main, so this tightening doesn't break CI today. From now on it'll catch future unreachable code.

## Test plan

- [x] Local `go tool deadcode ./...` returns clean
- [ ] CI on this PR is green