### PR TITLE
ci: migrate lint job to go-ci.yml@v1 (Step 1 of #14 alignment)

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -65,56 +65,8 @@ jobs:
           retention-days: 1
 
   lint:
-    runs-on: ubuntu-latest
     if: ${{ inputs.skip_tests != true }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Download dependencies
-        run: go mod download
-
-      - name: Check formatting (gofmt)
-        run: |
-          UNFORMATTED=$(gofmt -s -l .)
-          if [ -n "$UNFORMATTED" ]; then
-            echo "::error::De volgende bestanden zijn niet correct geformatteerd:"
-            echo "$UNFORMATTED"
-            exit 1
-          fi
-          echo "Alle bestanden zijn correct geformatteerd"
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run Go tests with race detector
-        run: go test -race ./...
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.12.1
-          args: --timeout=5m
-
-      - name: Check for dead code
-        run: |
-          deadcode_output=$(go tool deadcode ./...)
-          if [ -n "$deadcode_output" ]; then
-            echo "$deadcode_output"
-            exit 1
-          fi
-
-      - name: Run govulncheck
-        run: go tool govulncheck ./...
-
-      - name: Run staticcheck
-        run: go tool staticcheck ./...
+    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1
 
   integration:
     needs: build


### PR DESCRIPTION
## Summary

- Step 1 of [oszuidwest/.github-templates#14](https://github.com/oszuidwest/.github-templates/issues/14) — replace the inline `lint` job in `comprehensive-test.yml` with a `uses:` call to `oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1`.
- 49 LOC removed, 1 LOC added.

## Behavior changes

| Aspect | Before | After |
|---|---|---|
| Race tests | `go test -race ./...` | `go test -race -shuffle=on -v ./...` |
| Format check | `gofmt -s -l .` (with simplify) | `go fmt ./... && git diff --exit-code` (no simplify) |
| Error language | Dutch | English |
| Vet, golangci-lint v2.12.1, deadcode (strict, post #126), govulncheck, staticcheck | identical | identical |

`gofmt -s` simplify check is the only thing lost. Verified locally:

\`\`\`sh
$ gofmt -s -l .
# (empty, exit 0)
\`\`\`

No files trigger simplify today. Can be reinstated by adding the `gofmt` formatter to `.golangci.yml` if desired (separate concern).

## What stays bespoke

- `build` job — produces the binary artifact consumed by `integration`. Project-specific.
- `integration` matrix — 9 PostgreSQL suites with project-specific fixtures.

## Preserved invariants

- `if: \${{ inputs.skip_tests != true }}` is kept at the job level. The reusable workflow is skipped entirely when `skip_tests: true` is passed (e.g. from edge-release flow in `release.yml`). No regression for the existing release path.
- `permissions: contents: read` at workflow level satisfies the nested reusable's parse-time permission validation.

## Test plan

- [ ] CI on this PR is green (proves lint job still runs the right gates)
- [ ] Smoke-test: trigger `Comprehensive Test` via workflow_dispatch with `skip_tests: true` — lint job skipped, build/integration also skipped