### PR TITLE
chore: replace em dashes with regular hyphens

### DIFF
--- a/.github/workflows/docker-quality.yml
+++ b/.github/workflows/docker-quality.yml
@@ -38,7 +38,7 @@ jobs:
             echo "has_dockerfile=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Ignore rules live in .hadolint.yaml — do not duplicate here.
+      # Ignore rules live in .hadolint.yaml - do not duplicate here.
       - name: Hadolint
         if: steps.check_dockerfile.outputs.has_dockerfile == 'true'
         uses: hadolint/hadolint-action@v3.3.0

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -45,8 +45,8 @@ type HealthResponse struct {
 //
 // ChecksStale is the raw count from the most recent run (includes stale
 // files outside their configured ActiveWindow) and is preserved for
-// transparency. ChecksAlerting is window-aware — outside-window stales are
-// excluded — and is what drives the overall degraded status.
+// transparency. ChecksAlerting is window-aware - outside-window stales are
+// excluded - and is what drives the overall degraded status.
 type FileMonitorHealth struct {
 	Enabled        bool `json:"enabled"`
 	ChecksTotal    int  `json:"checks_total"`

--- a/internal/async/runner.go
+++ b/internal/async/runner.go
@@ -16,7 +16,7 @@ import (
 //
 //   - GoChild: secondary work spawned from within an active Go() or Done() body.
 //     The primary operation already holds a WaitGroup slot, so Close() is already
-//     blocking — adding a child is always safe and will be waited on.
+//     blocking - adding a child is always safe and will be waited on.
 //
 //   - TryGoBackground: independent background dispatch from outside any active
 //     primary operation (e.g. an HTTP handler, a scheduler job). Returns false
@@ -147,7 +147,7 @@ func (r *Runner) Go(fn func()) {
 //
 // Use this for follow-up work spawned from within an active Go() or Done()
 // body (e.g. async S3 upload after a backup completes). Because the primary
-// operation already holds a WaitGroup slot, Close() is already blocked —
+// operation already holds a WaitGroup slot, Close() is already blocked -
 // adding a child here is always safe and will be waited on.
 //
 // Do NOT use this for independent dispatches from outside a primary operation;
@@ -156,7 +156,7 @@ func (r *Runner) GoChild(fn func()) {
 	r.wg.Go(fn)
 }
 
-// TryGoBackground starts a background goroutine as an independent dispatch —
+// TryGoBackground starts a background goroutine as an independent dispatch -
 // that is, from outside any currently active Go() or Done() body.
 // Returns false and does nothing if Close() has already been called, allowing
 // callers to log the drop explicitly.

--- a/internal/async/runner_test.go
+++ b/internal/async/runner_test.go
@@ -81,14 +81,14 @@ func TestGoChild_DoesNotCheckClosed(t *testing.T) {
 	r := New()
 	r.Close()
 
-	// GoChild has no closed gate — it simply calls wg.Go. Calling it after
+	// GoChild has no closed gate - it simply calls wg.Go. Calling it after
 	// Close is a caller contract violation, but it must not panic.
 	done := make(chan struct{})
 	r.GoChild(func() { close(done) })
 
 	select {
 	case <-done:
-		// Goroutine ran — GoChild did not block or panic.
+		// Goroutine ran - GoChild did not block or panic.
 	case <-time.After(time.Second):
 		t.Fatal("GoChild goroutine did not run")
 	}
@@ -113,7 +113,7 @@ func TestTryGoBackground_ReturnsFalseAfterClose(t *testing.T) {
 }
 
 // TestTryGoBackground_WaitedOnByClose verifies that a goroutine started via
-// TryGoBackground before Close is waited on by Close — the same WaitGroup
+// TryGoBackground before Close is waited on by Close - the same WaitGroup
 // guarantee as GoChild.
 func TestTryGoBackground_WaitedOnByClose(t *testing.T) {
 	r := New()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,7 +118,7 @@ type FileMonitorConfig struct {
 // FileMonitorCheckConfig defines a single file to monitor for staleness.
 //
 // ActiveWindow is validated by validateFileMonitorConfig (struct-level) so the
-// parser's specific reason — equal start/end, range, format — survives into
+// parser's specific reason - equal start/end, range, format - survives into
 // the error message instead of collapsing to a generic tag string.
 type FileMonitorCheckConfig struct {
 	Name           string `json:"name"`
@@ -412,7 +412,7 @@ func validateFileMonitorConfig(sl validator.StructLevel) {
 	// Encode the slice index in the reported field name (e.g.
 	// "checks[1].active_window") so multiple bad windows produce distinct,
 	// locatable error labels. ReportError otherwise registers at the parent
-	// struct level — every bad check would collapse onto a single
+	// struct level - every bad check would collapse onto a single
 	// "filemonitor.active_window" key, defeating the point of telling the
 	// operator which entry to fix.
 	for i, c := range fm.Checks {

--- a/internal/config/timewindow.go
+++ b/internal/config/timewindow.go
@@ -12,7 +12,7 @@ import (
 // A window whose end is earlier than its start wraps around midnight (e.g.
 // 22:00-06:00 is active from 22:00 until 06:00 the next morning). An
 // unconfigured window (zero value) is always active; this is distinct from a
-// parsed window — equal start and end would otherwise be ambiguous, so it is
+// parsed window - equal start and end would otherwise be ambiguous, so it is
 // rejected at parse time and operators must omit the field for always-active
 // behaviour.
 type TimeWindow struct {
@@ -22,7 +22,7 @@ type TimeWindow struct {
 
 // ParseTimeWindow parses "HH:MM-HH:MM". An empty string returns an
 // unconfigured (always-active) window with no error. Equal start and end
-// minutes are rejected — operators should omit the field instead, since
+// minutes are rejected - operators should omit the field instead, since
 // there is no sensible interpretation of a zero-length window.
 func ParseTimeWindow(s string) (TimeWindow, error) {
 	if s == "" {

--- a/internal/config/timewindow_test.go
+++ b/internal/config/timewindow_test.go
@@ -190,7 +190,7 @@ func TestFileMonitorValidation_ActiveWindow(t *testing.T) {
 }
 
 func TestFileMonitorValidation_ActiveWindow_IncludesIndex(t *testing.T) {
-	// Multiple bad windows must produce distinct, indexed error labels —
+	// Multiple bad windows must produce distinct, indexed error labels -
 	// otherwise an operator with two typos sees the same "active_window"
 	// key twice and cannot tell which checks[] entry needs editing. The
 	// label is the only way to locate the bad row when the parser message

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -60,7 +60,7 @@ type statResult struct {
 // (until the OS returns), instead of one per Run() iteration. Joiners share the
 // original timeout budget measured from when statFn actually started (not from
 // when executeRun was called), so a permanently hanging flight only burns one
-// full StatTimeout — subsequent runs return immediately.
+// full StatTimeout - subsequent runs return immediately.
 //
 // startedNano is an atomic int64 (Unix nanoseconds). It is initialised to the
 // executeRun call time as a safe fallback for joiners that race the goroutine
@@ -97,7 +97,7 @@ type FileMonitorService struct {
 	// Published state: lastCheck + run IDs live under one lock so a Status()
 	// snapshot is internally consistent. Writing lastCheck without also bumping
 	// completedRunID (or vice versa) would let a client observe checks from
-	// run N+1 paired with completed_run_id=N — which would falsify the
+	// run N+1 paired with completed_run_id=N - which would falsify the
 	// documented exact-correlation contract.
 	//
 	// Status().Running comes from runner.IsRunning() (atomic) rather than a
@@ -216,7 +216,7 @@ func (s *FileMonitorService) executeRun() *FileMonitorStatus {
 }
 
 // processAlertStates evaluates check results against alert state under the
-// state lock. It handles the grace run (first run after restart, observe-only —
+// state lock. It handles the grace run (first run after restart, observe-only -
 // only graceRunDone is set; per-path alertState is not touched), active-window
 // alert suppression (IsStale is preserved transparently; only alert-state
 // transitions and notifications are suppressed), and alert/recovery transitions.
@@ -232,7 +232,7 @@ func (s *FileMonitorService) processAlertStates(
 	defer s.stateMu.Unlock()
 
 	if !s.graceRunDone {
-		// Grace run: observe only — don't update alert state or send notifications.
+		// Grace run: observe only - don't update alert state or send notifications.
 		// This avoids false alerts immediately after a restart.
 		s.graceRunDone = true
 		slog.Info("File monitor grace run completed, alerts will be sent from next check")
@@ -242,7 +242,7 @@ func (s *FileMonitorService) processAlertStates(
 	for i, check := range checks {
 		// Outside an active window the result still reflects raw staleness
 		// (transparent in /status) but does not flip alert state, send mail,
-		// or trigger a recovery. Suppressing recovery is essential — without
+		// or trigger a recovery. Suppressing recovery is essential - without
 		// it a midnight refresh would mail "[OK] recovered" for an alert the
 		// operator never received.
 		if !s.windows[check.Path].Active(now) {
@@ -294,7 +294,7 @@ func (s *FileMonitorService) dispatchNotifications(
 // Single-lock read: lastCheck and run IDs are written together under
 // publishedMu by publishCompleted, so a snapshot observed here is internally
 // consistent. Concretely, completed_run_id always names the run that
-// produced the visible Checks — clients can rely on the documented
+// produced the visible Checks - clients can rely on the documented
 // `completed_run_id == myRunID` exact-correlation contract.
 //
 // Running is read from the runner's atomic gate, not a mirrored field, so
@@ -335,7 +335,7 @@ func (s *FileMonitorService) StaleCount() int {
 
 // AlertingCount returns the number of checks currently in alert (InAlert==true)
 // in the most recent run. Stale-but-outside-window checks are excluded by
-// construction — Run() never flips InAlert for them — so this is the right
+// construction - Run() never flips InAlert for them - so this is the right
 // signal for /health degraded. Reads under publishedMu so it pairs
 // consistently with the Checks slice published by the same run.
 func (s *FileMonitorService) AlertingCount() int {
@@ -398,7 +398,7 @@ func (s *FileMonitorService) startNewRun() uint64 {
 // publishCompleted atomically publishes the run's result and bumps
 // completedRunID under a single lock. Pairing lastCheck with completedRunID
 // in one critical section is what makes the polling contract
-// `completed_run_id == myRunID` an exact-correlation guarantee — a Status()
+// `completed_run_id == myRunID` an exact-correlation guarantee - a Status()
 // reader can never see lastCheck from run N+1 alongside completedRunID=N.
 func (s *FileMonitorService) publishCompleted(status *FileMonitorStatus, runID uint64) {
 	s.publishedMu.Lock()
@@ -532,7 +532,7 @@ func (s *FileMonitorService) buildResult(
 			result.ErrorKind = FileCheckErrorKindPermission
 			slog.Warn("File monitor: permission denied", "name", label, "path", check.Path, "error", err)
 		default:
-			// FileExists stays nil — we cannot determine existence.
+			// FileExists stays nil - we cannot determine existence.
 			result.Error = err.Error()
 			result.ErrorKind = FileCheckErrorKindStatError
 			slog.Warn("File monitor: file stat error", "name", label, "path", check.Path, "error", err)

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -27,7 +27,7 @@ func (s *FileMonitorService) run() {
 // newTestService creates a FileMonitorService for testing. Variadic for
 // brevity at call sites (all tests pass an inline literal). The notification
 // service has no email configured so it never sends. Constructor errors fail
-// the test — they would always indicate an invalid ActiveWindow in the test
+// the test - they would always indicate an invalid ActiveWindow in the test
 // fixture, never a runtime condition worth proceeding past.
 func newTestService(t *testing.T, checks ...config.FileMonitorCheckConfig) *FileMonitorService {
 	t.Helper()
@@ -116,7 +116,7 @@ func TestGraceRun_NoPhantomRecovery(t *testing.T) {
 		t.Error("file should be fresh after touch")
 	}
 	if status.Checks[0].InAlert {
-		t.Error("expected InAlert=false — no phantom recovery should occur")
+		t.Error("expected InAlert=false - no phantom recovery should occur")
 	}
 }
 
@@ -517,7 +517,7 @@ func TestParallelChecks_FastFailNotBlockedBySlowStat(t *testing.T) {
 
 	// Total should be ~1s (slow timeout), not ~3s (sequential).
 	if elapsed > 1500*time.Millisecond {
-		t.Errorf("Run() took %v, expected ~1s — fast checks appear serialized behind slow stat", elapsed)
+		t.Errorf("Run() took %v, expected ~1s - fast checks appear serialized behind slow stat", elapsed)
 	}
 
 	results := svc.Status().Checks
@@ -831,7 +831,7 @@ func TestTriggerCheck_NoConflictAfterStatusReportsIdle(t *testing.T) {
 	// a client observes Running == false, the next TriggerCheck() must
 	// succeed without 409. Earlier the published "running" was cleared in
 	// publishCompleted (inside fn), but the runner's own Store(false) only
-	// fires in a defer after fn returns — so a brief window let the API
+	// fires in a defer after fn returns - so a brief window let the API
 	// report idle while TryStart() still rejected.
 	path := filepath.Join(t.TempDir(), "news.mp3")
 	touchFile(t, path)
@@ -865,7 +865,7 @@ func TestStatus_NoTornSnapshotUnderConcurrentReads(t *testing.T) {
 	// Why this catches the old bug. The two-lock implementation published
 	// lastCheck under statusMu, then bumped completedRunID under runStateMu
 	// via a separate `defer markCompleted`. A reader landing between those
-	// two unlocks would observe (CompletedRunID=N-1, LastCheckAt=tag[N]) —
+	// two unlocks would observe (CompletedRunID=N-1, LastCheckAt=tag[N]) -
 	// a mismatch this assertion would flag. Under the single-lock fix
 	// (publishCompleted writes both atomically), no such window exists, so
 	// the test passes deterministically.
@@ -891,7 +891,7 @@ func TestStatus_NoTornSnapshotUnderConcurrentReads(t *testing.T) {
 		return t, ok
 	}
 
-	// Pre-run twice so the tag map has entries before the readers start —
+	// Pre-run twice so the tag map has entries before the readers start -
 	// otherwise early reads find no tag and skip the assertion.
 	for range 2 {
 		runID, err := svc.TriggerCheck()
@@ -1073,7 +1073,7 @@ func makeFresh(t *testing.T, path string) {
 }
 
 func TestActiveWindow_NoAlertOutsideWindow(t *testing.T) {
-	// Window 22:00-06:00 (overnight) — at 14:00 we are firmly outside it.
+	// Window 22:00-06:00 (overnight) - at 14:00 we are firmly outside it.
 	pinNow(t, timeAt(14, 0))
 
 	path := filepath.Join(t.TempDir(), "news.mp3")
@@ -1240,7 +1240,7 @@ func TestActiveWindow_RecoveryRespectsWindow(t *testing.T) {
 		t.Errorf("recovery dispatch path = %q, want %q", got, path)
 	}
 
-	// 4) File goes stale again after recovery — a fresh alert must fire exactly
+	// 4) File goes stale again after recovery - a fresh alert must fire exactly
 	// once. This guards the invariant that alertState is cleared by the recovery
 	// dispatch, so the next stale detection starts a new alert cycle.
 	makeStale(t, path, 60*time.Minute)
@@ -1283,7 +1283,7 @@ func TestAlertingCount_ExcludesOutsideWindow(t *testing.T) {
 
 func TestNewFileMonitorService_RejectsInvalidActiveWindow(t *testing.T) {
 	// Tests that bypass config.Load() (i.e. construct Config{} directly, like
-	// newTestService does) must still hit a hard failure on a bad window —
+	// newTestService does) must still hit a hard failure on a bad window -
 	// otherwise an invalid string would silently degrade to "always active".
 	cfg := &config.Config{}
 	cfg.FileMonitor = config.FileMonitorConfig{


### PR DESCRIPTION
Em dash sweep - purely cosmetic. Skips tests/fixtures/mock_data.sql (song lyrics).