### PR TITLE
ci: optimize Docker security workflow

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -1,12 +1,12 @@
 ---
 name: Docker Security
 
-on:
+"on":
   push:
     branches: [main]
   pull_request:
   schedule:
-    - cron: '0 4 * * 0'  # Weekly Sunday 04:00 UTC
+    - cron: "0 4 * * 0"
   workflow_dispatch:
   workflow_call:
 
@@ -19,23 +19,23 @@ permissions:
   security-events: write
 
 env:
-  REGISTRY: ghcr.io
-  DOCKERFILE_PATH: "Dockerfile"
+  DOCKERFILE_PATH: Dockerfile
+  IMAGE_REF: ${{ github.repository }}:security-scan
 
 jobs:
   security-scan:
-    name: Security Scan
+    name: Security scan
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build Image for Scanning
+      - name: Build image for scanning
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -43,41 +43,37 @@ jobs:
           push: false
           pull: true
           load: true
-          tags: ${{ github.repository }}:scan
+          tags: ${{ env.IMAGE_REF }}
 
-      - name: Cache Trivy DB
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/trivy
-          key: trivy-db
-          restore-keys: |
-            trivy-db
-
-      # MEDIUM included so they surface in the Security tab.
-      - name: Trivy SARIF Report
+      - name: Trivy SARIF report
+        if: >-
+          github.event_name != 'pull_request' &&
+          github.event.repository.private == false
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ github.repository }}:scan
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          scanners: 'vuln,secret'
+          image-ref: ${{ env.IMAGE_REF }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH,MEDIUM
+          scanners: vuln,secret
           ignore-unfixed: true
-          exit-code: '0'
+          exit-code: "0"
           limit-severities-for-sarif: true
 
-      - name: Upload Trivy Results to GitHub Security
+      - name: Upload Trivy results to GitHub Security
+        if: >-
+          github.event_name != 'pull_request' &&
+          github.event.repository.private == false
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: trivy-results.sarif
 
-      - name: Fail on Critical Vulnerabilities
+      - name: Trivy high and critical summary
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ github.repository }}:scan
-          format: 'table'
-          severity: 'CRITICAL'
-          scanners: 'vuln,secret'
+          image-ref: ${{ env.IMAGE_REF }}
+          format: table
+          severity: CRITICAL,HIGH
+          scanners: vuln,secret
           ignore-unfixed: true
-          exit-code: '1'
+          exit-code: "0"


### PR DESCRIPTION
## Summary

- remove the separate Trivy DB cache step and use the Trivy action cache instead
- skip SARIF generation/upload on pull request runs and private repositories
- keep SARIF upload for public push, scheduled, and manual runs
- replace blocking critical-only failures with a non-blocking high/critical summary
- normalize the workflow YAML for linting

## Validation

- `yamllint` on all changed docker-security workflows
- Ruby YAML parse check on all changed docker-security workflows
- `actionlint` on each changed docker-security workflow
- `git diff --check`
