### PR TITLE
fix(api): remove deprecated chi RealIP middleware

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,7 +65,7 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 
 ## Authenticatie
 
-Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `/health`) een API-sleutel.
+Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `GET /api/health`) een API-sleutel.
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
@@ -1577,7 +1577,7 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   - `path`: Absoluut pad naar het bestand.
   - `max_age_minutes`: Maximaal toegestane leeftijd in minuten (minimaal 1).
   - `stat_timeout_seconds`: Maximale tijd in seconden voor `os.Stat` (standaard 5; `0` of weglaten = standaard). Beschermt tegen vastgelopen NFS- of SMB-mounts.
-  - `active_window`: Optioneel tijdvenster `"HH:MM-HH:MM"` waarin alerts en `/health degraded` actief zijn. Buiten dit venster blijft `is_stale` zichtbaar in `/status`, maar wordt er geen alert- of herstelmail verstuurd en blijft `/health` gezond. Een eindtijd vóór de starttijd betekent dat het venster over middernacht heen loopt, bijvoorbeeld `"22:00-06:00"`. Gelijke start- en eindtijd zijn ongeldig; laat het veld weg voor altijd actief.
+  - `active_window`: Optioneel tijdvenster `"HH:MM-HH:MM"` waarin alerts en `GET /api/health`-degradatie actief zijn. Buiten dit venster blijft `is_stale` zichtbaar in `GET /api/file-monitor/status`, maar wordt er geen alert- of herstelmail verstuurd en blijft `GET /api/health` gezond. Een eindtijd vóór de starttijd betekent dat het venster over middernacht heen loopt, bijvoorbeeld `"22:00-06:00"`. Gelijke start- en eindtijd zijn ongeldig; laat het veld weg voor altijd actief.
 
 Het controle-interval staat los van `max_age_minutes` en wordt geconfigureerd via `interval_seconds` (standaard 60 s).
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/doyensec/safeurl v0.2.2
-	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.12.3
 	golang.org/x/image v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/doyensec/safeurl v0.2.2 h1:+sFUqwOnqqmtUAC85/sGdOKfJh8zOacyghkaLzsOk4
 github.com/doyensec/safeurl v0.2.2/go.mod h1:3H0cgRpPYPSpgxRRn5yGD35Ns/LgGX/BVWSBbzUqXtY=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
-github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,7 +52,7 @@ func (s *Server) router() http.Handler {
 
 	router.Use(middleware.RequestID)
 	router.Use(middleware.Recoverer)
-	router.Use(middleware.RealIP)
+	router.Use(middleware.ClientIPFromHeader("Cf-Connecting-Ip"))
 	router.Use(middleware.Compress(5))
 
 	router.NotFound(func(w http.ResponseWriter, r *http.Request) {
@@ -146,11 +146,15 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		apiKey := r.Header.Get("X-API-Key")
 
 		if !s.isValidAPIKey(apiKey) {
+			remoteAddr := middleware.GetClientIP(r.Context())
+			if remoteAddr == "" {
+				remoteAddr = r.RemoteAddr
+			}
 			slog.Warn("Authentication failed", //nolint:gosec // G706: logged as structured slog value for security auditing
 				"reason", "invalid_api_key",
 				"path", r.URL.Path,
 				"method", r.Method,
-				"remote_addr", r.RemoteAddr)
+				"remote_addr", remoteAddr)
 
 			respondError(w, http.StatusUnauthorized, "Unauthorized: invalid or missing API key")
 			return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,7 +52,6 @@ func (s *Server) router() http.Handler {
 
 	router.Use(middleware.RequestID)
 	router.Use(middleware.Recoverer)
-	router.Use(middleware.ClientIPFromHeader("Cf-Connecting-Ip"))
 	router.Use(middleware.Compress(5))
 
 	router.NotFound(func(w http.ResponseWriter, r *http.Request) {
@@ -146,15 +145,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		apiKey := r.Header.Get("X-API-Key")
 
 		if !s.isValidAPIKey(apiKey) {
-			remoteAddr := middleware.GetClientIP(r.Context())
-			if remoteAddr == "" {
-				remoteAddr = r.RemoteAddr
-			}
-			slog.Warn("Authentication failed", //nolint:gosec // G706: logged as structured slog value for security auditing
+			//nolint:gosec // G706: structured auth-failure audit log; remote_addr is the direct peer.
+			slog.Warn("Authentication failed",
 				"reason", "invalid_api_key",
 				"path", r.URL.Path,
 				"method", r.Method,
-				"remote_addr", remoteAddr)
+				"remote_addr", r.RemoteAddr)
 
 			respondError(w, http.StatusUnauthorized, "Unauthorized: invalid or missing API key")
 			return


### PR DESCRIPTION
## Summary

- Bump `github.com/go-chi/chi/v5` from 5.2.5 to 5.3.0.
- Remove deprecated `middleware.RealIP` instead of replacing it with a trusted forwarded-header middleware.
- Keep auth-failure audit logging on `r.RemoteAddr`, so `remote_addr` is the direct TCP peer and no proxy header is treated as truth.
- Clarify API docs to name the public health endpoint as `GET /api/health`.

## Background

chi v5.3.0 deprecates `middleware.RealIP` because it can spoof `RemoteAddr` from `True-Client-IP`, `X-Real-IP`, or the leftmost `X-Forwarded-For` value.

This PR intentionally uses the smallest safe migration: no Cloudflare-specific assumption and no configurable trust model. Behind a reverse proxy, app logs show the proxy peer; rate limiting remains a proxy/load-balancer concern as documented.

## Test plan

- [x] `go test ./internal/api/...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [ ] CI green