### PR TITLE
ci: bump go-ci.yml shim from @v1 to @v2

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -53,7 +53,7 @@ jobs:
           retention-days: 1
 
   lint:
-    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v2
 
   integration:
     needs: build


### PR DESCRIPTION
## Summary

- Bumps `oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1` → `@v2` in the `lint` job of comprehensive-test.yml.

No functional change: the v2 tag of `.github-templates` was a breaking change scoped to `go-release.yml` only — `go-ci.yml` content is identical between v1 and v2. This bump completes the v1 → v2 cutover so the v1 line can eventually be retired. The `build` and `integration` jobs are untouched (project-specific).

Context: oszuidwest/.github-templates#5, #18, oszuidwest/zwfm-aerontoolbox#129.

## Test plan

- [ ] CI green on PR (`lint` job runs via `go-ci.yml@v2`; `build` + `integration` jobs run as before).