### PR TITLE
feat: database-driven media file existence check

### DIFF
--- a/API.md
+++ b/API.md
@@ -1285,7 +1285,7 @@ De controle draait asynchroon: een `POST` start een run op de achtergrond en gee
 In de Aeron-database staan audiopaden als **Windows-paden** (bijv. `O:\Audio\85\Artist - Title.wav`), terwijl de Toolbox doorgaans op Linux draait. De controle vertaalt een referentie in deze volgorde:
 
 1. **Drive-mapping (exact pad).** Met `drive_mappings` wordt een Windows-driveletter vertaald naar een hostmap (bijv. `O:` → `/mnt/aeron-o`). De volledige mapstructuur blijft behouden en het exacte pad wordt direct gecontroleerd. Dit is de snelste en meest eenduidige strategie.
-2. **Bestandsnaam-index (fallback).** De mappen in `roots` worden recursief geïndexeerd. Lukt het exacte pad niet, dan wordt gematcht op bestandsnaam — eerst inclusief extensie, daarna extensie-onafhankelijk (een `.wav` in de database matcht dan ook een `.flac` op schijf). Wanneer er geen padreferentie is, wordt teruggevallen op metadata (`artist - title`, `title`).
+2. **Bestandsnaam-index (fallback).** De mappen in `roots` worden recursief geïndexeerd. Lukt het exacte pad niet, dan wordt gematcht op bestandsnaam — eerst inclusief extensie, daarna extensie-onafhankelijk (een `.wav` in de database matcht dan ook een `.flac` op schijf). Er wordt uitsluitend op de bestandsnaam (`audio.name`) gematcht, niet op losse `artist`/`title`-metadata.
 
 Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de bron Windows is. Voicetracks worden standaard overgeslagen (`include_voicetracks`). Er wordt **geen** vaste `.wav`-aanname gedaan.
 
@@ -1411,7 +1411,7 @@ Toont de runstatus plus het resultaat van de meest recente run.
 - `db_reference`: De referentie uit de database die gebruikt is.
 - `checked_paths`: De concrete paden en zoekacties die zijn geprobeerd.
 - `matches`: De gevonden bestanden op schijf (één bij `present`, meerdere bij `ambiguous`).
-- `match_type`: Hoe gematcht is: `exact_path`, `filename`, `filename_noext` of `metadata` (ontbreekt bij geen match).
+- `match_type`: Hoe gematcht is: `exact_path`, `filename` of `filename_noext` (ontbreekt bij geen match).
 - `error`: Foutmelding bij `stat_error` (ontbreekt verder).
 
 **Pollingrecept:** lees `run_id` uit de `POST`-response (`myRunID`), poll daarna `GET .../status` tot `completed_run_id >= myRunID && running == false`.
@@ -1437,7 +1437,7 @@ Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de **geplande** controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1402,7 +1402,7 @@ Toont de runstatus plus het resultaat van de meest recente run.
 
 **Velden in `result`:**
 - `checked_at`: Tijdstip waarop de run de items verwerkte.
-- `scope`: De toegepaste scope (`date`, `from`, `to`, `block_id`, `limit`, `exclude_voicetracks`).
+- `scope`: De toegepaste scope (`date`, `from`, `to`, `block_id`, `lookahead_days`, `limit`, `exclude_voicetracks`).
 - `summary`: Tellingen per status (`total`, `present`, `missing`, `ambiguous`, `no_reference`, `errors`).
 - `items`: Resultaat per playlistitem.
 - `error`: Aanwezig wanneer de run zelf mislukte (bijvoorbeeld een databasefout).
@@ -1420,7 +1420,7 @@ Toont de runstatus plus het resultaat van de meest recente run.
 
 ### Geplande controle en e-mailnotificaties
 
-Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema (scope: vandaag). Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
+Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` checkt de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
 
 ### Integratie met de health-endpoint (mediabestandcontrole)
 

--- a/API.md
+++ b/API.md
@@ -1284,8 +1284,10 @@ De controle draait asynchroon: een `POST` start een run op de achtergrond en gee
 
 In de Aeron-database staan audiopaden als **Windows-paden** (bijv. `O:\Audio\85\Artist - Title.wav`), terwijl de Toolbox doorgaans op Linux draait. De controle vertaalt een referentie in deze volgorde:
 
-1. **Drive-mapping (exact pad).** Met `drive_mappings` wordt een Windows-driveletter vertaald naar een hostmap (bijv. `O:` → `/mnt/aeron-o`). De volledige mapstructuur blijft behouden en het exacte pad wordt direct gecontroleerd. Dit is de snelste en meest eenduidige strategie.
-2. **Bestandsnaam-index (fallback).** De mappen in `roots` worden recursief geïndexeerd. Lukt het exacte pad niet, dan wordt gematcht op bestandsnaam — eerst inclusief extensie, daarna extensie-onafhankelijk (een `.wav` in de database matcht dan ook een `.flac` op schijf). Er wordt uitsluitend op de bestandsnaam (`audio.name`) gematcht, niet op losse `artist`/`title`-metadata.
+1. **Drive-mount (exact pad).** Met `drive_mounts` wordt een Windows-driveletter vertaald naar een hostmap (bijv. `O:` → `/mnt/aeron-o`). De volledige mapstructuur blijft behouden en het exacte pad wordt direct gecontroleerd. Dit is de snelste en meest eenduidige strategie.
+2. **Bestandsnaam-index (fallback).** De mappen in `search_dirs` worden recursief geïndexeerd. Lukt het exacte pad niet, dan wordt gematcht op bestandsnaam — eerst inclusief extensie, daarna extensie-onafhankelijk (een `.wav` in de database matcht dan ook een `.flac` op schijf). Er wordt uitsluitend op de bestandsnaam (`audio.name`) gematcht, niet op losse `artist`/`title`-metadata.
+
+> **Kort:** `drive_mounts` controleert of het bestand op de **exacte plek** uit de database staat (volledig pad, alleen de driveletter wordt vertaald); `search_dirs` controleert of een bestand met die **naam** überhaupt ergens onder de opgegeven mappen bestaat (de map uit de database wordt genegeerd).
 
 Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de bron Windows is. Voicetracks worden standaard overgeslagen (`include_voicetracks`). Er wordt **geen** vaste `.wav`-aanname gedaan.
 
@@ -1382,7 +1384,7 @@ Toont de runstatus plus het resultaat van de meest recente run.
         "db_reference": "O:\\Audio\\93\\Robin S - 1993 Luv 4 Luv.wav",
         "checked_paths": [
           "/mnt/aeron-o/Audio/93/Robin S - 1993 Luv 4 Luv.wav",
-          "roots (by name): Robin S - 1993 Luv 4 Luv.wav"
+          "search_dirs (by name): Robin S - 1993 Luv 4 Luv.wav"
         ],
         "matches": []
       }

--- a/API.md
+++ b/API.md
@@ -15,6 +15,7 @@
   - [Database onderhoud](#database-onderhoud)
   - [Backup-endpoints](#backup-endpoints)
   - [Bestandscontrole](#bestandscontrole)
+  - [Mediabestandcontrole](#mediabestandcontrole)
   - [Notificaties](#notificaties)
 - [Codevoorbeelden](#codevoorbeelden)
 - [Configuratie](#configuratie)
@@ -53,6 +54,9 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 | **Bestandscontrole** |
 | `/api/file-monitor/status` | GET | Status bestandscontrole | Ja |
 | `/api/file-monitor/check` | POST | Handmatige bestandscontrole starten | Ja |
+| **Mediabestandcontrole** |
+| `/api/media/files/check` | POST | Controle op ontbrekende audiobestanden starten | Ja |
+| `/api/media/files/check/status` | GET | Resultaat van de mediabestandcontrole | Ja |
 | **Backups** |
 | `/api/db/backup` | POST | Nieuwe backup aanmaken | Ja |
 | `/api/db/backup/status` | GET | Backup status opvragen | Ja |
@@ -1267,6 +1271,173 @@ Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/hea
 
 - `checks_stale`: ruwe telling van bestanden die te oud zijn of niet bereikbaar zijn, inclusief bestanden buiten hun `active_window`.
 - `checks_alerting`: window-aware telling; bestanden buiten hun `active_window` tellen hier niet mee. Wanneer de database verbonden is en `checks_alerting > 0`, wordt de algemene status `"degraded"` (`"unhealthy"` heeft altijd prioriteit). Een bestand dat 's nachts verouderd raakt maar alleen overdag wordt ververst, telt hier dus niet mee.
+
+---
+
+## Mediabestandcontrole
+
+Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, is de mediabestandcontrole **database-gestuurd**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks vóórdat ze in de uitzending vallen.
+
+De controle draait asynchroon: een `POST` start een run op de achtergrond en geeft direct een `run_id` terug; het resultaat lees je op met `GET .../status`.
+
+### Hoe een databasereferentie wordt gematcht
+
+In de Aeron-database staan audiopaden als **Windows-paden** (bijv. `O:\Audio\85\Artist - Title.wav`), terwijl de Toolbox doorgaans op Linux draait. De controle vertaalt een referentie in deze volgorde:
+
+1. **Drive-mapping (exact pad).** Met `drive_mappings` wordt een Windows-driveletter vertaald naar een hostmap (bijv. `O:` → `/mnt/aeron-o`). De volledige mapstructuur blijft behouden en het exacte pad wordt direct gecontroleerd. Dit is de snelste en meest eenduidige strategie.
+2. **Bestandsnaam-index (fallback).** De mappen in `roots` worden recursief geïndexeerd. Lukt het exacte pad niet, dan wordt gematcht op bestandsnaam — eerst inclusief extensie, daarna extensie-onafhankelijk (een `.wav` in de database matcht dan ook een `.flac` op schijf). Wanneer er geen padreferentie is, wordt teruggevallen op metadata (`artist - title`, `title`).
+
+Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de bron Windows is. Voicetracks worden standaard overgeslagen (`include_voicetracks`). Er wordt **geen** vaste `.wav`-aanname gedaan.
+
+**Statussen per item:**
+- `present` — er is precies één bestand gevonden.
+- `missing` — geen bestand gevonden.
+- `ambiguous` — meerdere bestanden matchen de referentie (bijv. dezelfde bestandsnaam in verschillende mappen).
+- `no_reference` — het playlistitem heeft geen bruikbare referentie (bijv. de track bestaat niet meer in de database).
+- `stat_error` — het bestand kon niet gecontroleerd worden (time-out, geen rechten, mount onbereikbaar).
+
+### Mediabestandcontrole starten
+
+Start een controle op de achtergrond voor de opgegeven scope.
+
+**Endpoint:** `POST /api/media/files/check`
+**Authenticatie:** Vereist
+
+**Queryparameters (optioneel):**
+- `date=YYYY-MM-DD` — controleer één dag. Zonder datumparameters wordt **vandaag** gecontroleerd (zoals bij `/api/playlist`).
+- `from=YYYY-MM-DD&to=YYYY-MM-DD` — controleer een datumbereik. Het bereik is begrensd tot `media_file_check.max_range_days` (standaard 31) om enorme scans te voorkomen.
+- `block_id={uuid}` — controleer één playlistblok (heeft voorrang op datumfilters).
+- `limit={n}` — beperk het aantal te controleren items.
+- `include_voicetracks=true` — neem voicetracks mee (standaard uitgesloten).
+
+**Foutresponse indien uitgeschakeld:** `404 Not Found`
+```json
+{
+  "error": "media file check is not enabled"
+}
+```
+
+**Response:** `202 Accepted`
+```json
+{
+  "message": "Media file check started",
+  "run_id": 1,
+  "check": "/api/media/files/check/status"
+}
+```
+
+**Error response:** `409 Conflict`
+```json
+{
+  "error": "media file check already running"
+}
+```
+
+**Validatiefout (bijv. ongeldige datum of te groot bereik):** `400 Bad Request`
+```json
+{
+  "error": "range: date range exceeds the maximum of 31 days"
+}
+```
+
+De handmatige trigger en de geplande cronrun delen dezelfde single-flight gate; ze kunnen elkaar dus niet overlappen.
+
+### Resultaat van de mediabestandcontrole
+
+Toont de runstatus plus het resultaat van de meest recente run.
+
+**Endpoint:** `GET /api/media/files/check/status`
+**Authenticatie:** Vereist
+
+**Response:** `200 OK`
+```json
+{
+  "running": false,
+  "run_id": 1,
+  "completed_run_id": 1,
+  "started_at": "2026-06-29T06:00:00Z",
+  "result": {
+    "checked_at": "2026-06-29T06:00:01Z",
+    "scope": {
+      "date": "2026-06-29",
+      "exclude_voicetracks": true
+    },
+    "summary": {
+      "total": 713,
+      "present": 709,
+      "missing": 2,
+      "ambiguous": 1,
+      "no_reference": 0,
+      "errors": 1
+    },
+    "items": [
+      {
+        "trackid": "af042d85-55b2-4d26-9093-d1bb7278c607",
+        "artist": "Robin S",
+        "tracktitle": "Luv 4 Luv",
+        "start_time": "2026-06-29T00:09:05",
+        "block_id": "c087211a-b4ac-47c8-af26-3aa6ef40b870",
+        "block": "",
+        "status": "missing",
+        "db_reference": "O:\\Audio\\93\\Robin S - 1993 Luv 4 Luv.wav",
+        "checked_paths": [
+          "/mnt/aeron-o/Audio/93/Robin S - 1993 Luv 4 Luv.wav",
+          "roots (by name): Robin S - 1993 Luv 4 Luv.wav"
+        ],
+        "matches": []
+      }
+    ]
+  }
+}
+```
+
+**Velden op topniveau:**
+- `running`: Of er op dit moment een run bezig is.
+- `run_id`: Monotone identifier van de huidige of meest recent gestarte run (`0` als de service nog nooit heeft gedraaid).
+- `completed_run_id`: Identifier van de run waarvan het resultaat zichtbaar is in `result`.
+- `started_at`: Starttijd van de huidige of meest recente run.
+- `result`: Het resultaat van de meest recente voltooide run (`null` tot de eerste run klaar is).
+
+**Velden in `result`:**
+- `checked_at`: Tijdstip waarop de run de items verwerkte.
+- `scope`: De toegepaste scope (`date`, `from`, `to`, `block_id`, `limit`, `exclude_voicetracks`).
+- `summary`: Tellingen per status (`total`, `present`, `missing`, `ambiguous`, `no_reference`, `errors`).
+- `items`: Resultaat per playlistitem.
+- `error`: Aanwezig wanneer de run zelf mislukte (bijvoorbeeld een databasefout).
+
+**Velden per item:**
+- `trackid`, `artist`, `tracktitle`, `start_time`, `block_id`, `block`: Playlist- en trackgegevens.
+- `status`: Een van `present`, `missing`, `ambiguous`, `no_reference`, `stat_error`.
+- `db_reference`: De referentie uit de database die gebruikt is.
+- `checked_paths`: De concrete paden en zoekacties die zijn geprobeerd.
+- `matches`: De gevonden bestanden op schijf (één bij `present`, meerdere bij `ambiguous`).
+- `match_type`: Hoe gematcht is: `exact_path`, `filename`, `filename_noext` of `metadata` (ontbreekt bij geen match).
+- `error`: Foutmelding bij `stat_error` (ontbreekt verder).
+
+**Pollingrecept:** lees `run_id` uit de `POST`-response (`myRunID`), poll daarna `GET .../status` tot `completed_run_id >= myRunID && running == false`.
+
+### Geplande controle en e-mailnotificaties
+
+Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema (scope: vandaag). Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
+
+### Integratie met de health-endpoint (mediabestandcontrole)
+
+Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
+
+```json
+{
+  "status": "degraded",
+  "version": "1.0.0",
+  "database": "aeron",
+  "database_status": "connected",
+  "media_file_check": {
+    "enabled": true,
+    "problems": 3
+  }
+}
+```
+
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de **geplande** controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 - **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
+- **Mediabestanden:** controleer database-gestuurd of de audio uit de playlist daadwerkelijk op schijf staat
 
 ## Snel starten
 
@@ -69,6 +70,7 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `maintenance` | Drempelwaarden en automatische scheduler voor database health checks |
 | `backup` | Pad naar backups, retentie, scheduler en optionele S3-sync |
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
+| `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
 

--- a/config.example.json
+++ b/config.example.json
@@ -81,6 +81,24 @@
       }
     ]
   },
+  "media_file_check": {
+    "enabled": false,
+    "roots": [
+      "/mnt/aeron-audio"
+    ],
+    "drive_mappings": {
+      "O:": "/mnt/aeron-o",
+      "Y:": "/mnt/aeron-y"
+    },
+    "stat_timeout_seconds": 5,
+    "max_range_days": 31,
+    "case_insensitive": true,
+    "include_voicetracks": false,
+    "scheduler": {
+      "enabled": false,
+      "schedule": "0 6 * * *"
+    }
+  },
   "notifications": {
     "email": {
       "tenant_id": "",

--- a/config.example.json
+++ b/config.example.json
@@ -83,13 +83,13 @@
   },
   "media_file_check": {
     "enabled": false,
-    "roots": [
-      "/mnt/aeron-audio"
-    ],
-    "drive_mappings": {
+    "drive_mounts": {
       "O:": "/mnt/aeron-o",
       "Y:": "/mnt/aeron-y"
     },
+    "search_dirs": [
+      "/mnt/aeron-audio"
+    ],
     "stat_timeout_seconds": 5,
     "max_range_days": 31,
     "case_insensitive": true,

--- a/config.example.json
+++ b/config.example.json
@@ -94,6 +94,7 @@
     "max_range_days": 31,
     "case_insensitive": true,
     "include_voicetracks": false,
+    "lookahead_days": 7,
     "scheduler": {
       "enabled": false,
       "schedule": "0 6 * * *"

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/service"
 )
 
-// BackupDeleteResponse represents the response format for backup delete operations.
+// BackupDeleteResponse is returned after a backup file is deleted.
 type BackupDeleteResponse struct {
 	Message  string `json:"message"`
 	Filename string `json:"filename"`
@@ -67,7 +67,6 @@ func (s *Server) handleDownloadBackupFile(w http.ResponseWriter, r *http.Request
 func (s *Server) handleDeleteBackup(w http.ResponseWriter, r *http.Request) {
 	filename := chi.URLParam(r, "filename")
 
-	// Require confirmation header
 	const confirmHeader = "X-Confirm-Delete"
 	if r.Header.Get(confirmHeader) != filename {
 		respondError(w, http.StatusBadRequest, "Confirmation header missing: "+confirmHeader+" must contain the filename")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -162,20 +162,23 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp.Status = overallHealthStatus(dbConnected, notifyExpiresSoon, fmAlerting, mediaProblems)
+	resp.Status = overallHealthStatus(dbConnected, notifyExpiresSoon || fmAlerting > 0 || mediaProblems > 0)
 	respondJSON(w, http.StatusOK, resp)
 }
 
-// overallHealthStatus returns the highest-severity status given component states.
-// Severity order: "unhealthy" > "degraded" > "healthy".
-func overallHealthStatus(dbConnected, notifyExpiresSoon bool, fmAlerting, mediaProblems int) string {
-	if !dbConnected {
+// overallHealthStatus returns the highest-severity status given the database
+// connectivity and whether any component reported a degraded signal. Callers OR
+// their per-component signals into degraded, so adding a component never changes
+// this signature. Severity order: "unhealthy" > "degraded" > "healthy".
+func overallHealthStatus(dbConnected, degraded bool) string {
+	switch {
+	case !dbConnected:
 		return "unhealthy"
-	}
-	if notifyExpiresSoon || fmAlerting > 0 || mediaProblems > 0 {
+	case degraded:
 		return "degraded"
+	default:
+		return "healthy"
 	}
-	return "healthy"
 }
 
 func (s *Server) handleStats(entityType types.EntityType) http.HandlerFunc {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,4 +1,4 @@
-// Package api provides the HTTP API server for the Aeron radio automation system.
+// Package api serves the Aeron Toolbox HTTP API.
 package api
 
 import (
@@ -18,20 +18,20 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
-// ImageUploadRequest represents the JSON request body for image upload operations.
+// ImageUploadRequest accepts either an image URL or base64-encoded image data.
 type ImageUploadRequest struct {
 	URL   string `json:"url"`
 	Image string `json:"image"`
 }
 
-// ImageStatsResponse represents the response format for statistics endpoints.
+// ImageStatsResponse reports image coverage for artists or tracks.
 type ImageStatsResponse struct {
 	Total         int `json:"total"`
 	WithImages    int `json:"with_images"`
 	WithoutImages int `json:"without_images"`
 }
 
-// HealthResponse represents the response for the health check endpoint.
+// HealthResponse is returned by the public health endpoint.
 type HealthResponse struct {
 	Status         string                `json:"status"`
 	Version        string                `json:"version"`
@@ -42,7 +42,7 @@ type HealthResponse struct {
 	MediaFileCheck *MediaFileCheckHealth `json:"media_file_check,omitempty"`
 }
 
-// MediaFileCheckHealth represents media file check status in the health response.
+// MediaFileCheckHealth summarizes scheduled media-file check health.
 // Problems is the number of missing, ambiguous and errored items in the most
 // recent completed run. It only drives the overall degraded status when the
 // scheduled check is enabled, so ad-hoc API runs with arbitrary scope do not
@@ -52,7 +52,7 @@ type MediaFileCheckHealth struct {
 	Problems int  `json:"problems"`
 }
 
-// FileMonitorHealth represents file monitor status in the health response.
+// FileMonitorHealth summarizes file monitor health.
 //
 // ChecksStale is the raw count from the most recent run (includes stale
 // files outside their configured ActiveWindow) and is preserved for
@@ -65,7 +65,7 @@ type FileMonitorHealth struct {
 	ChecksAlerting int  `json:"checks_alerting"`
 }
 
-// NotificationHealth represents notification system status in the health response.
+// NotificationHealth summarizes notification configuration and recent failures.
 type NotificationHealth struct {
 	Configured   bool                     `json:"configured"`
 	LastError    string                   `json:"last_error,omitempty"`
@@ -73,7 +73,7 @@ type NotificationHealth struct {
 	SecretExpiry *notify.SecretExpiryInfo `json:"secret_expiry,omitempty"`
 }
 
-// ImageUploadResponse represents the response for image upload operations.
+// ImageUploadResponse reports the stored entity label and optimization result.
 type ImageUploadResponse struct {
 	Artist               string  `json:"artist"`
 	Track                string  `json:"track,omitzero"`
@@ -82,13 +82,13 @@ type ImageUploadResponse struct {
 	SizeReductionPercent float64 `json:"savings_percent"`
 }
 
-// BulkDeleteResponse represents the response for bulk delete operations.
+// BulkDeleteResponse reports how many images were removed.
 type BulkDeleteResponse struct {
 	Deleted int64  `json:"deleted"`
 	Message string `json:"message"`
 }
 
-// ImageDeleteResponse represents the response for image delete operations.
+// ImageDeleteResponse identifies the entity whose image was removed.
 type ImageDeleteResponse struct {
 	Message  string `json:"message"`
 	ArtistID string `json:"artist_id,omitzero"`
@@ -120,7 +120,6 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		DatabaseStatus: dbStatus,
 	}
 
-	// Add notification health info.
 	emailCfg := &s.service.Config().Notifications.Email
 	configured := notify.IsConfigured(emailCfg)
 	nh := &NotificationHealth{Configured: configured}
@@ -138,7 +137,6 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 	resp.Notifications = nh
 
-	// Add file monitor health info.
 	var fmAlerting int
 	fmCfg := s.service.Config().FileMonitor
 	if fmCfg.Enabled {
@@ -151,7 +149,6 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Add media file check health info.
 	var mediaProblems int
 	mfcCfg := s.service.Config().MediaFileCheck
 	if mfcCfg.Enabled {
@@ -398,7 +395,6 @@ func parsePlaylistOptions(query url.Values) database.PlaylistOptions {
 func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
-	// Single block with items
 	if query.Get("block_id") != "" {
 		opts := parsePlaylistOptions(query)
 		playlist, err := s.service.Media.GetPlaylist(r.Context(), &opts)
@@ -414,7 +410,6 @@ func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// All blocks with tracks for a date
 	date := query.Get("date")
 	result, err := s.service.Media.GetPlaylistWithTracks(r.Context(), date)
 	if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -33,12 +33,23 @@ type ImageStatsResponse struct {
 
 // HealthResponse represents the response for the health check endpoint.
 type HealthResponse struct {
-	Status         string              `json:"status"`
-	Version        string              `json:"version"`
-	Database       string              `json:"database"`
-	DatabaseStatus string              `json:"database_status"`
-	Notifications  *NotificationHealth `json:"notifications"`
-	FileMonitor    *FileMonitorHealth  `json:"file_monitor,omitempty"`
+	Status         string                `json:"status"`
+	Version        string                `json:"version"`
+	Database       string                `json:"database"`
+	DatabaseStatus string                `json:"database_status"`
+	Notifications  *NotificationHealth   `json:"notifications"`
+	FileMonitor    *FileMonitorHealth    `json:"file_monitor,omitempty"`
+	MediaFileCheck *MediaFileCheckHealth `json:"media_file_check,omitempty"`
+}
+
+// MediaFileCheckHealth represents media file check status in the health response.
+// Problems is the number of missing, ambiguous and errored items in the most
+// recent completed run. It only drives the overall degraded status when the
+// scheduled check is enabled, so ad-hoc API runs with arbitrary scope do not
+// flip the system's health.
+type MediaFileCheckHealth struct {
+	Enabled  bool `json:"enabled"`
+	Problems int  `json:"problems"`
 }
 
 // FileMonitorHealth represents file monitor status in the health response.
@@ -140,17 +151,28 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp.Status = overallHealthStatus(dbConnected, notifyExpiresSoon, fmAlerting)
+	// Add media file check health info.
+	var mediaProblems int
+	mfcCfg := s.service.Config().MediaFileCheck
+	if mfcCfg.Enabled {
+		problems := s.service.MediaFileCheck.ProblemCount()
+		resp.MediaFileCheck = &MediaFileCheckHealth{Enabled: true, Problems: problems}
+		if mfcCfg.Scheduler.Enabled {
+			mediaProblems = problems
+		}
+	}
+
+	resp.Status = overallHealthStatus(dbConnected, notifyExpiresSoon, fmAlerting, mediaProblems)
 	respondJSON(w, http.StatusOK, resp)
 }
 
 // overallHealthStatus returns the highest-severity status given component states.
 // Severity order: "unhealthy" > "degraded" > "healthy".
-func overallHealthStatus(dbConnected, notifyExpiresSoon bool, fmAlerting int) string {
+func overallHealthStatus(dbConnected, notifyExpiresSoon bool, fmAlerting, mediaProblems int) string {
 	if !dbConnected {
 		return "unhealthy"
 	}
-	if notifyExpiresSoon || fmAlerting > 0 {
+	if notifyExpiresSoon || fmAlerting > 0 || mediaProblems > 0 {
 		return "degraded"
 	}
 	return "healthy"

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -8,30 +8,22 @@ import "testing"
 
 func TestOverallHealthStatus(t *testing.T) {
 	tests := []struct {
-		name              string
-		dbConnected       bool
-		notifyExpiresSoon bool
-		fmAlerting        int
-		mediaProblems     int
-		want              string
+		name        string
+		dbConnected bool
+		degraded    bool
+		want        string
 	}{
-		{"all healthy", true, false, 0, 0, "healthy"},
-		{"notify expiry soon", true, true, 0, 0, "degraded"},
-		{"fm alerting", true, false, 1, 0, "degraded"},
-		{"media problems", true, false, 0, 1, "degraded"},
-		{"both degraded signals", true, true, 1, 0, "degraded"},
-		{"db down", false, false, 0, 0, "unhealthy"},
-		{"db down overrides notify expiry", false, true, 0, 0, "unhealthy"},
-		{"db down overrides fm alerting", false, false, 1, 0, "unhealthy"},
-		{"db down overrides media problems", false, false, 0, 1, "unhealthy"},
-		{"db down overrides all", false, true, 1, 1, "unhealthy"},
+		{"all healthy", true, false, "healthy"},
+		{"degraded signal", true, true, "degraded"},
+		{"db down", false, false, "unhealthy"},
+		{"db down overrides degraded", false, true, "unhealthy"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := overallHealthStatus(tt.dbConnected, tt.notifyExpiresSoon, tt.fmAlerting, tt.mediaProblems)
+			got := overallHealthStatus(tt.dbConnected, tt.degraded)
 			if got != tt.want {
-				t.Errorf("overallHealthStatus(%v, %v, %d, %d) = %q, want %q",
-					tt.dbConnected, tt.notifyExpiresSoon, tt.fmAlerting, tt.mediaProblems, got, tt.want)
+				t.Errorf("overallHealthStatus(%v, %v) = %q, want %q",
+					tt.dbConnected, tt.degraded, got, tt.want)
 			}
 		})
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1,7 +1,7 @@
 package api
 
-// Note: handleHealth itself is not unit-tested here because it requires a live
-// database for the Repository().Ping() call; it is smoke-tested by CI.
+// handleHealth itself is not unit-tested here because it requires a live
+// database for Repository().Ping(); it is smoke-tested by CI.
 // The status precedence logic is extracted into overallHealthStatus and tested below.
 
 import "testing"

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -12,23 +12,26 @@ func TestOverallHealthStatus(t *testing.T) {
 		dbConnected       bool
 		notifyExpiresSoon bool
 		fmAlerting        int
+		mediaProblems     int
 		want              string
 	}{
-		{"all healthy", true, false, 0, "healthy"},
-		{"notify expiry soon", true, true, 0, "degraded"},
-		{"fm alerting", true, false, 1, "degraded"},
-		{"both degraded signals", true, true, 1, "degraded"},
-		{"db down", false, false, 0, "unhealthy"},
-		{"db down overrides notify expiry", false, true, 0, "unhealthy"},
-		{"db down overrides fm alerting", false, false, 1, "unhealthy"},
-		{"db down overrides both", false, true, 1, "unhealthy"},
+		{"all healthy", true, false, 0, 0, "healthy"},
+		{"notify expiry soon", true, true, 0, 0, "degraded"},
+		{"fm alerting", true, false, 1, 0, "degraded"},
+		{"media problems", true, false, 0, 1, "degraded"},
+		{"both degraded signals", true, true, 1, 0, "degraded"},
+		{"db down", false, false, 0, 0, "unhealthy"},
+		{"db down overrides notify expiry", false, true, 0, 0, "unhealthy"},
+		{"db down overrides fm alerting", false, false, 1, 0, "unhealthy"},
+		{"db down overrides media problems", false, false, 0, 1, "unhealthy"},
+		{"db down overrides all", false, true, 1, 1, "unhealthy"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := overallHealthStatus(tt.dbConnected, tt.notifyExpiresSoon, tt.fmAlerting)
+			got := overallHealthStatus(tt.dbConnected, tt.notifyExpiresSoon, tt.fmAlerting, tt.mediaProblems)
 			if got != tt.want {
-				t.Errorf("overallHealthStatus(%v, %v, %d) = %q, want %q",
-					tt.dbConnected, tt.notifyExpiresSoon, tt.fmAlerting, got, tt.want)
+				t.Errorf("overallHealthStatus(%v, %v, %d, %d) = %q, want %q",
+					tt.dbConnected, tt.notifyExpiresSoon, tt.fmAlerting, tt.mediaProblems, got, tt.want)
 			}
 		})
 	}

--- a/internal/api/mediacheck.go
+++ b/internal/api/mediacheck.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/database"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
+)
+
+// MediaCheckStartResponse is returned by POST /media/files/check. RunID is the
+// monotonic ID of the run just started; clients poll /status until
+// completed_run_id >= RunID && running == false.
+type MediaCheckStartResponse struct {
+	Message string `json:"message"`
+	RunID   uint64 `json:"run_id"`
+	Check   string `json:"check"`
+}
+
+// dateParam is the accepted date format for media file check scope parameters.
+const dateParam = "2006-01-02"
+
+func (s *Server) handleMediaFileCheck(w http.ResponseWriter, r *http.Request) {
+	opts, err := parseMediaCheckOptions(r.URL.Query(), s.service.Config().MediaFileCheck.GetMaxRangeDays())
+	if err != nil {
+		respondError(w, errorCode(err), err.Error())
+		return
+	}
+
+	runID, err := s.service.MediaFileCheck.TriggerCheck(opts)
+	if err != nil {
+		respondError(w, errorCode(err), err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusAccepted, MediaCheckStartResponse{
+		Message: "Media file check started",
+		RunID:   runID,
+		Check:   "/api/media/files/check/status",
+	})
+}
+
+func (s *Server) handleMediaFileCheckStatus(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, s.service.MediaFileCheck.Status())
+}
+
+// parseMediaCheckOptions validates the scope query parameters and builds the
+// repository options. It enforces the configured maximum from/to range.
+func parseMediaCheckOptions(query url.Values, maxRangeDays int) (*database.MediaCheckOptions, error) {
+	opts := &database.MediaCheckOptions{
+		BlockID: query.Get("block_id"),
+		Date:    query.Get("date"),
+		From:    query.Get("from"),
+		To:      query.Get("to"),
+	}
+
+	if opts.BlockID != "" && !util.GUIDPattern.MatchString(opts.BlockID) {
+		return nil, types.NewValidationError("block_id", "must be a valid UUID")
+	}
+
+	for field, value := range map[string]string{"date": opts.Date, "from": opts.From, "to": opts.To} {
+		if value == "" {
+			continue
+		}
+		if _, err := time.Parse(dateParam, value); err != nil {
+			return nil, types.NewValidationError(field, "must be a valid date (YYYY-MM-DD)")
+		}
+	}
+
+	if err := validateDateRange(opts.From, opts.To, maxRangeDays); err != nil {
+		return nil, err
+	}
+
+	if limit := query.Get("limit"); limit != "" {
+		l, err := strconv.Atoi(limit)
+		if err != nil || l < 0 {
+			return nil, types.NewValidationError("limit", "must be a non-negative integer")
+		}
+		opts.Limit = l
+	}
+
+	if query.Get("include_voicetracks") == "true" {
+		opts.IncludeVoicetracks = true
+	}
+
+	return opts, nil
+}
+
+// validateDateRange enforces from <= to and a maximum span, when both bounds are
+// given. A single bound is left to the database (open-ended on one side).
+func validateDateRange(from, to string, maxRangeDays int) error {
+	if from == "" || to == "" {
+		return nil
+	}
+	fromDate, err := time.Parse(dateParam, from)
+	if err != nil {
+		return types.NewValidationError("from", "must be a valid date (YYYY-MM-DD)")
+	}
+	toDate, err := time.Parse(dateParam, to)
+	if err != nil {
+		return types.NewValidationError("to", "must be a valid date (YYYY-MM-DD)")
+	}
+	if toDate.Before(fromDate) {
+		return types.NewValidationError("to", "must not be before 'from'")
+	}
+	if maxRangeDays > 0 {
+		// Inclusive day span: a single day is span 1.
+		days := int(toDate.Sub(fromDate).Hours()/24) + 1
+		if days > maxRangeDays {
+			return types.NewValidationError("range",
+				"date range exceeds the maximum of "+strconv.Itoa(maxRangeDays)+" days")
+		}
+	}
+	return nil
+}

--- a/internal/api/mediacheck_test.go
+++ b/internal/api/mediacheck_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"net/url"
+	"testing"
+)
+
+func mustValues(t *testing.T, raw string) url.Values {
+	t.Helper()
+	v, err := url.ParseQuery(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func TestParseMediaCheckOptions_Defaults(t *testing.T) {
+	opts, err := parseMediaCheckOptions(url.Values{}, 31)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Date != "" || opts.From != "" || opts.To != "" || opts.BlockID != "" {
+		t.Errorf("expected empty scope, got %+v", opts)
+	}
+	if opts.IncludeVoicetracks {
+		t.Error("voicetracks should be excluded by default")
+	}
+}
+
+func TestParseMediaCheckOptions_ValidDate(t *testing.T) {
+	opts, err := parseMediaCheckOptions(mustValues(t, "date=2026-06-29"), 31)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Date != "2026-06-29" {
+		t.Errorf("date = %q", opts.Date)
+	}
+}
+
+func TestParseMediaCheckOptions_InvalidDate(t *testing.T) {
+	if _, err := parseMediaCheckOptions(mustValues(t, "date=29-06-2026"), 31); err == nil {
+		t.Fatal("expected error for malformed date")
+	}
+}
+
+func TestParseMediaCheckOptions_InvalidBlockID(t *testing.T) {
+	if _, err := parseMediaCheckOptions(mustValues(t, "block_id=not-a-uuid"), 31); err == nil {
+		t.Fatal("expected error for malformed block_id")
+	}
+}
+
+func TestParseMediaCheckOptions_ValidBlockID(t *testing.T) {
+	id := "add55a6e-2068-4114-b82a-e0729881f0be"
+	opts, err := parseMediaCheckOptions(mustValues(t, "block_id="+id), 31)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.BlockID != id {
+		t.Errorf("block_id = %q", opts.BlockID)
+	}
+}
+
+func TestParseMediaCheckOptions_IncludeVoicetracks(t *testing.T) {
+	opts, err := parseMediaCheckOptions(mustValues(t, "include_voicetracks=true"), 31)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opts.IncludeVoicetracks {
+		t.Error("expected voicetracks included")
+	}
+}
+
+func TestParseMediaCheckOptions_NegativeLimit(t *testing.T) {
+	if _, err := parseMediaCheckOptions(mustValues(t, "limit=-5"), 31); err == nil {
+		t.Fatal("expected error for negative limit")
+	}
+}
+
+func TestValidateDateRange(t *testing.T) {
+	if err := validateDateRange("2026-06-01", "2026-06-07", 31); err != nil {
+		t.Errorf("valid range rejected: %v", err)
+	}
+	if err := validateDateRange("2026-06-07", "2026-06-01", 31); err == nil {
+		t.Error("expected error when to < from")
+	}
+	if err := validateDateRange("2026-01-01", "2026-12-31", 31); err == nil {
+		t.Error("expected error when range exceeds cap")
+	}
+	// Inclusive span: exactly maxRangeDays is allowed.
+	if err := validateDateRange("2026-06-01", "2026-06-30", 30); err != nil {
+		t.Errorf("30-day inclusive range with cap 30 rejected: %v", err)
+	}
+	// Single bound is allowed (open-ended).
+	if err := validateDateRange("2026-06-01", "", 31); err != nil {
+		t.Errorf("single bound rejected: %v", err)
+	}
+}

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -9,14 +9,14 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// Response is the standard response format for all API endpoints.
+// Response wraps every API payload with a success flag and optional error.
 type Response struct {
 	Success bool   `json:"success"`
 	Data    any    `json:"data,omitempty"`
 	Error   string `json:"error,omitempty"`
 }
 
-// AsyncStartResponse is the response for async operations (backup).
+// AsyncStartResponse points clients to the status endpoint for async work.
 type AsyncStartResponse struct {
 	Message string `json:"message"`
 	Check   string `json:"check"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,14 +13,14 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// Server represents the HTTP API server for the Aeron radio automation system.
+// Server owns the HTTP routing, middleware, and listener lifecycle.
 type Server struct {
 	service *service.AeronService
 	version string
 	server  *http.Server
 }
 
-// New creates a new Server instance.
+// New returns a Server bound to the service layer and build version.
 func New(svc *service.AeronService, version string) *Server {
 	return &Server{
 		service: svc,
@@ -28,7 +28,7 @@ func New(svc *service.AeronService, version string) *Server {
 	}
 }
 
-// Start initializes and starts the HTTP server on the specified port.
+// Start serves the API on port until shutdown or listener failure.
 func (s *Server) Start(port string) error {
 	router := s.router()
 
@@ -41,7 +41,7 @@ func (s *Server) Start(port string) error {
 	return s.server.ListenAndServe()
 }
 
-// router builds the HTTP handler tree.
+// router builds the public health route and authenticated API surface.
 func (s *Server) router() http.Handler {
 	router := chi.NewRouter()
 
@@ -68,7 +68,6 @@ func (s *Server) router() http.Handler {
 
 		r.Get("/health", s.handleHealth)
 
-		// Authenticated routes with standard request timeout
 		r.Group(func(r chi.Router) {
 			r.Use(s.authMiddleware)
 			r.Use(middleware.Timeout(s.service.Config().API.GetRequestTimeout()))
@@ -79,12 +78,10 @@ func (s *Server) router() http.Handler {
 			r.Get("/playlist", s.handlePlaylist)
 
 			r.Route("/db", func(r chi.Router) {
-				// Maintenance endpoints
 				r.Route("/maintenance", func(r chi.Router) {
 					r.Get("/health", s.handleDatabaseHealth)
 				})
 
-				// Backup endpoints (guarded: 404 when backup is disabled)
 				r.Group(func(r chi.Router) {
 					r.Use(s.requireBackupEnabled)
 					r.Post("/backup", s.handleCreateBackup)
@@ -96,14 +93,12 @@ func (s *Server) router() http.Handler {
 				})
 			})
 
-			// File monitor endpoints (guarded: 404 when file monitor is disabled)
 			r.Group(func(r chi.Router) {
 				r.Use(s.requireFileMonitorEnabled)
 				r.Get("/file-monitor/status", s.handleFileMonitorStatus)
 				r.Post("/file-monitor/check", s.handleFileMonitorCheck)
 			})
 
-			// Media file check endpoints (guarded: 404 when disabled)
 			r.Group(func(r chi.Router) {
 				r.Use(s.requireMediaFileCheckEnabled)
 				r.Post("/media/files/check", s.handleMediaFileCheck)
@@ -117,7 +112,7 @@ func (s *Server) router() http.Handler {
 	return router
 }
 
-// Shutdown gracefully shuts down the server.
+// Shutdown gracefully stops the active HTTP server. It is a no-op before Start.
 func (s *Server) Shutdown(ctx context.Context) error {
 	if s.server == nil {
 		return nil

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -103,6 +103,13 @@ func (s *Server) router() http.Handler {
 				r.Post("/file-monitor/check", s.handleFileMonitorCheck)
 			})
 
+			// Media file check endpoints (guarded: 404 when disabled)
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireMediaFileCheckEnabled)
+				r.Post("/media/files/check", s.handleMediaFileCheck)
+				r.Get("/media/files/check/status", s.handleMediaFileCheckStatus)
+			})
+
 			r.Post("/notifications/test-email", s.handleTestEmail)
 		})
 	})
@@ -174,6 +181,16 @@ func (s *Server) requireFileMonitorEnabled(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !s.service.Config().FileMonitor.Enabled {
 			respondError(w, http.StatusNotFound, "file monitor is not enabled")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) requireMediaFileCheckEnabled(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.service.Config().MediaFileCheck.Enabled {
+			respondError(w, http.StatusNotFound, "media file check is not enabled")
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/async/runner.go
+++ b/internal/async/runner.go
@@ -1,4 +1,4 @@
-// Package async provides utilities for managing async operations with graceful shutdown.
+// Package async implements single-flight background runners with shutdown tracking.
 package async
 
 import (
@@ -8,9 +8,7 @@ import (
 	"time"
 )
 
-// Runner manages a single async operation with graceful shutdown support.
-// It ensures only one operation runs at a time and provides context integration
-// for timeout and shutdown signaling.
+// Runner gates one primary async operation and tracks related goroutines.
 //
 // There are two patterns for background goroutines, with different shutdown semantics:
 //
@@ -44,17 +42,17 @@ type Runner struct {
 	closed  bool
 }
 
-// New creates a new Runner.
+// New returns an idle Runner.
 func New() *Runner {
 	return &Runner{
 		done: make(chan struct{}),
 	}
 }
 
-// Close signals shutdown and waits for any running operations to complete.
+// Close signals shutdown and waits for tracked work to finish.
 // After Close returns, all subsequent TryStart() and TryGoBackground() calls
-// will return false. The context returned by Context() will be cancelled.
-// Safe to call more than once; the done channel is closed exactly once.
+// return false. Contexts returned by Context() are cancelled.
+// Close is safe to call repeatedly.
 func (r *Runner) Close() {
 	r.closeOnce.Do(func() {
 		r.closeMu.Lock()
@@ -65,7 +63,7 @@ func (r *Runner) Close() {
 	r.wg.Wait()
 }
 
-// IsRunning returns true if an operation is currently running.
+// IsRunning reports whether the primary operation is active.
 func (r *Runner) IsRunning() bool {
 	return r.running.Load()
 }
@@ -84,7 +82,7 @@ func (r *Runner) tryReserve() bool {
 	return true
 }
 
-// TryStart attempts to start a new operation.
+// TryStart reserves the single primary-operation slot.
 // Returns false if an operation is already running or Close() has been called.
 // On success it reserves a WaitGroup slot before returning, so a concurrent
 // Close() calling wg.Wait() will block until the paired Go() or Done() call
@@ -100,17 +98,13 @@ func (r *Runner) TryStart() bool {
 	return true
 }
 
-// Done marks the current operation as complete and releases the WaitGroup
-// slot reserved by TryStart(). Use this for synchronous operations that
-// don't use Go().
+// Done releases the TryStart slot for synchronous operations that do not call Go.
 func (r *Runner) Done() {
 	r.running.Store(false)
 	r.wg.Done()
 }
 
-// Context returns a context that is cancelled when either:
-// - The timeout expires
-// - Close() is called (shutdown requested)
+// Context returns a context cancelled by timeout or Runner shutdown.
 //
 // The caller must call the returned cancel function when done.
 // The internal goroutine is tracked by the Runner's WaitGroup to ensure
@@ -130,7 +124,7 @@ func (r *Runner) Context(timeout time.Duration) (context.Context, context.Cancel
 	return ctx, cancel
 }
 
-// Go starts the primary operation in a goroutine.
+// Go runs the reserved primary operation in a goroutine.
 // The running flag is automatically cleared when fn returns.
 // Must be called after a successful TryStart(); it consumes the WaitGroup
 // slot reserved by TryStart().
@@ -156,10 +150,8 @@ func (r *Runner) GoChild(fn func()) {
 	r.wg.Go(fn)
 }
 
-// TryGoBackground starts a background goroutine as an independent dispatch -
-// that is, from outside any currently active Go() or Done() body.
-// Returns false and does nothing if Close() has already been called, allowing
-// callers to log the drop explicitly.
+// TryGoBackground starts independent background work outside a primary run.
+// It returns false without spawning if Close() has already started.
 func (r *Runner) TryGoBackground(fn func()) bool {
 	if !r.tryReserve() {
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,7 +184,12 @@ type MediaFileCheckConfig struct {
 	MaxRangeDays       int               `json:"max_range_days" validate:"gte=0"`
 	CaseInsensitive    *bool             `json:"case_insensitive"`
 	IncludeVoicetracks bool              `json:"include_voicetracks"`
-	Scheduler          SchedulerConfig   `json:"scheduler"`
+	// LookaheadDays extends the scheduled run beyond today: it checks today
+	// through today+LookaheadDays (inclusive), so missing files surface before
+	// they air. 0 (default) checks only today. Manual API runs use their own
+	// from/to range and ignore this.
+	LookaheadDays int             `json:"lookahead_days" validate:"gte=0"`
+	Scheduler     SchedulerConfig `json:"scheduler"`
 }
 
 // DefaultMediaFileCheckStatTimeoutSeconds is the default per-stat timeout for media file checks.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,18 +168,18 @@ func (c *FileMonitorConfig) Interval() time.Duration {
 // while this service typically runs on Linux. Two complementary strategies map a
 // database reference to a real file:
 //
-//   - DriveMappings translates a Windows drive prefix to a host directory
+//   - DriveMounts translates a Windows drive prefix to a host directory
 //     (e.g. "O:" -> "/mnt/aeron-o"), preserving the directory structure so an
 //     exact path can be stat'd. This is the fast, unambiguous primary strategy.
-//   - Roots are directories indexed recursively; a reference is then matched by
-//     filename (with and, as a fallback, without extension). This is the
+//   - SearchDirs are directories indexed recursively; a reference is then matched
+//     by filename (with and, as a fallback, without extension). This is the
 //     fallback for files whose exact path moved or that are mounted flat.
 //
-// At least one of DriveMappings or Roots must be configured when Enabled.
+// At least one of DriveMounts or SearchDirs must be configured when Enabled.
 type MediaFileCheckConfig struct {
 	Enabled            bool              `json:"enabled"`
-	Roots              []string          `json:"roots"`
-	DriveMappings      map[string]string `json:"drive_mappings"`
+	SearchDirs         []string          `json:"search_dirs"`
+	DriveMounts        map[string]string `json:"drive_mounts"`
 	StatTimeoutSec     int               `json:"stat_timeout_seconds" validate:"gte=0"`
 	MaxRangeDays       int               `json:"max_range_days" validate:"gte=0"`
 	CaseInsensitive    *bool             `json:"case_insensitive"`
@@ -506,7 +506,7 @@ var driveLetterPattern = regexp.MustCompile(`^([A-Za-z]):\\?$`)
 
 // validateMediaFileCheckConfig checks that, when the media file check is
 // enabled, at least one resolution source is configured and that every path is
-// absolute. Drive-mapping keys must be Windows drive prefixes ("O:") and their
+// absolute. Drive-mount keys must be Windows drive prefixes ("O:") and their
 // targets absolute host directories. The checks only run when enabled so a
 // disabled, half-filled block does not block startup.
 func validateMediaFileCheckConfig(sl validator.StructLevel) {
@@ -515,25 +515,25 @@ func validateMediaFileCheckConfig(sl validator.StructLevel) {
 		return
 	}
 
-	if len(mfc.Roots) == 0 && len(mfc.DriveMappings) == 0 {
-		sl.ReportError(mfc.Roots, "roots", "Roots", "media_check_no_source", "")
+	if len(mfc.SearchDirs) == 0 && len(mfc.DriveMounts) == 0 {
+		sl.ReportError(mfc.SearchDirs, "search_dirs", "SearchDirs", "media_check_no_source", "")
 	}
 
-	for i, root := range mfc.Roots {
-		if !filepath.IsAbs(root) {
-			fieldName := fmt.Sprintf("roots[%d]", i)
-			structFieldName := fmt.Sprintf("Roots[%d]", i)
-			sl.ReportError(mfc.Roots[i], fieldName, structFieldName, "absolute_path", "")
+	for i, dir := range mfc.SearchDirs {
+		if !filepath.IsAbs(dir) {
+			fieldName := fmt.Sprintf("search_dirs[%d]", i)
+			structFieldName := fmt.Sprintf("SearchDirs[%d]", i)
+			sl.ReportError(mfc.SearchDirs[i], fieldName, structFieldName, "absolute_path", "")
 		}
 	}
 
-	for drive, target := range mfc.DriveMappings {
+	for drive, target := range mfc.DriveMounts {
 		if !driveLetterPattern.MatchString(drive) {
-			sl.ReportError(target, "drive_mappings", "DriveMappings", "media_check_drive_key", drive)
+			sl.ReportError(target, "drive_mounts", "DriveMounts", "media_check_drive_key", drive)
 			continue
 		}
 		if !filepath.IsAbs(target) {
-			sl.ReportError(target, "drive_mappings", "DriveMappings", "media_check_drive_target", drive)
+			sl.ReportError(target, "drive_mounts", "DriveMounts", "media_check_drive_target", drive)
 		}
 	}
 }
@@ -574,7 +574,7 @@ func tagMessage(tag, param string) string {
 	case "required_when_enabled":
 		return "must have at least one entry when enabled"
 	case "media_check_no_source":
-		return "requires at least one root or drive mapping when enabled"
+		return "requires at least one search dir or drive mount when enabled"
 	case "media_check_drive_key":
 		return fmt.Sprintf("has an invalid drive key %q (expected e.g. \"O:\")", param)
 	case "media_check_drive_target":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Package config provides application configuration management.
+// Package config loads, defaults, and validates JSON configuration for the API server.
 package config
 
 import (
@@ -19,7 +19,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
-// DatabaseConfig contains PostgreSQL database connection parameters.
+// DatabaseConfig holds PostgreSQL connection settings.
 type DatabaseConfig struct {
 	Host                   string `json:"host" validate:"required"`
 	Port                   string `json:"port" validate:"required"`
@@ -33,7 +33,7 @@ type DatabaseConfig struct {
 	ConnMaxLifetimeMinutes int    `json:"conn_max_lifetime_minutes" validate:"gte=0"`
 }
 
-// ImageConfig contains image processing and optimization settings.
+// ImageConfig controls image validation and optimization.
 type ImageConfig struct {
 	TargetWidth               int   `json:"target_width" validate:"required,gt=0"`
 	TargetHeight              int   `json:"target_height" validate:"required,gt=0"`
@@ -42,14 +42,14 @@ type ImageConfig struct {
 	MaxImageDownloadSizeBytes int64 `json:"max_image_download_size_bytes" validate:"gte=0"`
 }
 
-// APIConfig contains API authentication and server settings.
+// APIConfig controls API authentication and request timeouts.
 type APIConfig struct {
 	Enabled               bool     `json:"enabled"`
 	Keys                  []string `json:"keys" validate:"required_if=Enabled true,dive,required"`
 	RequestTimeoutSeconds int      `json:"request_timeout_seconds" validate:"gte=0"`
 }
 
-// MaintenanceConfig contains thresholds and settings for database health monitoring.
+// MaintenanceConfig holds thresholds used by database health checks.
 type MaintenanceConfig struct {
 	BloatThreshold              float64         `json:"bloat_threshold" validate:"gte=0,lte=100"`
 	DeadTupleThreshold          int64           `json:"dead_tuple_threshold" validate:"gte=0"`
@@ -63,13 +63,13 @@ type MaintenanceConfig struct {
 	Scheduler                   SchedulerConfig `json:"scheduler"`
 }
 
-// SchedulerConfig contains settings for individual scheduled operations.
+// SchedulerConfig controls a single cron-backed operation.
 type SchedulerConfig struct {
 	Enabled  bool   `json:"enabled"`
 	Schedule string `json:"schedule" validate:"required_if=Enabled true"`
 }
 
-// S3Config contains settings for S3-compatible storage synchronization.
+// S3Config configures optional S3-compatible backup synchronization.
 type S3Config struct {
 	Enabled         bool   `json:"enabled"`
 	Bucket          string `json:"bucket" validate:"required_if=Enabled true"`
@@ -81,7 +81,7 @@ type S3Config struct {
 	ForcePathStyle  bool   `json:"force_path_style"`
 }
 
-// BackupConfig contains settings for database backup functionality.
+// BackupConfig configures local and optional remote database backups.
 type BackupConfig struct {
 	Enabled            bool            `json:"enabled"`
 	Path               string          `json:"path" validate:"required_if=Enabled true"`
@@ -95,21 +95,21 @@ type BackupConfig struct {
 	S3                 S3Config        `json:"s3"`
 }
 
-// NotificationsConfig contains notification settings.
+// NotificationsConfig groups all notification providers.
 type NotificationsConfig struct {
 	Email GraphConfig `json:"email"`
 }
 
-// GraphConfig contains Microsoft Graph API settings for email notifications.
+// GraphConfig configures Microsoft Graph email delivery.
 type GraphConfig struct {
 	TenantID     string `json:"tenant_id" validate:"omitempty,guid"`
 	ClientID     string `json:"client_id" validate:"omitempty,guid"`
-	ClientSecret string `json:"client_secret"` //nolint:gosec // Configuration field, not a credential
+	ClientSecret string `json:"client_secret"` //nolint:gosec // G101: user-supplied config secret, not a hardcoded credential
 	FromAddress  string `json:"from_address"`
 	Recipients   string `json:"recipients"`
 }
 
-// FileMonitorConfig contains settings for monitoring file freshness on disk.
+// FileMonitorConfig configures freshness checks for files on disk.
 type FileMonitorConfig struct {
 	Enabled         bool                     `json:"enabled"`
 	IntervalSeconds int                      `json:"interval_seconds" validate:"gte=0"`
@@ -129,7 +129,7 @@ type FileMonitorCheckConfig struct {
 	ActiveWindow   string `json:"active_window"`
 }
 
-// DisplayName returns the check name if set, otherwise the file path.
+// DisplayName returns the configured label, falling back to the file path.
 func (c *FileMonitorCheckConfig) DisplayName() string {
 	if c.Name != "" {
 		return c.Name
@@ -161,8 +161,7 @@ func (c *FileMonitorConfig) Interval() time.Duration {
 	return time.Duration(c.IntervalSeconds) * time.Second
 }
 
-// MediaFileCheckConfig contains settings for verifying that audio files
-// referenced by the playlist actually exist on disk.
+// MediaFileCheckConfig configures playlist audio verification against disk files.
 //
 // The Aeron database stores Windows paths (e.g. O:\Audio\85\Artist - Title.wav)
 // while this service typically runs on Linux. Two complementary strategies map a
@@ -184,10 +183,8 @@ type MediaFileCheckConfig struct {
 	MaxRangeDays       int               `json:"max_range_days" validate:"gte=0"`
 	CaseInsensitive    *bool             `json:"case_insensitive"`
 	IncludeVoicetracks bool              `json:"include_voicetracks"`
-	// LookaheadDays extends the scheduled run beyond today: it checks today
-	// through today+LookaheadDays (inclusive), so missing files surface before
-	// they air. 0 (default) checks only today. Manual API runs use their own
-	// from/to range and ignore this.
+	// LookaheadDays extends scheduled runs from today through today+N
+	// inclusive. A zero value checks only today; manual API runs ignore this.
 	LookaheadDays int             `json:"lookahead_days" validate:"gte=0"`
 	Scheduler     SchedulerConfig `json:"scheduler"`
 }
@@ -207,7 +204,7 @@ func (c *MediaFileCheckConfig) StatTimeout() time.Duration {
 	return time.Duration(c.StatTimeoutSec) * time.Second
 }
 
-// GetMaxRangeDays returns the maximum allowed from/to span in days.
+// GetMaxRangeDays returns the configured from/to span cap or its default.
 func (c *MediaFileCheckConfig) GetMaxRangeDays() int {
 	return cmp.Or(c.MaxRangeDays, DefaultMediaFileCheckMaxRangeDays)
 }
@@ -221,13 +218,13 @@ func (c *MediaFileCheckConfig) IsCaseInsensitive() bool {
 	return *c.CaseInsensitive
 }
 
-// LogConfig contains logging configuration.
+// LogConfig configures global structured logging.
 type LogConfig struct {
 	Level  string `json:"level" validate:"omitempty,oneof=debug info warn error"`
 	Format string `json:"format" validate:"omitempty,oneof=text json"`
 }
 
-// Config represents the complete application configuration.
+// Config is the fully loaded application configuration.
 type Config struct {
 	Database       DatabaseConfig       `json:"database"`
 	Image          ImageConfig          `json:"image"`
@@ -262,27 +259,27 @@ const (
 	DefaultBackupTimeoutMinutes        = 30
 )
 
-// GetMaxDownloadBytes returns the maximum allowed image download size in bytes.
+// GetMaxDownloadBytes returns the configured image download cap or its default.
 func (c *ImageConfig) GetMaxDownloadBytes() int64 {
 	return cmp.Or(c.MaxImageDownloadSizeBytes, DefaultMaxImageDownloadSizeBytes)
 }
 
-// GetRequestTimeout returns the HTTP request timeout as a Duration.
+// GetRequestTimeout returns the configured HTTP timeout or its default.
 func (c *APIConfig) GetRequestTimeout() time.Duration {
 	return time.Duration(cmp.Or(c.RequestTimeoutSeconds, DefaultRequestTimeoutSeconds)) * time.Second
 }
 
-// GetMaxOpenConns returns the maximum number of open database connections.
+// GetMaxOpenConns returns the configured open-connection cap or its default.
 func (c *DatabaseConfig) GetMaxOpenConns() int {
 	return cmp.Or(c.MaxOpenConns, DefaultMaxOpenConnections)
 }
 
-// GetMaxIdleConns returns the maximum number of idle database connections.
+// GetMaxIdleConns returns the configured idle-connection cap or its default.
 func (c *DatabaseConfig) GetMaxIdleConns() int {
 	return cmp.Or(c.MaxIdleConns, DefaultMaxIdleConnections)
 }
 
-// GetConnMaxLifetime returns the maximum lifetime of database connections as a Duration.
+// GetConnMaxLifetime returns the configured connection lifetime or its default.
 func (c *DatabaseConfig) GetConnMaxLifetime() time.Duration {
 	return time.Duration(cmp.Or(c.ConnMaxLifetimeMinutes, DefaultConnMaxLifetimeMinutes)) * time.Minute
 }
@@ -337,32 +334,32 @@ func (c *MaintenanceConfig) GetLongQueryThresholdSeconds() int {
 	return cmp.Or(c.LongQueryThresholdSeconds, DefaultLongQueryThresholdSeconds)
 }
 
-// GetPath returns the directory path where backup files are stored.
+// GetPath returns the backup directory or its default.
 func (c *BackupConfig) GetPath() string {
 	return cmp.Or(c.Path, DefaultBackupPath)
 }
 
-// GetRetentionDays returns the number of days to keep backup files before automatic deletion.
+// GetRetentionDays returns the backup age limit or its default.
 func (c *BackupConfig) GetRetentionDays() int {
 	return cmp.Or(c.RetentionDays, DefaultBackupRetentionDays)
 }
 
-// GetMaxBackups returns the maximum number of backup files to retain.
+// GetMaxBackups returns the backup count limit or its default.
 func (c *BackupConfig) GetMaxBackups() int {
 	return cmp.Or(c.MaxBackups, DefaultBackupMaxBackups)
 }
 
-// GetDefaultCompression returns the compression level (0-9) for backups.
+// GetDefaultCompression returns the backup compression level, capped at 9.
 func (c *BackupConfig) GetDefaultCompression() int {
 	return min(cmp.Or(c.DefaultCompression, DefaultBackupCompression), 9)
 }
 
-// GetTimeout returns the maximum duration for backup operations.
+// GetTimeout returns the backup timeout or its default.
 func (c *BackupConfig) GetTimeout() time.Duration {
 	return time.Duration(cmp.Or(c.TimeoutMinutes, DefaultBackupTimeoutMinutes)) * time.Minute
 }
 
-// GetPathPrefix returns the S3 path prefix for constructing object keys.
+// GetPathPrefix returns the S3 object prefix with a trailing slash when set.
 func (c *S3Config) GetPathPrefix() string {
 	prefix := c.PathPrefix
 	if prefix != "" && !strings.HasSuffix(prefix, "/") {
@@ -393,7 +390,7 @@ func (c *LogConfig) GetFormat() string {
 	return "text"
 }
 
-// Load loads and validates application configuration from a JSON file.
+// Load reads JSON configuration, applies environment overrides, and validates it.
 func Load(configPath string) (*Config, error) {
 	config := &Config{}
 
@@ -560,7 +557,7 @@ func formatErrors(err error) error {
 
 	var msgs []string
 	for _, e := range ve {
-		field := strings.ToLower(e.Namespace()[7:]) // Strip "Config." prefix
+		field := strings.ToLower(e.Namespace()[7:]) // strip "Config." prefix
 		msgs = append(msgs, fmt.Sprintf("%s %s", field, tagMessage(e.Tag(), e.Param())))
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -160,6 +161,61 @@ func (c *FileMonitorConfig) Interval() time.Duration {
 	return time.Duration(c.IntervalSeconds) * time.Second
 }
 
+// MediaFileCheckConfig contains settings for verifying that audio files
+// referenced by the playlist actually exist on disk.
+//
+// The Aeron database stores Windows paths (e.g. O:\Audio\85\Artist - Title.wav)
+// while this service typically runs on Linux. Two complementary strategies map a
+// database reference to a real file:
+//
+//   - DriveMappings translates a Windows drive prefix to a host directory
+//     (e.g. "O:" -> "/mnt/aeron-o"), preserving the directory structure so an
+//     exact path can be stat'd. This is the fast, unambiguous primary strategy.
+//   - Roots are directories indexed recursively; a reference is then matched by
+//     filename (with and, as a fallback, without extension). This is the
+//     fallback for files whose exact path moved or that are mounted flat.
+//
+// At least one of DriveMappings or Roots must be configured when Enabled.
+type MediaFileCheckConfig struct {
+	Enabled            bool              `json:"enabled"`
+	Roots              []string          `json:"roots"`
+	DriveMappings      map[string]string `json:"drive_mappings"`
+	StatTimeoutSec     int               `json:"stat_timeout_seconds" validate:"gte=0"`
+	MaxRangeDays       int               `json:"max_range_days" validate:"gte=0"`
+	CaseInsensitive    *bool             `json:"case_insensitive"`
+	IncludeVoicetracks bool              `json:"include_voicetracks"`
+	Scheduler          SchedulerConfig   `json:"scheduler"`
+}
+
+// DefaultMediaFileCheckStatTimeoutSeconds is the default per-stat timeout for media file checks.
+const DefaultMediaFileCheckStatTimeoutSeconds = 5
+
+// DefaultMediaFileCheckMaxRangeDays caps the from/to span of a single media file check.
+const DefaultMediaFileCheckMaxRangeDays = 31
+
+// StatTimeout returns the per-stat timeout. Falls back to
+// DefaultMediaFileCheckStatTimeoutSeconds when StatTimeoutSec is zero or negative.
+func (c *MediaFileCheckConfig) StatTimeout() time.Duration {
+	if c.StatTimeoutSec <= 0 {
+		return DefaultMediaFileCheckStatTimeoutSeconds * time.Second
+	}
+	return time.Duration(c.StatTimeoutSec) * time.Second
+}
+
+// GetMaxRangeDays returns the maximum allowed from/to span in days.
+func (c *MediaFileCheckConfig) GetMaxRangeDays() int {
+	return cmp.Or(c.MaxRangeDays, DefaultMediaFileCheckMaxRangeDays)
+}
+
+// IsCaseInsensitive reports whether filename matching ignores case. Defaults to
+// true (the references originate on case-insensitive Windows) when unset.
+func (c *MediaFileCheckConfig) IsCaseInsensitive() bool {
+	if c.CaseInsensitive == nil {
+		return true
+	}
+	return *c.CaseInsensitive
+}
+
 // LogConfig contains logging configuration.
 type LogConfig struct {
 	Level  string `json:"level" validate:"omitempty,oneof=debug info warn error"`
@@ -168,14 +224,15 @@ type LogConfig struct {
 
 // Config represents the complete application configuration.
 type Config struct {
-	Database      DatabaseConfig      `json:"database"`
-	Image         ImageConfig         `json:"image"`
-	API           APIConfig           `json:"api"`
-	Maintenance   MaintenanceConfig   `json:"maintenance"`
-	Backup        BackupConfig        `json:"backup"`
-	FileMonitor   FileMonitorConfig   `json:"file_monitor"`
-	Notifications NotificationsConfig `json:"notifications"`
-	Log           LogConfig           `json:"log"`
+	Database       DatabaseConfig       `json:"database"`
+	Image          ImageConfig          `json:"image"`
+	API            APIConfig            `json:"api"`
+	Maintenance    MaintenanceConfig    `json:"maintenance"`
+	Backup         BackupConfig         `json:"backup"`
+	FileMonitor    FileMonitorConfig    `json:"file_monitor"`
+	MediaFileCheck MediaFileCheckConfig `json:"media_file_check"`
+	Notifications  NotificationsConfig  `json:"notifications"`
+	Log            LogConfig            `json:"log"`
 }
 
 const (
@@ -383,6 +440,7 @@ func newConfigValidator() *validator.Validate {
 
 	v.RegisterStructValidation(validateS3Config, S3Config{})
 	v.RegisterStructValidation(validateFileMonitorConfig, FileMonitorConfig{})
+	v.RegisterStructValidation(validateMediaFileCheckConfig, MediaFileCheckConfig{})
 
 	return v
 }
@@ -442,6 +500,44 @@ func validateFileMonitorConfig(sl validator.StructLevel) {
 	}
 }
 
+// driveLetterPattern matches a Windows drive prefix such as "O:" (optionally
+// written "O:\"). Capture group 1 is the letter.
+var driveLetterPattern = regexp.MustCompile(`^([A-Za-z]):\\?$`)
+
+// validateMediaFileCheckConfig checks that, when the media file check is
+// enabled, at least one resolution source is configured and that every path is
+// absolute. Drive-mapping keys must be Windows drive prefixes ("O:") and their
+// targets absolute host directories. The checks only run when enabled so a
+// disabled, half-filled block does not block startup.
+func validateMediaFileCheckConfig(sl validator.StructLevel) {
+	mfc := sl.Current().Interface().(MediaFileCheckConfig)
+	if !mfc.Enabled {
+		return
+	}
+
+	if len(mfc.Roots) == 0 && len(mfc.DriveMappings) == 0 {
+		sl.ReportError(mfc.Roots, "roots", "Roots", "media_check_no_source", "")
+	}
+
+	for i, root := range mfc.Roots {
+		if !filepath.IsAbs(root) {
+			fieldName := fmt.Sprintf("roots[%d]", i)
+			structFieldName := fmt.Sprintf("Roots[%d]", i)
+			sl.ReportError(mfc.Roots[i], fieldName, structFieldName, "absolute_path", "")
+		}
+	}
+
+	for drive, target := range mfc.DriveMappings {
+		if !driveLetterPattern.MatchString(drive) {
+			sl.ReportError(target, "drive_mappings", "DriveMappings", "media_check_drive_key", drive)
+			continue
+		}
+		if !filepath.IsAbs(target) {
+			sl.ReportError(target, "drive_mappings", "DriveMappings", "media_check_drive_target", drive)
+		}
+	}
+}
+
 // validate validates the configuration using struct tags and struct-level validators.
 func validate(config *Config) error {
 	if err := configValidator.Struct(config); err != nil {
@@ -477,6 +573,12 @@ func tagMessage(tag, param string) string {
 		return "is required when no endpoint is specified"
 	case "required_when_enabled":
 		return "must have at least one entry when enabled"
+	case "media_check_no_source":
+		return "requires at least one root or drive mapping when enabled"
+	case "media_check_drive_key":
+		return fmt.Sprintf("has an invalid drive key %q (expected e.g. \"O:\")", param)
+	case "media_check_drive_target":
+		return fmt.Sprintf("target for drive %q must be an absolute path", param)
 	case "duplicate_path":
 		return fmt.Sprintf("is duplicated (%s)", param)
 	case "absolute_path":

--- a/internal/config/mediacheck_test.go
+++ b/internal/config/mediacheck_test.go
@@ -5,9 +5,9 @@ import "testing"
 func TestMediaFileCheck_DisabledSkipsValidation(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.MediaFileCheck = MediaFileCheckConfig{
-		Enabled:       false,
-		Roots:         []string{"relative/path"}, // would be invalid if enabled
-		DriveMappings: map[string]string{"bad": "also-relative"},
+		Enabled:     false,
+		SearchDirs:  []string{"relative/path"}, // would be invalid if enabled
+		DriveMounts: map[string]string{"bad": "also-relative"},
 	}
 
 	if err := validate(cfg); err != nil {
@@ -20,15 +20,15 @@ func TestMediaFileCheck_EnabledRequiresSource(t *testing.T) {
 	cfg.MediaFileCheck = MediaFileCheckConfig{Enabled: true}
 
 	if err := validate(cfg); err == nil {
-		t.Fatal("expected error when enabled with no roots or drive mappings, got nil")
+		t.Fatal("expected error when enabled with no search dirs or drive mounts, got nil")
 	}
 }
 
 func TestMediaFileCheck_EnabledWithAbsoluteRoot(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.MediaFileCheck = MediaFileCheckConfig{
-		Enabled: true,
-		Roots:   []string{"/mnt/aeron-audio"},
+		Enabled:    true,
+		SearchDirs: []string{"/mnt/aeron-audio"},
 	}
 
 	if err := validate(cfg); err != nil {
@@ -39,8 +39,8 @@ func TestMediaFileCheck_EnabledWithAbsoluteRoot(t *testing.T) {
 func TestMediaFileCheck_RelativeRootRejected(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.MediaFileCheck = MediaFileCheckConfig{
-		Enabled: true,
-		Roots:   []string{"relative/audio"},
+		Enabled:    true,
+		SearchDirs: []string{"relative/audio"},
 	}
 
 	if err := validate(cfg); err == nil {
@@ -51,8 +51,8 @@ func TestMediaFileCheck_RelativeRootRejected(t *testing.T) {
 func TestMediaFileCheck_DriveMappingValid(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.MediaFileCheck = MediaFileCheckConfig{
-		Enabled:       true,
-		DriveMappings: map[string]string{"O:": "/mnt/aeron-o", "Y:": "/mnt/aeron-y"},
+		Enabled:     true,
+		DriveMounts: map[string]string{"O:": "/mnt/aeron-o", "Y:": "/mnt/aeron-y"},
 	}
 
 	if err := validate(cfg); err != nil {
@@ -63,8 +63,8 @@ func TestMediaFileCheck_DriveMappingValid(t *testing.T) {
 func TestMediaFileCheck_DriveMappingBadKey(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.MediaFileCheck = MediaFileCheckConfig{
-		Enabled:       true,
-		DriveMappings: map[string]string{"audio": "/mnt/aeron-o"},
+		Enabled:     true,
+		DriveMounts: map[string]string{"audio": "/mnt/aeron-o"},
 	}
 
 	if err := validate(cfg); err == nil {
@@ -75,8 +75,8 @@ func TestMediaFileCheck_DriveMappingBadKey(t *testing.T) {
 func TestMediaFileCheck_DriveMappingRelativeTarget(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.MediaFileCheck = MediaFileCheckConfig{
-		Enabled:       true,
-		DriveMappings: map[string]string{"O:": "relative/dir"},
+		Enabled:     true,
+		DriveMounts: map[string]string{"O:": "relative/dir"},
 	}
 
 	if err := validate(cfg); err == nil {

--- a/internal/config/mediacheck_test.go
+++ b/internal/config/mediacheck_test.go
@@ -84,6 +84,19 @@ func TestMediaFileCheck_DriveMappingRelativeTarget(t *testing.T) {
 	}
 }
 
+func TestMediaFileCheck_NegativeLookaheadRejected(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled:       true,
+		SearchDirs:    []string{"/mnt/aeron-audio"},
+		LookaheadDays: -1,
+	}
+
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected error for negative lookahead_days, got nil")
+	}
+}
+
 func TestMediaFileCheck_Defaults(t *testing.T) {
 	cfg := MediaFileCheckConfig{}
 

--- a/internal/config/mediacheck_test.go
+++ b/internal/config/mediacheck_test.go
@@ -1,0 +1,105 @@
+package config
+
+import "testing"
+
+func TestMediaFileCheck_DisabledSkipsValidation(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled:       false,
+		Roots:         []string{"relative/path"}, // would be invalid if enabled
+		DriveMappings: map[string]string{"bad": "also-relative"},
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("disabled media_file_check should skip validation, got: %v", err)
+	}
+}
+
+func TestMediaFileCheck_EnabledRequiresSource(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{Enabled: true}
+
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected error when enabled with no roots or drive mappings, got nil")
+	}
+}
+
+func TestMediaFileCheck_EnabledWithAbsoluteRoot(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled: true,
+		Roots:   []string{"/mnt/aeron-audio"},
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestMediaFileCheck_RelativeRootRejected(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled: true,
+		Roots:   []string{"relative/audio"},
+	}
+
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected error for relative root, got nil")
+	}
+}
+
+func TestMediaFileCheck_DriveMappingValid(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled:       true,
+		DriveMappings: map[string]string{"O:": "/mnt/aeron-o", "Y:": "/mnt/aeron-y"},
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestMediaFileCheck_DriveMappingBadKey(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled:       true,
+		DriveMappings: map[string]string{"audio": "/mnt/aeron-o"},
+	}
+
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected error for invalid drive key, got nil")
+	}
+}
+
+func TestMediaFileCheck_DriveMappingRelativeTarget(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.MediaFileCheck = MediaFileCheckConfig{
+		Enabled:       true,
+		DriveMappings: map[string]string{"O:": "relative/dir"},
+	}
+
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected error for relative drive mapping target, got nil")
+	}
+}
+
+func TestMediaFileCheck_Defaults(t *testing.T) {
+	cfg := MediaFileCheckConfig{}
+
+	if got := cfg.StatTimeout(); got.Seconds() != DefaultMediaFileCheckStatTimeoutSeconds {
+		t.Errorf("StatTimeout default = %v, want %ds", got, DefaultMediaFileCheckStatTimeoutSeconds)
+	}
+	if got := cfg.GetMaxRangeDays(); got != DefaultMediaFileCheckMaxRangeDays {
+		t.Errorf("GetMaxRangeDays default = %d, want %d", got, DefaultMediaFileCheckMaxRangeDays)
+	}
+	if !cfg.IsCaseInsensitive() {
+		t.Error("IsCaseInsensitive default = false, want true")
+	}
+
+	off := false
+	cfg.CaseInsensitive = &off
+	if cfg.IsCaseInsensitive() {
+		t.Error("IsCaseInsensitive = true after explicit false")
+	}
+}

--- a/internal/config/timewindow.go
+++ b/internal/config/timewindow.go
@@ -7,14 +7,14 @@ import (
 	"time"
 )
 
-// TimeWindow represents a HH:MM-HH:MM window in local time.
+// TimeWindow is a local-time HH:MM-HH:MM activity window.
 //
 // A window whose end is earlier than its start wraps around midnight (e.g.
 // 22:00-06:00 is active from 22:00 until 06:00 the next morning). An
 // unconfigured window (zero value) is always active; this is distinct from a
 // parsed window - equal start and end would otherwise be ambiguous, so it is
 // rejected at parse time and operators must omit the field for always-active
-// behaviour.
+// behavior.
 type TimeWindow struct {
 	startMin, endMin int
 	configured       bool

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// DB is the database interface for data access operations.
+// DB is the sqlx surface used by repository query helpers.
 type DB interface {
 	GetContext(ctx context.Context, dest any, query string, args ...any) error
 	SelectContext(ctx context.Context, dest any, query string, args ...any) error
@@ -18,14 +18,14 @@ type DB interface {
 	PingContext(ctx context.Context) error
 }
 
-// Artist is a basic artist entity with ID, name, and image status.
+// Artist is the compact artist projection used by list-style queries.
 type Artist struct {
 	ID         string `db:"artistid"`
 	ArtistName string `db:"artist"`
 	HasImage   bool   `db:"has_image"`
 }
 
-// ArtistDetails contains complete artist information including social media and metadata.
+// ArtistDetails is the full artist projection returned by detail endpoints.
 type ArtistDetails struct {
 	ID          string `db:"artistid" json:"artistid"`
 	ArtistName  string `db:"artist" json:"artist"`
@@ -37,7 +37,7 @@ type ArtistDetails struct {
 	RepeatValue int    `db:"repeat_value" json:"repeat_value"`
 }
 
-// Track is a basic track entity with ID, title, artist, and image status.
+// Track is the compact track projection used by list-style queries.
 type Track struct {
 	ID         string `db:"titleid"`
 	TrackTitle string `db:"tracktitle"`
@@ -45,7 +45,7 @@ type Track struct {
 	HasImage   bool   `db:"has_image"`
 }
 
-// TrackDetails contains complete track information including timing and audio properties.
+// TrackDetails is the full track projection returned by detail endpoints.
 type TrackDetails struct {
 	ID            string `db:"titleid" json:"titleid"`
 	TrackTitle    string `db:"tracktitle" json:"tracktitle"`

--- a/internal/database/mediacheck.go
+++ b/internal/database/mediacheck.go
@@ -42,6 +42,10 @@ type MediaCheckOptions struct {
 	To                 string
 	Limit              int
 	IncludeVoicetracks bool
+	// LookaheadDays widens the default (today) scope to today through
+	// today+LookaheadDays inclusive. Only set by the scheduled run; ignored when
+	// BlockID/Date/From/To already select an explicit scope.
+	LookaheadDays int
 }
 
 // mediaCheckColumns selects the playlist item, track, audio and block fields.
@@ -94,6 +98,13 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 		if opts.To != "" {
 			conditions = append(conditions, fmt.Sprintf("pi.startdatetime < %s::date + INTERVAL '1 day'", nextParam(opts.To)))
 		}
+	case opts.LookaheadDays > 0:
+		// Today through today+LookaheadDays inclusive. The date math runs in the
+		// database (CURRENT_DATE + N) so it stays consistent with the today-scope
+		// regardless of the app's timezone.
+		conditions = append(conditions, fmt.Sprintf(
+			"pi.startdatetime >= CURRENT_DATE AND pi.startdatetime < CURRENT_DATE + %s::int",
+			nextParam(opts.LookaheadDays+1)))
 	default:
 		conditions = append(conditions,
 			"pi.startdatetime >= CURRENT_DATE AND pi.startdatetime < CURRENT_DATE + INTERVAL '1 day'")

--- a/internal/database/mediacheck.go
+++ b/internal/database/mediacheck.go
@@ -29,7 +29,7 @@ type MediaCheckItem struct {
 	AudioName  string `db:"audioname"`
 }
 
-// MediaCheckOptions contains the scope filters for a media file check query.
+// MediaCheckOptions defines the playlist scope for a media file check query.
 //
 // Filter precedence mirrors the playlist endpoint: a BlockID selects a single
 // block; otherwise Date selects one calendar day; otherwise From/To select a
@@ -68,9 +68,9 @@ const mediaCheckJoins = `
 	LEFT JOIN %s.audio au ON t.audioid = au.audioid
 	LEFT JOIN %s.playlistblock pb ON pi.blockid = pb.blockid`
 
-// BuildMediaCheckQuery generates a parameterized query selecting playlist items
-// with their audio references for the given scope. The schema is validated as an
-// identifier; all user-supplied values are bound as parameters.
+// BuildMediaCheckQuery builds a parameterized playlist-audio query for the
+// requested scope. The schema is validated as an identifier; user values are
+// always bound as parameters.
 func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string, params []any, err error) {
 	if !types.IsValidIdentifier(schema) {
 		return "", nil, types.NewValidationError("schema", fmt.Sprintf("invalid schema name: %s", schema))
@@ -126,8 +126,7 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 	return query, params, nil
 }
 
-// GetMediaCheckItems returns playlist items with their audio references for the
-// given scope.
+// GetMediaCheckItems returns playlist items and audio references for opts.
 func (r *Repository) GetMediaCheckItems(ctx context.Context, opts *MediaCheckOptions) ([]MediaCheckItem, error) {
 	query, params, err := BuildMediaCheckQuery(r.schema, opts)
 	if err != nil {

--- a/internal/database/mediacheck.go
+++ b/internal/database/mediacheck.go
@@ -1,0 +1,140 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
+)
+
+// MediaCheckItem holds the database fields needed to verify that a playlist
+// item's audio file exists on disk.
+//
+// The audio reference fields come from the aeron.audio table joined via
+// track.audioid. In the real Aeron schema both FilePath and FileName hold full
+// Windows paths (and may differ); AudioName is the bare filename without
+// extension and is the most reliably populated reference. Empty strings denote
+// an absent reference. TrackFound is false when the playlist item's titleid no
+// longer resolves to a track (e.g. the track was deleted after airing).
+type MediaCheckItem struct {
+	TrackID      string `db:"trackid"`
+	Artist       string `db:"artist"`
+	TrackTitle   string `db:"tracktitle"`
+	StartTime    string `db:"start_time"`
+	BlockID      string `db:"blockid"`
+	BlockName    string `db:"block"`
+	TrackFound   bool   `db:"track_found"`
+	AudioID      string `db:"audioid"`
+	FilePath     string `db:"filepath"`
+	FileName     string `db:"filename"`
+	AudioName    string `db:"audioname"`
+	IsVoicetrack bool   `db:"is_voicetrack"`
+}
+
+// MediaCheckOptions contains the scope filters for a media file check query.
+//
+// Filter precedence mirrors the playlist endpoint: a BlockID selects a single
+// block; otherwise Date selects one calendar day; otherwise From/To select a
+// date range (at least one bound); otherwise the query defaults to the current
+// day.
+type MediaCheckOptions struct {
+	BlockID            string
+	Date               string
+	From               string
+	To                 string
+	Limit              int
+	IncludeVoicetracks bool
+}
+
+// mediaCheckColumns selects the playlist item, track, audio and block fields.
+// %s is the VoicetrackUserID used to flag voice tracks.
+const mediaCheckColumns = `
+	COALESCE(pi.titleid::text, '') as trackid,
+	COALESCE(t.tracktitle, '') as tracktitle,
+	COALESCE(t.artist, '') as artist,
+	TO_CHAR(pi.startdatetime, 'YYYY-MM-DD"T"HH24:MI:SS') as start_time,
+	COALESCE(pi.blockid::text, '') as blockid,
+	COALESCE(pb.name, '') as block,
+	CASE WHEN t.titleid IS NOT NULL THEN true ELSE false END as track_found,
+	COALESCE(t.audioid::text, '') as audioid,
+	COALESCE(au.filepath, '') as filepath,
+	COALESCE(au.filename, '') as filename,
+	COALESCE(au.name, '') as audioname,
+	CASE WHEN t.userid = '%s' THEN true ELSE false END as is_voicetrack`
+
+// mediaCheckJoins defines the table relationships. The three %s are the schema
+// for playlistitem, track, audio and playlistblock respectively.
+const mediaCheckJoins = `
+	FROM %s.playlistitem pi
+	LEFT JOIN %s.track t ON pi.titleid = t.titleid
+	LEFT JOIN %s.audio au ON t.audioid = au.audioid
+	LEFT JOIN %s.playlistblock pb ON pi.blockid = pb.blockid`
+
+// BuildMediaCheckQuery generates a parameterized query selecting playlist items
+// with their audio references for the given scope. The schema is validated as an
+// identifier; all user-supplied values are bound as parameters.
+func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string, params []any, err error) {
+	if !types.IsValidIdentifier(schema) {
+		return "", nil, types.NewValidationError("schema", fmt.Sprintf("invalid schema name: %s", schema))
+	}
+
+	paramCount := 0
+	nextParam := func(v any) string {
+		paramCount++
+		params = append(params, v)
+		return "$" + strconv.Itoa(paramCount)
+	}
+
+	var conditions []string
+	switch {
+	case opts.BlockID != "":
+		conditions = append(conditions, fmt.Sprintf("pi.blockid = %s", nextParam(opts.BlockID)))
+	case opts.Date != "":
+		p := nextParam(opts.Date)
+		conditions = append(conditions,
+			fmt.Sprintf("pi.startdatetime >= %s::date AND pi.startdatetime < %s::date + INTERVAL '1 day'", p, p))
+	case opts.From != "" || opts.To != "":
+		if opts.From != "" {
+			conditions = append(conditions, fmt.Sprintf("pi.startdatetime >= %s::date", nextParam(opts.From)))
+		}
+		if opts.To != "" {
+			conditions = append(conditions, fmt.Sprintf("pi.startdatetime < %s::date + INTERVAL '1 day'", nextParam(opts.To)))
+		}
+	default:
+		conditions = append(conditions,
+			"pi.startdatetime >= CURRENT_DATE AND pi.startdatetime < CURRENT_DATE + INTERVAL '1 day'")
+	}
+
+	if !opts.IncludeVoicetracks {
+		conditions = append(conditions,
+			fmt.Sprintf("(t.userid IS NULL OR t.userid <> %s::uuid)", nextParam(types.VoicetrackUserID)))
+	}
+
+	columns := fmt.Sprintf(mediaCheckColumns, types.VoicetrackUserID)
+	joins := fmt.Sprintf(mediaCheckJoins, schema, schema, schema, schema)
+	query = fmt.Sprintf("SELECT %s %s WHERE %s ORDER BY pi.startdatetime",
+		columns, joins, strings.Join(conditions, " AND "))
+
+	if opts.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %s", nextParam(opts.Limit))
+	}
+
+	return query, params, nil
+}
+
+// GetMediaCheckItems returns playlist items with their audio references for the
+// given scope.
+func (r *Repository) GetMediaCheckItems(ctx context.Context, opts *MediaCheckOptions) ([]MediaCheckItem, error) {
+	query, params, err := BuildMediaCheckQuery(r.schema, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []MediaCheckItem
+	if err := r.db.SelectContext(ctx, &items, query, params...); err != nil {
+		return nil, types.NewOperationError("fetch media check items", err)
+	}
+	return items, nil
+}

--- a/internal/database/mediacheck.go
+++ b/internal/database/mediacheck.go
@@ -16,21 +16,17 @@ import (
 // track.audioid. In the real Aeron schema both FilePath and FileName hold full
 // Windows paths (and may differ); AudioName is the bare filename without
 // extension and is the most reliably populated reference. Empty strings denote
-// an absent reference. TrackFound is false when the playlist item's titleid no
-// longer resolves to a track (e.g. the track was deleted after airing).
+// an absent reference.
 type MediaCheckItem struct {
-	TrackID      string `db:"trackid"`
-	Artist       string `db:"artist"`
-	TrackTitle   string `db:"tracktitle"`
-	StartTime    string `db:"start_time"`
-	BlockID      string `db:"blockid"`
-	BlockName    string `db:"block"`
-	TrackFound   bool   `db:"track_found"`
-	AudioID      string `db:"audioid"`
-	FilePath     string `db:"filepath"`
-	FileName     string `db:"filename"`
-	AudioName    string `db:"audioname"`
-	IsVoicetrack bool   `db:"is_voicetrack"`
+	TrackID    string `db:"trackid"`
+	Artist     string `db:"artist"`
+	TrackTitle string `db:"tracktitle"`
+	StartTime  string `db:"start_time"`
+	BlockID    string `db:"blockid"`
+	BlockName  string `db:"block"`
+	FilePath   string `db:"filepath"`
+	FileName   string `db:"filename"`
+	AudioName  string `db:"audioname"`
 }
 
 // MediaCheckOptions contains the scope filters for a media file check query.
@@ -49,7 +45,6 @@ type MediaCheckOptions struct {
 }
 
 // mediaCheckColumns selects the playlist item, track, audio and block fields.
-// %s is the VoicetrackUserID used to flag voice tracks.
 const mediaCheckColumns = `
 	COALESCE(pi.titleid::text, '') as trackid,
 	COALESCE(t.tracktitle, '') as tracktitle,
@@ -57,14 +52,11 @@ const mediaCheckColumns = `
 	TO_CHAR(pi.startdatetime, 'YYYY-MM-DD"T"HH24:MI:SS') as start_time,
 	COALESCE(pi.blockid::text, '') as blockid,
 	COALESCE(pb.name, '') as block,
-	CASE WHEN t.titleid IS NOT NULL THEN true ELSE false END as track_found,
-	COALESCE(t.audioid::text, '') as audioid,
 	COALESCE(au.filepath, '') as filepath,
 	COALESCE(au.filename, '') as filename,
-	COALESCE(au.name, '') as audioname,
-	CASE WHEN t.userid = '%s' THEN true ELSE false END as is_voicetrack`
+	COALESCE(au.name, '') as audioname`
 
-// mediaCheckJoins defines the table relationships. The three %s are the schema
+// mediaCheckJoins defines the table relationships. The four %s are the schema
 // for playlistitem, track, audio and playlistblock respectively.
 const mediaCheckJoins = `
 	FROM %s.playlistitem pi
@@ -112,10 +104,9 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 			fmt.Sprintf("(t.userid IS NULL OR t.userid <> %s::uuid)", nextParam(types.VoicetrackUserID)))
 	}
 
-	columns := fmt.Sprintf(mediaCheckColumns, types.VoicetrackUserID)
 	joins := fmt.Sprintf(mediaCheckJoins, schema, schema, schema, schema)
 	query = fmt.Sprintf("SELECT %s %s WHERE %s ORDER BY pi.startdatetime",
-		columns, joins, strings.Join(conditions, " AND "))
+		mediaCheckColumns, joins, strings.Join(conditions, " AND "))
 
 	if opts.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %s", nextParam(opts.Limit))

--- a/internal/database/mediacheck_test.go
+++ b/internal/database/mediacheck_test.go
@@ -1,0 +1,96 @@
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildMediaCheckQuery_InvalidSchema(t *testing.T) {
+	if _, _, err := BuildMediaCheckQuery("bad schema!", &MediaCheckOptions{}); err == nil {
+		t.Fatal("expected error for invalid schema, got nil")
+	}
+}
+
+func TestBuildMediaCheckQuery_DefaultsToToday(t *testing.T) {
+	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, "CURRENT_DATE") {
+		t.Errorf("expected CURRENT_DATE default scope, got: %s", query)
+	}
+	// Only the voicetrack-exclusion parameter should be bound.
+	if len(params) != 1 {
+		t.Errorf("params = %v, want 1 (voicetrack id)", params)
+	}
+	if !strings.Contains(query, "t.userid IS NULL OR t.userid <>") {
+		t.Errorf("expected voicetrack exclusion, got: %s", query)
+	}
+}
+
+func TestBuildMediaCheckQuery_Date(t *testing.T) {
+	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{Date: "2026-06-29"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, "$1::date") {
+		t.Errorf("expected bound date param, got: %s", query)
+	}
+	if params[0] != "2026-06-29" {
+		t.Errorf("params[0] = %v, want date", params[0])
+	}
+}
+
+func TestBuildMediaCheckQuery_BlockTakesPrecedence(t *testing.T) {
+	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{
+		BlockID: "abc", Date: "2026-06-29",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, "pi.blockid = $1") {
+		t.Errorf("expected block filter first, got: %s", query)
+	}
+	if params[0] != "abc" {
+		t.Errorf("params[0] = %v, want block id", params[0])
+	}
+	if strings.Contains(query, "CURRENT_DATE") || strings.Contains(query, "::date") {
+		t.Errorf("block scope should not include date filters, got: %s", query)
+	}
+}
+
+func TestBuildMediaCheckQuery_Range(t *testing.T) {
+	query, _, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{From: "2026-06-01", To: "2026-06-07"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, ">= $1::date") || !strings.Contains(query, "< $2::date + INTERVAL '1 day'") {
+		t.Errorf("expected from/to range, got: %s", query)
+	}
+}
+
+func TestBuildMediaCheckQuery_IncludeVoicetracks(t *testing.T) {
+	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{IncludeVoicetracks: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(query, "t.userid <>") {
+		t.Errorf("voicetracks should be included, got: %s", query)
+	}
+	if len(params) != 0 {
+		t.Errorf("params = %v, want none", params)
+	}
+}
+
+func TestBuildMediaCheckQuery_Limit(t *testing.T) {
+	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, "LIMIT") {
+		t.Errorf("expected LIMIT clause, got: %s", query)
+	}
+	if params[len(params)-1] != 50 {
+		t.Errorf("last param = %v, want 50", params[len(params)-1])
+	}
+}

--- a/internal/database/mediacheck_test.go
+++ b/internal/database/mediacheck_test.go
@@ -74,6 +74,30 @@ func TestBuildMediaCheckQuery_Range(t *testing.T) {
 	}
 }
 
+func TestBuildMediaCheckQuery_Lookahead(t *testing.T) {
+	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{LookaheadDays: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, "CURRENT_DATE + $1::int") {
+		t.Errorf("expected lookahead upper bound, got: %s", query)
+	}
+	// LookaheadDays=2 → today through today+2 inclusive → upper bound CURRENT_DATE + 3.
+	if params[0] != 3 {
+		t.Errorf("params[0] = %v, want 3 (lookahead+1)", params[0])
+	}
+}
+
+func TestBuildMediaCheckQuery_DateIgnoresLookahead(t *testing.T) {
+	query, _, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{Date: "2026-06-29", LookaheadDays: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(query, "::int") {
+		t.Errorf("explicit date scope must ignore lookahead, got: %s", query)
+	}
+}
+
 func TestBuildMediaCheckQuery_IncludeVoicetracks(t *testing.T) {
 	query, params, err := BuildMediaCheckQuery("aeron", &MediaCheckOptions{IncludeVoicetracks: true})
 	if err != nil {

--- a/internal/database/mediacheck_test.go
+++ b/internal/database/mediacheck_test.go
@@ -26,6 +26,11 @@ func TestBuildMediaCheckQuery_DefaultsToToday(t *testing.T) {
 	if !strings.Contains(query, "t.userid IS NULL OR t.userid <>") {
 		t.Errorf("expected voicetrack exclusion, got: %s", query)
 	}
+	for _, removed := range []string{"as track_found", "as audioid", "as is_voicetrack"} {
+		if strings.Contains(query, removed) {
+			t.Errorf("query still selects removed column %q: %s", removed, query)
+		}
+	}
 }
 
 func TestBuildMediaCheckQuery_Date(t *testing.T) {

--- a/internal/database/playlist.go
+++ b/internal/database/playlist.go
@@ -9,7 +9,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// playlistItemColumns defines the fields returned for each playlist item.
+// playlistItemColumns selects the API projection for playlist items.
 const playlistItemColumns = `
 	pi.titleid as trackid,
 	COALESCE(t.tracktitle, '') as tracktitle,
@@ -25,13 +25,13 @@ const playlistItemColumns = `
 	CASE WHEN t.userid = '%s' THEN true ELSE false END as is_voicetrack,
 	CASE WHEN COALESCE(pi.commblock, 0) > 0 THEN true ELSE false END as is_commblock`
 
-// playlistItemJoins defines the table relationships for playlist item queries.
+// playlistItemJoins joins playlist items to track and artist data.
 const playlistItemJoins = `
 	FROM %s.playlistitem pi
 	LEFT JOIN %s.track t ON pi.titleid = t.titleid
 	LEFT JOIN %s.artist a ON t.artistid = a.artistid`
 
-// PlaylistBlock represents a programming block with scheduling information.
+// PlaylistBlock is a scheduled programming block.
 type PlaylistBlock struct {
 	BlockID        string `db:"blockid" json:"blockid"`
 	Name           string `db:"name" json:"name"`
@@ -40,7 +40,7 @@ type PlaylistBlock struct {
 	Date           string `db:"date" json:"date"`
 }
 
-// PlaylistItem represents a single scheduled track or media item.
+// PlaylistItem is one scheduled track or media item within a block.
 type PlaylistItem struct {
 	TrackID        string `db:"trackid" json:"trackid"`
 	TrackTitle     string `db:"tracktitle" json:"tracktitle"`
@@ -57,7 +57,7 @@ type PlaylistItem struct {
 	IsCommblock    bool   `db:"is_commblock" json:"is_commblock"`
 }
 
-// PlaylistOptions contains filter, sort, and pagination parameters for playlist queries.
+// PlaylistOptions controls playlist filtering, sorting, and pagination.
 type PlaylistOptions struct {
 	BlockID     string
 	Date        string
@@ -70,7 +70,7 @@ type PlaylistOptions struct {
 	ArtistImage *bool
 }
 
-// BuildPlaylistQuery generates a parameterized SQL query from playlist filter options.
+// BuildPlaylistQuery builds a parameterized block-item query.
 func BuildPlaylistQuery(schema string, opts *PlaylistOptions) (query string, params []any, err error) {
 	var conditions []string
 	paramCount := 0
@@ -147,7 +147,7 @@ func BuildPlaylistQuery(schema string, opts *PlaylistOptions) (query string, par
 	return query, params, nil
 }
 
-// ExecutePlaylistQuery executes a playlist query and maps results to PlaylistItem structs.
+// ExecutePlaylistQuery runs a playlist query and scans rows into PlaylistItem values.
 func ExecutePlaylistQuery(ctx context.Context, db DB, query string, params []any) ([]PlaylistItem, error) {
 	var items []PlaylistItem
 	err := db.SelectContext(ctx, &items, query, params...)

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1,4 +1,4 @@
-// Package database provides PostgreSQL data access for the Aeron database.
+// Package database queries the Aeron PostgreSQL schema and maps rows to API models.
 package database
 
 import (
@@ -14,18 +14,18 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// Repository provides data access methods for the Aeron database.
+// Repository binds Aeron queries to a PostgreSQL schema.
 type Repository struct {
 	db     *sqlx.DB
 	schema string
 }
 
-// NewRepository returns a Repository for accessing the specified schema.
+// NewRepository returns a Repository scoped to schema.
 func NewRepository(db *sqlx.DB, schema string) *Repository {
 	return &Repository{db: db, schema: schema}
 }
 
-// DB returns the underlying database connection.
+// DB exposes the underlying pool for specialized queries.
 func (r *Repository) DB() *sqlx.DB {
 	return r.db
 }
@@ -35,7 +35,7 @@ func (r *Repository) Schema() string {
 	return r.schema
 }
 
-// Ping verifies the database connection is alive.
+// Ping verifies the database connection can answer requests.
 func (r *Repository) Ping(ctx context.Context) error {
 	return r.db.PingContext(ctx)
 }
@@ -49,16 +49,12 @@ func (r *Repository) resolveTable(table types.Table) (qualifiedName, label, idCo
 	return qualifiedName, string(table), types.IDColumnForTable(table), nil
 }
 
-// Artist operations.
-
 // GetArtist retrieves complete artist details by UUID.
 func (r *Repository) GetArtist(ctx context.Context, id string) (*ArtistDetails, error) {
 	slog.Debug("Entity lookup", "type", "artist", "id", id)
 	query := fmt.Sprintf(artistDetailsQuery, r.schema)
 	return getEntityByID[ArtistDetails](ctx, r.db, query, id, "artist", "fetch artist")
 }
-
-// Track operations.
 
 // GetTrack retrieves complete track details by UUID.
 func (r *Repository) GetTrack(ctx context.Context, id string) (*TrackDetails, error) {
@@ -67,9 +63,7 @@ func (r *Repository) GetTrack(ctx context.Context, id string) (*TrackDetails, er
 	return getEntityByID[TrackDetails](ctx, r.db, query, id, "track", "fetch track")
 }
 
-// Image operations.
-
-// GetImage retrieves the image for an entity.
+// GetImage retrieves the stored image for an artist or track.
 func (r *Repository) GetImage(ctx context.Context, table types.Table, id string) ([]byte, error) {
 	qualifiedTableName, label, idCol, err := r.resolveTable(table)
 	if err != nil {
@@ -94,7 +88,7 @@ func (r *Repository) GetImage(ctx context.Context, table types.Table, id string)
 	return imageData, nil
 }
 
-// UpdateImage stores new image data for the specified entity.
+// UpdateImage stores image bytes for an artist or track.
 func (r *Repository) UpdateImage(ctx context.Context, table types.Table, id string, imageData []byte) error {
 	qualifiedTableName, label, idCol, err := r.resolveTable(table)
 	if err != nil {
@@ -110,7 +104,7 @@ func (r *Repository) UpdateImage(ctx context.Context, table types.Table, id stri
 	return nil
 }
 
-// DeleteImage removes the image for an entity.
+// DeleteImage clears the stored image for an artist or track.
 func (r *Repository) DeleteImage(ctx context.Context, table types.Table, id string) error {
 	qualifiedTableName, label, idCol, err := r.resolveTable(table)
 	if err != nil {
@@ -136,15 +130,13 @@ func (r *Repository) DeleteImage(ctx context.Context, table types.Table, id stri
 	return nil
 }
 
-// Count operations.
-
-// ImageCounts contains total and with-image counts for a table.
+// ImageCounts is the total and with-image count for a table.
 type ImageCounts struct {
 	Total      int `db:"total"`
 	WithImages int `db:"with_images"`
 }
 
-// CountImages returns total entity count and count with images in a single query.
+// CountImages returns total rows and rows with images in one query.
 func (r *Repository) CountImages(ctx context.Context, table types.Table) (*ImageCounts, error) {
 	qualifiedTableName, label, _, err := r.resolveTable(table)
 	if err != nil {
@@ -159,7 +151,7 @@ func (r *Repository) CountImages(ctx context.Context, table types.Table) (*Image
 	return &counts, nil
 }
 
-// CountWithImages counts entities that have images.
+// CountWithImages counts rows whose picture column is set.
 func (r *Repository) CountWithImages(ctx context.Context, table types.Table) (int, error) {
 	return r.countItems(ctx, table, true)
 }
@@ -185,7 +177,7 @@ func (r *Repository) countItems(ctx context.Context, table types.Table, hasImage
 	return count, nil
 }
 
-// DeleteAllImages removes all images for entities in the specified table.
+// DeleteAllImages clears every stored image in table.
 func (r *Repository) DeleteAllImages(ctx context.Context, table types.Table) (int64, error) {
 	qualifiedTableName, label, _, err := r.resolveTable(table)
 	if err != nil {
@@ -202,9 +194,7 @@ func (r *Repository) DeleteAllImages(ctx context.Context, table types.Table) (in
 	return result.RowsAffected()
 }
 
-// Playlist operations.
-
-// GetPlaylist retrieves playlist items based on options.
+// GetPlaylist retrieves playlist items for the requested block scope.
 func (r *Repository) GetPlaylist(ctx context.Context, opts *PlaylistOptions) ([]PlaylistItem, error) {
 	query, params, err := BuildPlaylistQuery(r.schema, opts)
 	if err != nil {
@@ -213,7 +203,7 @@ func (r *Repository) GetPlaylist(ctx context.Context, opts *PlaylistOptions) ([]
 	return ExecutePlaylistQuery(ctx, r.db, query, params)
 }
 
-// GetPlaylistBlocks retrieves all playlist blocks for a specific date.
+// GetPlaylistBlocks retrieves all playlist blocks for date or today when empty.
 func (r *Repository) GetPlaylistBlocks(ctx context.Context, date string) ([]PlaylistBlock, error) {
 	var dateFilter string
 	params := []any{}
@@ -246,7 +236,7 @@ func (r *Repository) GetPlaylistBlocks(ctx context.Context, date string) ([]Play
 	return blocks, nil
 }
 
-// GetPlaylistWithTracks retrieves all blocks with their associated tracks for a date.
+// GetPlaylistWithTracks retrieves date-scoped blocks and their items.
 func (r *Repository) GetPlaylistWithTracks(
 	ctx context.Context, date string,
 ) ([]PlaylistBlock, map[string][]PlaylistItem, error) {

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -1,4 +1,4 @@
-// Package image provides image processing and optimization functionality.
+// Package image validates, resizes, and re-encodes uploaded artwork.
 package image
 
 import (
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/image/draw"
 )
 
-// Config contains image processing settings.
+// Config controls image dimensions, quality, and minimum-size policy.
 type Config struct {
 	TargetWidth   int
 	TargetHeight  int
@@ -21,7 +21,7 @@ type Config struct {
 	RejectSmaller bool
 }
 
-// ProcessingResult contains the results of image processing operations.
+// ProcessingResult reports original and stored image characteristics.
 type ProcessingResult struct {
 	Data      []byte
 	Format    string
@@ -31,7 +31,7 @@ type ProcessingResult struct {
 	Savings   float64
 }
 
-// Info contains image metadata.
+// Info is decoded image metadata.
 type Info struct {
 	Format string
 	Width  int
@@ -39,17 +39,17 @@ type Info struct {
 	Size   int
 }
 
-// Optimizer handles image optimization operations.
+// Optimizer applies configured resize and encoding rules.
 type Optimizer struct {
 	Config Config
 }
 
-// NewOptimizer returns an Optimizer configured with the specified settings.
+// NewOptimizer returns an Optimizer for config.
 func NewOptimizer(config Config) *Optimizer {
 	return &Optimizer{Config: config}
 }
 
-// DownloadImage downloads an image from a URL with SSRF protection.
+// DownloadImage fetches a remote image through the shared SSRF guard.
 func DownloadImage(urlString string, maxSize int64) ([]byte, error) {
 	return util.ValidateAndDownloadImage(urlString, maxSize)
 }
@@ -63,7 +63,7 @@ func getImageInfo(data []byte) (format string, width, height int, err error) {
 	return format, config.Width, config.Height, nil
 }
 
-// OptimizeImage processes and optimizes image data according to the configured settings.
+// OptimizeImage resizes and re-encodes supported image data when beneficial.
 // The format parameter is the already-detected image format (e.g. "jpeg", "png").
 func (o *Optimizer) OptimizeImage(data []byte, format string) (optimized []byte, outFormat, encoder string, err error) {
 	switch format {
@@ -145,7 +145,7 @@ func (o *Optimizer) resizeImage(sourceImage image.Image, maxWidth, maxHeight int
 	return dst
 }
 
-// Process is the main entry point for image processing.
+// Process validates imageData and returns the bytes that should be stored.
 func Process(imageData []byte, config Config) (*ProcessingResult, error) {
 	originalInfo, err := extractImageInfo(imageData)
 	if err != nil {

--- a/internal/notify/backoff.go
+++ b/internal/notify/backoff.go
@@ -7,20 +7,20 @@ import (
 )
 
 const (
-	// backoffFactor is the multiplier for exponential backoff.
+	// backoffFactor is the multiplier for each retry delay.
 	backoffFactor = 2.0
-	// backoffJitter adds randomness to prevent thundering herd (0.5 = up to 50%).
+	// backoffJitter adds up to 50% random delay to avoid synchronized retries.
 	backoffJitter = 0.5
 )
 
-// Backoff provides retry delay calculation with exponential growth.
+// Backoff calculates retry delays with capped exponential growth.
 type Backoff struct {
 	mu       sync.Mutex
 	current  time.Duration
 	maxDelay time.Duration
 }
 
-// NewBackoff returns a new Backoff with the given initial and maximum delays.
+// NewBackoff returns a Backoff starting at initial and capped at maxDelay.
 func NewBackoff(initial, maxDelay time.Duration) *Backoff {
 	return &Backoff{
 		current:  initial,
@@ -28,7 +28,7 @@ func NewBackoff(initial, maxDelay time.Duration) *Backoff {
 	}
 }
 
-// Next returns the current delay and advances to the next value.
+// Next returns the current jittered delay and advances the sequence.
 func (b *Backoff) Next() time.Duration {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -36,7 +36,6 @@ func (b *Backoff) Next() time.Duration {
 	delay := b.current
 	b.current = min(time.Duration(float64(b.current)*backoffFactor), b.maxDelay)
 
-	// Add jitter to prevent thundering herd
 	jitter := time.Duration(rand.Int64N(int64(float64(delay) * backoffJitter))) //nolint:gosec // Non-security random for jitter
 	delay += jitter
 

--- a/internal/notify/expiry.go
+++ b/internal/notify/expiry.go
@@ -15,13 +15,13 @@ import (
 )
 
 const (
-	// expiryWarningDays is the number of days before expiration to show a warning.
+	// expiryWarningDays is the warning threshold for client secret expiry.
 	expiryWarningDays = 30
-	// expiryCacheTTL is how long to cache the expiry info before re-checking.
+	// expiryCacheTTL is the maximum age of cached expiry data.
 	expiryCacheTTL = 1 * time.Hour
 )
 
-// SecretExpiryInfo contains information about client secret expiration.
+// SecretExpiryInfo is the health payload for Graph client secret expiry.
 type SecretExpiryInfo struct {
 	ExpiresAt   string `json:"expires_at,omitempty"`
 	ExpiresSoon bool   `json:"expires_soon"`
@@ -29,7 +29,7 @@ type SecretExpiryInfo struct {
 	Error       string `json:"error,omitempty"`
 }
 
-// SecretExpiryChecker checks client secret expiration via Microsoft Graph API.
+// SecretExpiryChecker caches Microsoft Graph client secret expiry.
 type SecretExpiryChecker struct {
 	mu         sync.RWMutex
 	cfg        *config.GraphConfig
@@ -39,7 +39,7 @@ type SecretExpiryChecker struct {
 	refreshing bool // prevents multiple concurrent refreshes
 }
 
-// NewSecretExpiryChecker creates a new expiry checker for the given config.
+// NewSecretExpiryChecker returns an expiry checker for cfg.
 func NewSecretExpiryChecker(cfg *config.GraphConfig) *SecretExpiryChecker {
 	return &SecretExpiryChecker{
 		cfg:        cfg,
@@ -47,8 +47,7 @@ func NewSecretExpiryChecker(cfg *config.GraphConfig) *SecretExpiryChecker {
 	}
 }
 
-// Info returns the secret expiry information, using a cached value if fresh enough.
-// If the cache is stale, it triggers an async refresh and returns the stale cached value.
+// Info returns cached expiry information and refreshes stale data asynchronously.
 // Only one refresh runs at a time to prevent thundering herd during outages.
 func (c *SecretExpiryChecker) Info() SecretExpiryInfo {
 	c.mu.RLock()
@@ -57,20 +56,18 @@ func (c *SecretExpiryChecker) Info() SecretExpiryInfo {
 	c.mu.RUnlock()
 
 	if needsRefresh {
-		// refresh() has its own guard to prevent concurrent refreshes
 		go c.refresh()
 	}
 
 	return cached
 }
 
-// refresh fetches fresh expiry information from the Graph API and updates the cache.
+// refresh fetches expiry information from Graph and updates the cache.
 func (c *SecretExpiryChecker) refresh() {
-	// Set refreshing flag and ensure it's cleared when done
 	c.mu.Lock()
 	if c.refreshing {
 		c.mu.Unlock()
-		return // Another refresh is already in progress
+		return
 	}
 	c.refreshing = true
 	cfg := c.cfg
@@ -97,7 +94,7 @@ func (c *SecretExpiryChecker) refresh() {
 	c.mu.Unlock()
 }
 
-// applicationResponse represents a Microsoft Graph application response.
+// applicationResponse is the subset of the Graph application payload we need.
 type applicationResponse struct {
 	PasswordCredentials []passwordCredential `json:"passwordCredentials"`
 }
@@ -106,7 +103,7 @@ type passwordCredential struct {
 	EndDateTime string `json:"endDateTime"`
 }
 
-// fetchExpiryInfo queries the Graph API for credential expiry information.
+// fetchExpiryInfo queries Graph for the earliest non-expired client secret.
 func (c *SecretExpiryChecker) fetchExpiryInfo(cfg *config.GraphConfig) (SecretExpiryInfo, error) {
 	ctx, cancel := context.WithTimeoutCause(
 		context.Background(),
@@ -149,7 +146,6 @@ func (c *SecretExpiryChecker) fetchExpiryInfo(cfg *config.GraphConfig) (SecretEx
 		return SecretExpiryInfo{}, fmt.Errorf("parse response: %w", err)
 	}
 
-	// Find the earliest non-expired credential
 	now := time.Now()
 	var earliest time.Time
 	for _, cred := range appResp.PasswordCredentials {
@@ -161,7 +157,7 @@ func (c *SecretExpiryChecker) fetchExpiryInfo(cfg *config.GraphConfig) (SecretEx
 			continue
 		}
 		if expiry.Before(now) {
-			continue // Skip already-expired credentials
+			continue
 		}
 		if earliest.IsZero() || expiry.Before(earliest) {
 			earliest = expiry

--- a/internal/notify/filemonitor.go
+++ b/internal/notify/filemonitor.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// FileAlertResult contains information about a single file check for notification purposes.
+// FileAlertResult is the notification payload for one stale or recovered file.
 type FileAlertResult struct {
 	Name          string
 	Path          string
@@ -18,7 +18,7 @@ type FileAlertResult struct {
 	CheckedAt     time.Time
 }
 
-// SendFileAlerts sends a single email listing all newly detected stale or missing files.
+// SendFileAlerts sends one email listing newly stale, missing, or errored files.
 func (s *NotificationService) SendFileAlerts(alerts []FileAlertResult) {
 	if !IsConfigured(&s.config.Notifications.Email) || len(alerts) == 0 {
 		return
@@ -28,7 +28,7 @@ func (s *NotificationService) SendFileAlerts(alerts []FileAlertResult) {
 	s.sendAsync(subject, body)
 }
 
-// SendFileRecoveries sends a single email listing all files that have recovered.
+// SendFileRecoveries sends one email listing files that recovered.
 func (s *NotificationService) SendFileRecoveries(recoveries []FileAlertResult) {
 	if !IsConfigured(&s.config.Notifications.Email) || len(recoveries) == 0 {
 		return

--- a/internal/notify/graph.go
+++ b/internal/notify/graph.go
@@ -1,4 +1,4 @@
-// Package notify provides email notifications via Microsoft Graph API.
+// Package notify sends operational emails through Microsoft Graph.
 package notify
 
 import (
@@ -25,22 +25,20 @@ const (
 	graphScope       = "https://graph.microsoft.com/.default"
 	tokenURLTemplate = "https://login.microsoftonline.com/%s/oauth2/v2.0/token" //nolint:gosec // URL template, not a credential
 
-	// Retry settings.
 	maxRetries       = 3
 	initialRetryWait = 1 * time.Second
 	maxRetryWait     = 30 * time.Second
 
-	// HTTP client timeout.
 	httpTimeout = 30 * time.Second
 )
 
-// GraphClient sends emails via Microsoft Graph API.
+// GraphClient sends plain-text mail through Microsoft Graph.
 type GraphClient struct {
 	fromAddress string
 	httpClient  *http.Client
 }
 
-// NewGraphClient creates a new Graph API email client.
+// NewGraphClient returns a Graph mail client for cfg.
 func NewGraphClient(cfg *config.GraphConfig) (*GraphClient, error) {
 	if err := validateCredentials(cfg, false); err != nil {
 		return nil, err
@@ -51,7 +49,6 @@ func NewGraphClient(cfg *config.GraphConfig) (*GraphClient, error) {
 
 	conf := newCredentialsConfig(cfg)
 
-	// Configure base HTTP client with timeout to prevent indefinite hangs
 	baseClient := &http.Client{Timeout: httpTimeout}
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, baseClient)
 	httpClient := conf.Client(ctx)
@@ -61,8 +58,6 @@ func NewGraphClient(cfg *config.GraphConfig) (*GraphClient, error) {
 		httpClient:  httpClient,
 	}, nil
 }
-
-// Graph API request types.
 
 type graphMailRequest struct {
 	Message graphMessage `json:"message"`
@@ -87,7 +82,7 @@ type graphEmailAddress struct {
 	Address string `json:"address"`
 }
 
-// SendMail sends a plain text email to the specified recipients.
+// SendMail sends one plain-text email to the non-empty recipients.
 // The context controls cancellation of the request and any retries.
 func (c *GraphClient) SendMail(ctx context.Context, recipients []string, subject, body string) error {
 	if len(recipients) == 0 {
@@ -126,21 +121,19 @@ func (c *GraphClient) SendMail(ctx context.Context, recipients []string, subject
 	return c.doWithRetry(ctx, jsonData)
 }
 
-// doWithRetry sends the email request with automatic retries and exponential backoff.
-// The context controls cancellation - if cancelled, the retry loop stops immediately.
+// doWithRetry sends the request with bounded retries and exponential backoff.
+// Context cancellation stops the retry loop immediately.
 func (c *GraphClient) doWithRetry(ctx context.Context, jsonData []byte) error {
 	apiURL := fmt.Sprintf("%s/users/%s/sendMail", graphBaseURL, url.PathEscape(c.fromAddress))
 	backoff := NewBackoff(initialRetryWait, maxRetryWait)
 
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		// Check context before each attempt
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("request cancelled: %w", err)
 		}
 
 		if attempt > 0 {
-			// Context-aware sleep
 			if err := sleepWithContext(ctx, backoff.Next()); err != nil {
 				return fmt.Errorf("request cancelled during retry wait: %w", err)
 			}
@@ -186,7 +179,7 @@ func (c *GraphClient) doWithRetry(ctx context.Context, jsonData []byte) error {
 	return fmt.Errorf("max retries exceeded: %w", lastErr)
 }
 
-// sleepWithContext sleeps for the given duration or until the context is cancelled.
+// sleepWithContext sleeps for d unless ctx is cancelled first.
 func sleepWithContext(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
@@ -198,7 +191,7 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	}
 }
 
-// ValidateAuth verifies that the email credentials are valid by making a lightweight request.
+// ValidateAuth verifies credentials by requesting the configured mailbox.
 func (c *GraphClient) ValidateAuth() error {
 	apiURL := fmt.Sprintf("%s/users/%s", graphBaseURL, url.PathEscape(c.fromAddress))
 	req, err := http.NewRequest(http.MethodGet, apiURL, http.NoBody)
@@ -228,7 +221,7 @@ func (c *GraphClient) ValidateAuth() error {
 	}
 }
 
-// ValidateConfig validates that cfg has all required fields with strict GUID format checking.
+// ValidateConfig validates required Graph email fields and GUID shapes.
 func ValidateConfig(cfg *config.GraphConfig) error {
 	if err := validateCredentials(cfg, true); err != nil {
 		return err
@@ -242,17 +235,15 @@ func ValidateConfig(cfg *config.GraphConfig) error {
 	return nil
 }
 
-// IsConfigured reports whether the Graph configuration has the minimum required fields.
-// It validates that credentials are present and at least one valid recipient exists.
+// IsConfigured reports whether enough Graph email config exists to send mail.
 func IsConfigured(cfg *config.GraphConfig) bool {
 	if cfg.TenantID == "" || cfg.ClientID == "" || cfg.ClientSecret == "" || cfg.FromAddress == "" {
 		return false
 	}
-	// Verify at least one valid recipient after parsing
 	return len(ParseRecipients(cfg.Recipients)) > 0
 }
 
-// ParseRecipients splits a comma-separated recipients string into a slice.
+// ParseRecipients splits comma-separated recipients and drops empty entries.
 func ParseRecipients(recipients string) []string {
 	var result []string
 	for r := range strings.SplitSeq(recipients, ",") {
@@ -263,7 +254,7 @@ func ParseRecipients(recipients string) []string {
 	return result
 }
 
-// validateCredentials checks that required credential fields are present.
+// validateCredentials checks credential presence and, in strict mode, GUID shape.
 func validateCredentials(cfg *config.GraphConfig, strict bool) error {
 	if cfg.TenantID == "" {
 		return fmt.Errorf("tenant ID is required")
@@ -283,7 +274,7 @@ func validateCredentials(cfg *config.GraphConfig, strict bool) error {
 	return nil
 }
 
-// newCredentialsConfig creates an OAuth2 client credentials configuration.
+// newCredentialsConfig builds the OAuth2 client-credentials config.
 func newCredentialsConfig(cfg *config.GraphConfig) *clientcredentials.Config {
 	return &clientcredentials.Config{
 		ClientID:     cfg.ClientID,

--- a/internal/notify/healthalert.go
+++ b/internal/notify/healthalert.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// HealthAlertResult contains the information needed to send a health check notification.
+// HealthAlertResult is the notification payload for database health checks.
 type HealthAlertResult struct {
 	Recommendations    []string
 	ActiveConnections  int
@@ -18,13 +18,13 @@ type HealthAlertResult struct {
 	CheckedAt          time.Time
 }
 
-// HasIssues returns true if the health check found any problems.
+// HasIssues reports whether the check should keep the alert state active.
 func (r *HealthAlertResult) HasIssues() bool {
 	return len(r.Recommendations) > 0 || len(r.LongRunningQueries) > 0
 }
 
-// NotifyHealthCheckError sends an alert when the health check itself fails (e.g. database unreachable).
-// Uses the same state tracking as NotifyHealthAlert so a recovery email is sent when the next check succeeds.
+// NotifyHealthCheckError opens the health alert state when the check itself fails.
+// The next successful clean check will emit the matching recovery email.
 func (s *NotificationService) NotifyHealthCheckError(err error) {
 	if !IsConfigured(&s.config.Notifications.Email) || err == nil {
 		return
@@ -45,7 +45,7 @@ func (s *NotificationService) NotifyHealthCheckError(err error) {
 	s.sendAsync(subject, b.String())
 }
 
-// NotifyHealthAlert sends a failure or recovery email based on the health check result.
+// NotifyHealthAlert updates the database-health alert/recovery state.
 func (s *NotificationService) NotifyHealthAlert(r *HealthAlertResult) {
 	if r == nil {
 		return

--- a/internal/notify/mediacheck.go
+++ b/internal/notify/mediacheck.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
 // MediaCheckProblem describes a single problematic playlist item (a file that is
@@ -86,16 +88,11 @@ func formatMediaCheckRecovery(r *MediaCheckResult) (subject, body string) {
 // problemLabel renders a short "artist - title" label, falling back to the
 // reference when metadata is absent.
 func problemLabel(p *MediaCheckProblem) string {
-	switch {
-	case p.Artist != "" && p.TrackTitle != "":
-		return p.Artist + " - " + p.TrackTitle
-	case p.TrackTitle != "":
-		return p.TrackTitle
-	case p.Artist != "":
-		return p.Artist
-	case p.DBReference != "":
-		return p.DBReference
-	default:
-		return "unknown item"
+	if label := util.FormatArtistTitle(p.Artist, p.TrackTitle); label != "" {
+		return label
 	}
+	if p.DBReference != "" {
+		return p.DBReference
+	}
+	return "unknown item"
 }

--- a/internal/notify/mediacheck.go
+++ b/internal/notify/mediacheck.go
@@ -1,0 +1,101 @@
+package notify
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MediaCheckProblem describes a single problematic playlist item (a file that is
+// missing, ambiguous, or could not be checked).
+type MediaCheckProblem struct {
+	Artist      string
+	TrackTitle  string
+	StartTime   string
+	Block       string
+	Status      string // "missing", "ambiguous", "stat_error", or "error"
+	DBReference string
+}
+
+// MediaCheckResult contains the information needed to send a media file check
+// notification.
+type MediaCheckResult struct {
+	CheckedAt time.Time
+	Scope     string
+	Total     int
+	Problems  []MediaCheckProblem
+}
+
+// NotifyMediaCheckResult sends a failure email when a scheduled check finds
+// problems and a recovery email on the first clean run afterwards.
+func (s *NotificationService) NotifyMediaCheckResult(r *MediaCheckResult) {
+	if r == nil {
+		return
+	}
+	s.notifyOnTransition(&s.prevMediaCheckFailed, len(r.Problems) > 0,
+		func() (string, string) { return formatMediaCheckFailure(r) },
+		func() (string, string) { return formatMediaCheckRecovery(r) },
+	)
+}
+
+func formatMediaCheckFailure(r *MediaCheckResult) (subject, body string) {
+	if len(r.Problems) == 1 {
+		subject = fmt.Sprintf("[ERROR] Media file check: %s - Aeron Toolbox", problemLabel(&r.Problems[0]))
+	} else {
+		subject = fmt.Sprintf("[ERROR] Media file check: %d problems - Aeron Toolbox", len(r.Problems))
+	}
+
+	var b strings.Builder
+	b.WriteString("Media file check found problems\n\n")
+	fmt.Fprintf(&b, "Timestamp: %s\n", r.CheckedAt.Format(timeFormat))
+	fmt.Fprintf(&b, "Scope:     %s\n", r.Scope)
+	fmt.Fprintf(&b, "Checked:   %d items\n", r.Total)
+	fmt.Fprintf(&b, "Problems:  %d\n\n", len(r.Problems))
+
+	for i := range r.Problems {
+		p := &r.Problems[i]
+		fmt.Fprintf(&b, "  [%s] %s\n", strings.ToUpper(p.Status), problemLabel(p))
+		if p.StartTime != "" {
+			fmt.Fprintf(&b, "    Start:     %s\n", p.StartTime)
+		}
+		if p.Block != "" {
+			fmt.Fprintf(&b, "    Block:     %s\n", p.Block)
+		}
+		if p.DBReference != "" {
+			fmt.Fprintf(&b, "    Reference: %s\n", p.DBReference)
+		}
+		b.WriteString("\n")
+	}
+
+	return subject, b.String()
+}
+
+func formatMediaCheckRecovery(r *MediaCheckResult) (subject, body string) {
+	subject = "[OK] Media file check: recovered - Aeron Toolbox"
+
+	var b strings.Builder
+	b.WriteString("Media file check recovered\n\n")
+	b.WriteString("All referenced files were found again after a previous failure.\n\n")
+	fmt.Fprintf(&b, "Timestamp: %s\n", r.CheckedAt.Format(timeFormat))
+	fmt.Fprintf(&b, "Scope:     %s\n", r.Scope)
+	fmt.Fprintf(&b, "Checked:   %d items\n", r.Total)
+
+	return subject, b.String()
+}
+
+// problemLabel renders a short "artist - title" label, falling back to the
+// reference when metadata is absent.
+func problemLabel(p *MediaCheckProblem) string {
+	switch {
+	case p.Artist != "" && p.TrackTitle != "":
+		return p.Artist + " - " + p.TrackTitle
+	case p.TrackTitle != "":
+		return p.TrackTitle
+	case p.Artist != "":
+		return p.Artist
+	case p.DBReference != "":
+		return p.DBReference
+	default:
+		return "unknown item"
+	}
+}

--- a/internal/notify/mediacheck.go
+++ b/internal/notify/mediacheck.go
@@ -8,8 +8,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
-// MediaCheckProblem describes a single problematic playlist item (a file that is
-// missing, ambiguous, or could not be checked).
+// MediaCheckProblem is a missing, ambiguous, or unchecked playlist item.
 type MediaCheckProblem struct {
 	Artist      string
 	TrackTitle  string
@@ -19,8 +18,7 @@ type MediaCheckProblem struct {
 	DBReference string
 }
 
-// MediaCheckResult contains the information needed to send a media file check
-// notification.
+// MediaCheckResult is the notification payload for scheduled media file checks.
 type MediaCheckResult struct {
 	CheckedAt time.Time
 	Scope     string
@@ -28,8 +26,7 @@ type MediaCheckResult struct {
 	Problems  []MediaCheckProblem
 }
 
-// NotifyMediaCheckResult sends a failure email when a scheduled check finds
-// problems and a recovery email on the first clean run afterwards.
+// NotifyMediaCheckResult updates the media-file alert/recovery state.
 func (s *NotificationService) NotifyMediaCheckResult(r *MediaCheckResult) {
 	if r == nil {
 		return

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -48,6 +48,7 @@ type NotificationService struct {
 	prevBackupFailed      bool
 	prevHealthAlertActive bool
 	prevS3Failed          bool
+	prevMediaCheckFailed  bool
 	stateMu               sync.Mutex
 
 	// Last notification send error (for health endpoint)

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -13,12 +13,10 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
 )
 
-// timeFormat is the standard timestamp format for notification emails.
+// timeFormat is the timestamp layout used in notification emails.
 const timeFormat = "2006-01-02 15:04:05"
 
-// Input types for notification methods (avoids circular dependency with service package).
-
-// BackupResult contains the information needed to send a backup notification.
+// BackupResult is the notification payload for a backup run.
 type BackupResult struct {
 	Success   bool
 	StartedAt *time.Time
@@ -27,13 +25,13 @@ type BackupResult struct {
 	Error     string
 }
 
-// S3SyncResult contains the information needed to send an S3 sync notification.
+// S3SyncResult is the notification payload for S3 backup synchronization.
 type S3SyncResult struct {
 	Synced bool
 	Error  string
 }
 
-// NotificationService handles email notifications for backup, health check, and S3 sync events.
+// NotificationService sends transition-based operational email alerts.
 type NotificationService struct {
 	config     *config.Config
 	runner     *async.Runner
@@ -60,7 +58,7 @@ type NotificationService struct {
 	expiryChecker *SecretExpiryChecker
 }
 
-// New creates a new NotificationService.
+// New returns a notification service for cfg.
 func New(cfg *config.Config) *NotificationService {
 	emailCfg := &cfg.Notifications.Email
 	svc := &NotificationService{
@@ -79,8 +77,7 @@ func New(cfg *config.Config) *NotificationService {
 	return svc
 }
 
-// notifyOnTransition sends a failure email on first failure, and a recovery email on first success
-// after a failure. The prevFailed pointer tracks the state for this notification type.
+// notifyOnTransition sends first-failure and first-recovery emails for one signal.
 func (s *NotificationService) notifyOnTransition(
 	prevFailed *bool,
 	isFailing bool,
@@ -113,7 +110,7 @@ func (s *NotificationService) notifyOnTransition(
 	s.stateMu.Unlock()
 }
 
-// NotifyBackupResult sends a failure or recovery email based on the backup result.
+// NotifyBackupResult updates the backup alert/recovery state.
 func (s *NotificationService) NotifyBackupResult(r *BackupResult) {
 	if r == nil {
 		return
@@ -124,7 +121,7 @@ func (s *NotificationService) NotifyBackupResult(r *BackupResult) {
 	)
 }
 
-// NotifyS3SyncResult sends a failure or recovery email based on the S3 sync result.
+// NotifyS3SyncResult updates the S3 sync alert/recovery state.
 func (s *NotificationService) NotifyS3SyncResult(filename string, r *S3SyncResult) {
 	if r == nil {
 		return
@@ -142,9 +139,8 @@ func (s *NotificationService) LastError() (string, *time.Time) {
 	return s.lastError, s.lastErrorAt
 }
 
-// SecretExpiry returns the cached secret expiry information, or nil if not configured.
-// This method never blocks on external API calls - it returns cached data and triggers
-// an async refresh if the cache is stale.
+// SecretExpiry returns cached secret-expiry information, or nil when disabled.
+// It never blocks on Graph API calls; stale cache data triggers an async refresh.
 func (s *NotificationService) SecretExpiry() *SecretExpiryInfo {
 	if s.expiryChecker == nil {
 		return nil
@@ -153,15 +149,14 @@ func (s *NotificationService) SecretExpiry() *SecretExpiryInfo {
 	return &info
 }
 
-// StartExpiryChecker triggers an initial background refresh of the secret expiry info.
-// Call this at startup to populate the cache before the first health check.
+// StartExpiryChecker warms the secret-expiry cache in the background.
 func (s *NotificationService) StartExpiryChecker() {
 	if s.expiryChecker != nil {
 		go s.expiryChecker.refresh()
 	}
 }
 
-// ValidateAuth verifies that the notification credentials are valid.
+// ValidateAuth verifies Microsoft Graph credentials and mailbox access.
 func (s *NotificationService) ValidateAuth() error {
 	client, err := s.getOrCreateClient()
 	if err != nil {
@@ -170,7 +165,7 @@ func (s *NotificationService) ValidateAuth() error {
 	return client.ValidateAuth()
 }
 
-// SendTestEmail sends a synchronous test email to validate the notification setup.
+// SendTestEmail sends a synchronous probe message to all configured recipients.
 // The context controls cancellation of the request.
 func (s *NotificationService) SendTestEmail(ctx context.Context) error {
 	client, err := s.getOrCreateClient()
@@ -187,14 +182,12 @@ func (s *NotificationService) SendTestEmail(ctx context.Context) error {
 	return client.SendMail(ctx, s.recipients, subject, body)
 }
 
-// Close stops the notification service runner.
+// Close waits for tracked background notification work to finish.
 func (s *NotificationService) Close() {
 	s.runner.Close()
 }
 
-// Internal methods.
-
-// getOrCreateClient returns a cached or newly created GraphClient.
+// getOrCreateClient returns the cached Graph client or builds one for current config.
 func (s *NotificationService) getOrCreateClient() (*GraphClient, error) {
 	s.clientMu.Lock()
 	defer s.clientMu.Unlock()
@@ -233,7 +226,7 @@ func (s *NotificationService) sendAsync(subject, body string) {
 // sendTimeout is the maximum time allowed for sending a notification email.
 const sendTimeout = 2 * time.Minute
 
-// send sends an email and tracks any errors.
+// send delivers one email and records the last failure for health reporting.
 func (s *NotificationService) send(subject, body string) {
 	client, err := s.getOrCreateClient()
 	if err != nil {
@@ -262,8 +255,6 @@ func (s *NotificationService) trackError(err error) {
 	now := time.Now()
 	s.lastErrorAt = &now
 }
-
-// Email formatting.
 
 func (s *NotificationService) formatBackupFailure(r *BackupResult) (subject, body string) {
 	subject = "[ERROR] Backup failed - Aeron Toolbox"

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
-// BackupService handles database backup operations.
+// BackupService creates, validates, lists, and deletes PostgreSQL backups.
 type BackupService struct {
 	repo       *database.Repository
 	config     *config.Config
@@ -39,7 +39,7 @@ type BackupService struct {
 	status   *BackupStatus
 }
 
-// BackupStatus represents the status of the last backup operation.
+// BackupStatus is the latest backup run snapshot.
 type BackupStatus struct {
 	Running   bool          `json:"running"`
 	StartedAt *time.Time    `json:"started_at,omitempty"`
@@ -50,13 +50,13 @@ type BackupStatus struct {
 	S3Sync    *S3SyncStatus `json:"s3_sync,omitempty"`
 }
 
-// S3SyncStatus represents the status of S3 synchronization.
+// S3SyncStatus is the latest remote sync result for a backup.
 type S3SyncStatus struct {
 	Synced bool   `json:"synced"`
 	Error  string `json:"error,omitempty"`
 }
 
-// newBackupService creates a BackupService with resolved tool paths and optional S3 client.
+// newBackupService resolves backup tooling and optional S3 state.
 func newBackupService(
 	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
 ) (*BackupService, error) {
@@ -68,7 +68,6 @@ func newBackupService(
 	}
 
 	if cfg.Backup.Enabled {
-		// Resolve required external tools at startup
 		pgDumpPath, err := resolveToolPath(cfg.Backup.PgDumpPath, "pg_dump")
 		if err != nil {
 			return nil, err
@@ -92,7 +91,6 @@ func newBackupService(
 		}
 		svc.backupRoot = root
 
-		// Initialize S3 backend if configured
 		s3svc, err := newS3Service(&cfg.Backup.S3)
 		if err != nil {
 			return nil, err
@@ -103,19 +101,17 @@ func newBackupService(
 	return svc, nil
 }
 
-// Close stops the backup service and waits for any running backup to complete.
+// Close waits for any running backup or tracked follow-up work.
 func (s *BackupService) Close() {
 	s.runner.Close()
 }
 
-// Types.
-
-// BackupRequest represents the request body for backup operations.
+// BackupRequest selects optional backup parameters.
 type BackupRequest struct {
 	Compression int `json:"compression"`
 }
 
-// BackupInfo represents metadata about an existing backup file.
+// BackupInfo describes one local backup file.
 type BackupInfo struct {
 	Filename      string    `json:"filename"`
 	Size          int64     `json:"size_bytes"`
@@ -123,14 +119,12 @@ type BackupInfo struct {
 	CreatedAt     time.Time `json:"created_at"`
 }
 
-// BackupListResponse represents the response for listing backups.
+// BackupListResponse is the backup directory summary.
 type BackupListResponse struct {
 	Backups    []BackupInfo `json:"backups"`
 	TotalSize  int64        `json:"total_size_bytes"`
 	TotalCount int          `json:"total_count"`
 }
-
-// Helpers.
 
 const (
 	backupPrefix = "aeron-backup-"
@@ -139,7 +133,7 @@ const (
 
 var safeBackupFilenamePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-.]+$`)
 
-// resolveToolPath returns the absolute path to an external tool, checking custom paths first.
+// resolveToolPath returns the configured tool path or resolves toolName from PATH.
 func resolveToolPath(customPath, toolName string) (string, error) {
 	if customPath != "" {
 		if _, err := os.Stat(customPath); err != nil {
@@ -155,7 +149,7 @@ func resolveToolPath(customPath, toolName string) (string, error) {
 	return path, nil
 }
 
-// checkEnabled returns an error if backup functionality is disabled.
+// checkEnabled rejects backup operations when backup support is not initialized.
 func (s *BackupService) checkEnabled() error {
 	if !s.config.Backup.Enabled || s.backupRoot == nil {
 		return types.NewConfigError("backup.enabled", "backup functionality is not enabled")
@@ -163,7 +157,7 @@ func (s *BackupService) checkEnabled() error {
 	return nil
 }
 
-// validateBackupFilename ensures the filename has valid characters, expected prefix and .dump extension.
+// validateBackupFilename accepts only managed .dump backup filenames.
 func validateBackupFilename(filename string) error {
 	if !safeBackupFilenamePattern.MatchString(filename) {
 		return types.NewValidationError("filename", "invalid filename")
@@ -174,7 +168,7 @@ func validateBackupFilename(filename string) error {
 	return nil
 }
 
-// buildPgDumpArgs constructs pg_dump command-line arguments for the given settings.
+// buildPgDumpArgs constructs the pg_dump arguments for the configured database.
 func (s *BackupService) buildPgDumpArgs(compression int) []string {
 	return []string{
 		"--format=custom",
@@ -188,7 +182,7 @@ func (s *BackupService) buildPgDumpArgs(compression int) []string {
 	}
 }
 
-// compressionLevel returns a valid compression level (0-9), applying defaults and validation.
+// compressionLevel applies the default and validates the 0-9 pg_dump range.
 func (s *BackupService) compressionLevel(requested int) (int, error) {
 	level := requested
 	if level == 0 {
@@ -200,9 +194,9 @@ func (s *BackupService) compressionLevel(requested int) (int, error) {
 	return level, nil
 }
 
-// validateBackupFile checks backup file integrity using pg_restore --list.
+// validateBackupFile checks backup integrity with pg_restore --list.
 func (s *BackupService) validateBackupFile(ctx context.Context, filePath string) error {
-	//nolint:gosec // pgRestorePath is from validated config
+	//nolint:gosec // G204: pgRestorePath is resolved from config/PATH at startup.
 	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list", filePath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -215,13 +209,13 @@ func (s *BackupService) validateBackupFile(ctx context.Context, filePath string)
 	return nil
 }
 
-// generateBackupFilename creates a timestamped filename with .dump extension.
+// generateBackupFilename returns a managed timestamped .dump filename.
 func generateBackupFilename() string {
 	timestamp := time.Now().Format("2006-01-02-150405")
 	return fmt.Sprintf("%s%s%s", backupPrefix, timestamp, backupSuffix)
 }
 
-// executePgDump runs pg_dump and returns file info on success, cleaning up on failure.
+// executePgDump runs pg_dump and removes the partial file on failure.
 func (s *BackupService) executePgDump(
 	ctx context.Context, pgDumpPath, filename, fullPath string, args []string,
 ) (os.FileInfo, time.Duration, error) {
@@ -266,8 +260,6 @@ func (s *BackupService) executePgDump(
 	return fileInfo, duration, nil
 }
 
-// Public methods.
-
 // Start initiates a database backup in the background. Returns an error if
 // validation fails or a backup is already running.
 func (s *BackupService) Start(req BackupRequest) error {
@@ -282,7 +274,7 @@ func (s *BackupService) Start(req BackupRequest) error {
 		return types.NewConflictError("backup", "backup already in progress")
 	}
 
-	// Initialize status before spawning goroutine to prevent race condition
+	// Initialize status before spawning the goroutine to avoid a race.
 	s.setStatusStarted()
 
 	s.runner.Go(func() {
@@ -295,7 +287,7 @@ func (s *BackupService) Start(req BackupRequest) error {
 	return nil
 }
 
-// Run executes a database backup synchronously, blocking until completion.
+// Run executes a database backup synchronously.
 func (s *BackupService) Run(ctx context.Context, req BackupRequest) error {
 	if !s.runner.TryStart() {
 		return types.NewConflictError("backup", "backup already in progress")
@@ -307,8 +299,8 @@ func (s *BackupService) Run(ctx context.Context, req BackupRequest) error {
 	return s.execute(ctx, req)
 }
 
-// execute creates a database backup and synchronizes it to S3 if configured.
-// Note: Caller must call setStatusStarted() before invoking this method.
+// execute creates a backup and starts optional S3 synchronization.
+// The caller must publish the started status first.
 func (s *BackupService) execute(ctx context.Context, req BackupRequest) error {
 	if err := s.checkEnabled(); err != nil {
 		s.setStatusDone(false, "", err.Error())
@@ -337,7 +329,6 @@ func (s *BackupService) execute(ctx context.Context, req BackupRequest) error {
 		return err
 	}
 
-	// Validate backup file integrity
 	slog.Info("Validating backup", "filename", filename)
 
 	validateCtx, validateCancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -387,7 +378,7 @@ func (s *BackupService) execute(ctx context.Context, req BackupRequest) error {
 	return nil
 }
 
-// Status returns the current state and result of the last backup operation.
+// Status returns a snapshot of the latest backup state.
 func (s *BackupService) Status() *BackupStatus {
 	s.statusMu.RLock()
 	defer s.statusMu.RUnlock()
@@ -439,7 +430,7 @@ func (s *BackupService) setS3SyncStatus(synced bool, errMsg string) {
 	}
 }
 
-// notifyBackup sends a backup notification based on the current status.
+// notifyBackup sends the current backup status to the notifier.
 func (s *BackupService) notifyBackup() {
 	st := s.Status()
 	s.notify.NotifyBackupResult(&notify.BackupResult{
@@ -451,7 +442,7 @@ func (s *BackupService) notifyBackup() {
 	})
 }
 
-// List returns metadata for all backup files in the backup directory.
+// List returns metadata for managed backup files in the backup directory.
 func (s *BackupService) List() (*BackupListResponse, error) {
 	if err := s.checkEnabled(); err != nil {
 		return nil, err
@@ -508,7 +499,7 @@ func (s *BackupService) List() (*BackupListResponse, error) {
 	}, nil
 }
 
-// Delete removes a backup file from local storage and S3 if configured.
+// Delete removes a managed backup locally and schedules remote deletion.
 func (s *BackupService) Delete(filename string) error {
 	if err := s.checkEnabled(); err != nil {
 		return err
@@ -546,7 +537,7 @@ func (s *BackupService) Delete(filename string) error {
 	return nil
 }
 
-// GetFilePath returns the absolute path to a backup file.
+// GetFilePath validates filename and returns its absolute local path.
 func (s *BackupService) GetFilePath(filename string) (string, error) {
 	if err := s.checkEnabled(); err != nil {
 		return "", err
@@ -563,14 +554,14 @@ func (s *BackupService) GetFilePath(filename string) (string, error) {
 	return filepath.Join(s.config.Backup.GetPath(), filename), nil
 }
 
-// ValidationResult represents the result of on-demand backup validation.
+// ValidationResult is the on-demand backup validation result.
 type ValidationResult struct {
 	Filename string `json:"filename"`
 	Valid    bool   `json:"valid"`
 	Error    string `json:"error,omitempty"`
 }
 
-// Validate checks backup file integrity using pg_restore --list.
+// Validate checks a managed backup with pg_restore --list.
 func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
 	fullPath, err := s.GetFilePath(filename)
 	if err != nil {
@@ -594,9 +585,7 @@ func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
 	return result, nil
 }
 
-// Background cleanup.
-
-// cleanupOldBackups removes files exceeding retention days or max backup count.
+// cleanupOldBackups removes backups exceeding age or count retention.
 func (s *BackupService) cleanupOldBackups() {
 	backups, err := s.List()
 	if err != nil {

--- a/internal/service/filemonitor.go
+++ b/internal/service/filemonitor.go
@@ -33,7 +33,7 @@ var nowFunc = time.Now
 // A radio config typically lists a handful of files, so 8 is plenty.
 const statCheckParallelism = 8
 
-// FileCheckErrorKind categorises why a file check failed.
+// FileCheckErrorKind classifies why a file check failed.
 type FileCheckErrorKind string
 
 const (
@@ -73,7 +73,7 @@ type statInFlight struct {
 	result      statResult
 }
 
-// FileMonitorService monitors files on disk for staleness based on modification time.
+// FileMonitorService checks configured files for staleness and alert transitions.
 type FileMonitorService struct {
 	config *config.Config
 	notify fileMonitorNotifier
@@ -113,8 +113,7 @@ type FileMonitorService struct {
 	completedRunID uint64
 }
 
-// FileMonitorStatus contains the results of the most recent file monitor check
-// plus the live run-state for the service.
+// FileMonitorStatus combines the latest check results with live run state.
 //
 // Polling recipe after POST /check: read run_id from the response (myRunID),
 // then poll /status until completed_run_id >= myRunID && running == false.
@@ -131,7 +130,7 @@ type FileMonitorStatus struct {
 	Checks          []FileCheckResult `json:"checks"`
 }
 
-// FileCheckResult contains the result of checking a single file.
+// FileCheckResult is the API verdict for one configured file.
 //
 // Five valid state profiles exist:
 //   - File exists:        FileExists=true,  FileAgeMinutes/LastModified set, Error empty
@@ -220,7 +219,7 @@ func (s *FileMonitorService) executeRun() *FileMonitorStatus {
 // only graceRunDone is set; per-path alertState is not touched), active-window
 // alert suppression (IsStale is preserved transparently; only alert-state
 // transitions and notifications are suppressed), and alert/recovery transitions.
-// Note: mutates results[i].InAlert in-place via the shared slice backing array.
+// It mutates results[i].InAlert in-place via the shared slice backing array.
 // Returns new alerts and recoveries for notification dispatch (which must happen
 // outside the lock).
 func (s *FileMonitorService) processAlertStates(
@@ -271,7 +270,7 @@ func (s *FileMonitorService) processAlertStates(
 	return newAlerts, newRecoveries
 }
 
-// dispatchNotifications sends batched alert and recovery notifications.
+// dispatchNotifications sends alert and recovery batches outside state locks.
 func (s *FileMonitorService) dispatchNotifications(
 	newAlerts, newRecoveries []notify.FileAlertResult,
 ) {
@@ -344,7 +343,7 @@ func (s *FileMonitorService) AlertingCount() int {
 	return s.countChecksLocked(func(c FileCheckResult) bool { return c.InAlert })
 }
 
-// countChecksLocked counts results satisfying pred. Caller must hold publishedMu for reading.
+// countChecksLocked counts results satisfying pred; caller holds publishedMu for reading.
 func (s *FileMonitorService) countChecksLocked(pred func(FileCheckResult) bool) int {
 	if s.lastCheck == nil {
 		return 0
@@ -485,7 +484,7 @@ func (s *FileMonitorService) startOrJoinFlight(path string, now time.Time) (*sta
 	return flight, true
 }
 
-// timeoutResult builds a synthetic stale-with-timeout result for a hung stat.
+// timeoutResult builds a stale result for a stat that exceeded its budget.
 func (s *FileMonitorService) timeoutResult(
 	check config.FileMonitorCheckConfig, flight *statInFlight, timeout time.Duration,
 ) FileCheckResult {
@@ -504,7 +503,7 @@ func (s *FileMonitorService) timeoutResult(
 	}
 }
 
-// buildResult turns an os.Stat outcome into a FileCheckResult.
+// buildResult maps an os.Stat outcome to the API result shape.
 func (s *FileMonitorService) buildResult(
 	check config.FileMonitorCheckConfig, info os.FileInfo, err error, now time.Time,
 ) FileCheckResult {
@@ -564,7 +563,7 @@ func (s *FileMonitorService) buildResult(
 	return result
 }
 
-// toAlertResult converts a check result to a notification alert result.
+// toAlertResult converts a check result to a notification payload.
 func toAlertResult(
 	check config.FileMonitorCheckConfig, result *FileCheckResult, checkedAt time.Time,
 ) notify.FileAlertResult {

--- a/internal/service/maintenance.go
+++ b/internal/service/maintenance.go
@@ -14,14 +14,14 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
-// MaintenanceService handles database health monitoring.
+// MaintenanceService inspects PostgreSQL health and emits maintenance alerts.
 type MaintenanceService struct {
 	repo   *database.Repository
 	config *config.Config
 	notify *notify.NotificationService
 }
 
-// newMaintenanceService creates a new MaintenanceService instance.
+// newMaintenanceService returns a maintenance service using repo, cfg, and notifySvc.
 func newMaintenanceService(
 	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
 ) *MaintenanceService {
@@ -36,9 +36,7 @@ func newMaintenanceService(
 // are found. It is stripped before passing results to the notification system.
 const noIssuesDetected = "No issues detected"
 
-// Health types.
-
-// DatabaseHealth represents the overall health status of the database.
+// DatabaseHealth is the API health report for the configured database.
 type DatabaseHealth struct {
 	DatabaseName       string                   `json:"database_name"`
 	DatabaseVersion    string                   `json:"database_version"`
@@ -55,7 +53,7 @@ type DatabaseHealth struct {
 	CheckedAt          time.Time                `json:"checked_at"`
 }
 
-// TableHealth represents health statistics for a single table.
+// TableHealth is the maintenance snapshot for one table.
 type TableHealth struct {
 	Name            string     `json:"name"`
 	RowCount        int64      `json:"row_count"`
@@ -80,7 +78,7 @@ type TableHealth struct {
 	NeedsAnalyze    bool       `json:"needs_analyze"`
 }
 
-// tableHealthRow contains health statistics and size information for a database table.
+// tableHealthRow is the raw PostgreSQL statistics row for one table.
 type tableHealthRow struct {
 	TableName       string     `db:"table_name"`
 	LiveTuples      int64      `db:"live_tuples"`
@@ -98,9 +96,7 @@ type tableHealthRow struct {
 	ToastSize       int64      `db:"toast_size"`
 }
 
-// Health operations.
-
-// GetHealth retrieves comprehensive database health information.
+// GetHealth collects database, table, connection, and query health.
 func (s *MaintenanceService) GetHealth(ctx context.Context) (*DatabaseHealth, error) {
 	schema := s.repo.Schema()
 	health := &DatabaseHealth{
@@ -187,7 +183,7 @@ func (s *MaintenanceService) CheckHealthAndAlert(ctx context.Context) {
 	s.notify.NotifyHealthAlert(result)
 }
 
-// getDatabaseSize returns the total database size.
+// getDatabaseSize returns the current database size in raw and display forms.
 func (s *MaintenanceService) getDatabaseSize(ctx context.Context) (size string, sizeRaw int64, err error) {
 	err = s.repo.DB().GetContext(ctx, &sizeRaw, "SELECT pg_database_size(current_database())")
 	if err != nil {
@@ -196,7 +192,7 @@ func (s *MaintenanceService) getDatabaseSize(ctx context.Context) (size string, 
 	return util.FormatBytes(sizeRaw), sizeRaw, nil
 }
 
-// getConnectionUsage returns the current connection count, maximum, and usage percentage.
+// getConnectionUsage returns active connections, max_connections, and usage percent.
 func (s *MaintenanceService) getConnectionUsage(ctx context.Context) (active, maxConns int, pct float64, err error) {
 	if err := s.repo.DB().GetContext(ctx, &active,
 		"SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()"); err != nil {
@@ -248,7 +244,7 @@ func (s *MaintenanceService) getLongRunningQueries(ctx context.Context) ([]types
 	return queries, nil
 }
 
-// getTableHealth retrieves health statistics for all tables in the schema.
+// getTableHealth retrieves maintenance statistics for all user tables in schema.
 func (s *MaintenanceService) getTableHealth(ctx context.Context) ([]TableHealth, error) {
 	schema := s.repo.Schema()
 	query := `
@@ -288,8 +284,7 @@ func (s *MaintenanceService) getTableHealth(ctx context.Context) ([]TableHealth,
 	return tables, nil
 }
 
-// convertTableRow maps a raw database statistics row to a TableHealth struct,
-// computing derived fields like dead-tuple percentage (0–100) and maintenance flags.
+// convertTableRow maps raw PostgreSQL stats and derives maintenance flags.
 func convertTableRow(row *tableHealthRow, cfg *config.MaintenanceConfig) TableHealth {
 	table := TableHealth{
 		Name:            row.TableName,
@@ -327,9 +322,7 @@ func convertTableRow(row *tableHealthRow, cfg *config.MaintenanceConfig) TableHe
 	return table
 }
 
-// Recommendations.
-
-// generateRecommendations returns recommendations for the entire database health report.
+// generateRecommendations returns operator actions for the health report.
 func (s *MaintenanceService) generateRecommendations(health *DatabaseHealth) []string {
 	var recs []string
 

--- a/internal/service/media.go
+++ b/internal/service/media.go
@@ -11,13 +11,13 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// MediaService handles artist, track, image, and playlist operations.
+// MediaService coordinates artist, track, image, and playlist workflows.
 type MediaService struct {
 	repo   *database.Repository
 	config *config.Config
 }
 
-// newMediaService creates a MediaService with the provided repository and configuration.
+// newMediaService returns a media service using repo and cfg.
 func newMediaService(repo *database.Repository, cfg *config.Config) *MediaService {
 	return &MediaService{
 		repo:   repo,
@@ -25,35 +25,29 @@ func newMediaService(repo *database.Repository, cfg *config.Config) *MediaServic
 	}
 }
 
-// Artist operations.
-
-// GetArtist retrieves an artist by ID.
+// GetArtist returns artist details for id.
 func (s *MediaService) GetArtist(ctx context.Context, id string) (*database.ArtistDetails, error) {
 	return s.repo.GetArtist(ctx, id)
 }
 
-// Track operations.
-
-// GetTrack retrieves a track by ID.
+// GetTrack returns track details for id.
 func (s *MediaService) GetTrack(ctx context.Context, id string) (*database.TrackDetails, error) {
 	return s.repo.GetTrack(ctx, id)
 }
 
-// Image operations.
-
-// GetImage retrieves the image for an entity.
+// GetImage returns stored artwork for an artist or track.
 func (s *MediaService) GetImage(ctx context.Context, entityType types.EntityType, id string) ([]byte, error) {
 	table := types.Table(entityType)
 	return s.repo.GetImage(ctx, table, id)
 }
 
-// DeleteImage removes the image from an entity.
+// DeleteImage clears stored artwork for an artist or track.
 func (s *MediaService) DeleteImage(ctx context.Context, entityType types.EntityType, id string) error {
 	table := types.Table(entityType)
 	return s.repo.DeleteImage(ctx, table, id)
 }
 
-// ImageUploadParams contains the parameters for image upload operations.
+// ImageUploadParams selects the target entity and exactly one image source.
 type ImageUploadParams struct {
 	EntityType types.EntityType
 	ID         string
@@ -61,7 +55,7 @@ type ImageUploadParams struct {
 	ImageData  []byte
 }
 
-// ImageUploadResult contains the results of an image upload operation.
+// ImageUploadResult reports the stored entity label and optimization outcome.
 type ImageUploadResult struct {
 	ArtistName           string
 	TrackTitle           string
@@ -70,7 +64,7 @@ type ImageUploadResult struct {
 	SizeReductionPercent float64
 }
 
-// UploadImage downloads, resizes, optimizes, and stores an image for an artist or track.
+// UploadImage validates, optimizes, and stores artwork for an artist or track.
 func (s *MediaService) UploadImage(ctx context.Context, params *ImageUploadParams) (*ImageUploadResult, error) {
 	slog.Debug("Image upload started",
 		"entityType", params.EntityType,
@@ -146,16 +140,14 @@ func (s *MediaService) UploadImage(ctx context.Context, params *ImageUploadParam
 	}, nil
 }
 
-// Statistics operations.
-
-// ImageStats represents statistics about images in the database.
+// ImageStats reports image coverage for one entity type.
 type ImageStats struct {
 	Total         int
 	WithImages    int
 	WithoutImages int
 }
 
-// GetStatistics returns image statistics for entities of the specified type.
+// GetStatistics returns image coverage for artists or tracks.
 func (s *MediaService) GetStatistics(ctx context.Context, entityType types.EntityType) (*ImageStats, error) {
 	if err := validateEntityType(entityType); err != nil {
 		return nil, err
@@ -173,13 +165,13 @@ func (s *MediaService) GetStatistics(ctx context.Context, entityType types.Entit
 	}, nil
 }
 
-// DeleteResult contains the results of a bulk image deletion operation.
+// DeleteResult reports a bulk artwork deletion.
 type DeleteResult struct {
 	CountBefore  int
 	DeletedCount int64
 }
 
-// DeleteAllImages removes all images from all entities of the specified type.
+// DeleteAllImages clears all artwork for one entity type.
 func (s *MediaService) DeleteAllImages(ctx context.Context, entityType types.EntityType) (*DeleteResult, error) {
 	if err := validateEntityType(entityType); err != nil {
 		return nil, err
@@ -204,9 +196,7 @@ func (s *MediaService) DeleteAllImages(ctx context.Context, entityType types.Ent
 	return &DeleteResult{CountBefore: count, DeletedCount: deleted}, nil
 }
 
-// Playlist operations.
-
-// DefaultPlaylistOptions returns playlist query options with sensible defaults.
+// DefaultPlaylistOptions returns the API defaults for playlist queries.
 func DefaultPlaylistOptions() database.PlaylistOptions {
 	return database.PlaylistOptions{
 		ExportTypes: []int{},
@@ -214,20 +204,20 @@ func DefaultPlaylistOptions() database.PlaylistOptions {
 	}
 }
 
-// GetPlaylist retrieves played tracks for a date or block with filtering and pagination.
+// GetPlaylist returns block-scoped playlist items with filtering and pagination.
 func (s *MediaService) GetPlaylist(
 	ctx context.Context, opts *database.PlaylistOptions,
 ) ([]database.PlaylistItem, error) {
 	return s.repo.GetPlaylist(ctx, opts)
 }
 
-// PlaylistBlockWithTracks represents a playlist block with its associated tracks.
+// PlaylistBlockWithTracks combines a block with its scheduled items.
 type PlaylistBlockWithTracks struct {
 	database.PlaylistBlock
 	Tracks []database.PlaylistItem `json:"tracks"`
 }
 
-// GetPlaylistWithTracks retrieves all playlist blocks for a date with their tracks.
+// GetPlaylistWithTracks returns date-scoped blocks with their items.
 func (s *MediaService) GetPlaylistWithTracks(ctx context.Context, date string) ([]PlaylistBlockWithTracks, error) {
 	blocks, tracksByBlock, err := s.repo.GetPlaylistWithTracks(ctx, date)
 	if err != nil {
@@ -249,9 +239,7 @@ func (s *MediaService) GetPlaylistWithTracks(ctx context.Context, date string) (
 	return result, nil
 }
 
-// Validation helpers.
-
-// validateEntityType ensures the entity type is either artist or track.
+// validateEntityType accepts only artist and track operations.
 func validateEntityType(entityType types.EntityType) error {
 	if entityType != types.EntityTypeArtist && entityType != types.EntityTypeTrack {
 		return types.NewValidationError("entityType",
@@ -260,7 +248,7 @@ func validateEntityType(entityType types.EntityType) error {
 	return nil
 }
 
-// validateImageUploadParams ensures parameters contain exactly one image source.
+// validateImageUploadParams requires a valid entity and exactly one image source.
 func validateImageUploadParams(params *ImageUploadParams) error {
 	if err := validateEntityType(params.EntityType); err != nil {
 		return err

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -26,13 +26,12 @@ const mediaCheckParallelism = 8
 // against individually frozen files.
 const mediaCheckRunTimeout = 30 * time.Minute
 
-// mediaCheckNotifier is the slice of the notification service used by the media
-// file check. Defined as an interface so the service can be tested with a fake.
+// mediaCheckNotifier is the notification subset required by the media file check.
 type mediaCheckNotifier interface {
 	NotifyMediaCheckResult(*notify.MediaCheckResult)
 }
 
-// MediaCheckScope echoes the resolved scope of a check run.
+// MediaCheckScope echoes the effective scope of a check run.
 type MediaCheckScope struct {
 	Date               string `json:"date,omitempty"`
 	From               string `json:"from,omitempty"`
@@ -53,7 +52,7 @@ type MediaCheckSummary struct {
 	Errors      int `json:"errors"`
 }
 
-// MediaCheckItemResult is the per-item outcome reported to operators.
+// MediaCheckItemResult is one operator-facing item verdict.
 type MediaCheckItemResult struct {
 	TrackID      string          `json:"trackid"`
 	Artist       string          `json:"artist"`
@@ -69,7 +68,7 @@ type MediaCheckItemResult struct {
 	Error        string          `json:"error,omitempty"`
 }
 
-// MediaCheckResult is the full result of one check run.
+// MediaCheckResult is the published result of one check run.
 type MediaCheckResult struct {
 	CheckedAt time.Time              `json:"checked_at"`
 	Scope     MediaCheckScope        `json:"scope"`
@@ -91,9 +90,8 @@ type MediaCheckStatus struct {
 	Result         *MediaCheckResult `json:"result"`
 }
 
-// MediaFileCheckService verifies that audio files referenced by the playlist
-// exist on disk. Runs are single-flighted through a Runner so a manual API
-// trigger and a scheduled run can never overlap.
+// MediaFileCheckService verifies that playlist audio references exist on disk.
+// Runs are single-flighted so manual and scheduled checks cannot overlap.
 type MediaFileCheckService struct {
 	repo   *database.Repository
 	config *config.Config
@@ -109,7 +107,7 @@ type MediaFileCheckService struct {
 	completedRunID uint64
 }
 
-// newMediaFileCheckService constructs the service.
+// newMediaFileCheckService returns a media file check service.
 func newMediaFileCheckService(
 	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
 ) *MediaFileCheckService {
@@ -140,8 +138,7 @@ func (s *MediaFileCheckService) TriggerScheduled() (uint64, error) {
 	return s.trigger(&opts, true)
 }
 
-// scheduledOptions builds the scope for scheduled runs: today (optionally
-// extended by LookaheadDays), honouring the configured voicetrack policy.
+// scheduledOptions builds the default scheduled scope and voicetrack policy.
 func (s *MediaFileCheckService) scheduledOptions() database.MediaCheckOptions {
 	return database.MediaCheckOptions{
 		LookaheadDays:      s.config.MediaFileCheck.LookaheadDays,
@@ -312,8 +309,6 @@ func (s *MediaFileCheckService) publishCompleted(result *MediaCheckResult, runID
 	}
 	s.completedRunID = runID
 }
-
-// Helpers (pure).
 
 func toMatchInput(item *database.MediaCheckItem) *matchInput {
 	return &matchInput{

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -38,6 +38,7 @@ type MediaCheckScope struct {
 	From               string `json:"from,omitempty"`
 	To                 string `json:"to,omitempty"`
 	BlockID            string `json:"block_id,omitempty"`
+	LookaheadDays      int    `json:"lookahead_days,omitempty"`
 	Limit              int    `json:"limit,omitempty"`
 	ExcludeVoicetracks bool   `json:"exclude_voicetracks"`
 }
@@ -139,10 +140,11 @@ func (s *MediaFileCheckService) TriggerScheduled() (uint64, error) {
 	return s.trigger(&opts, true)
 }
 
-// scheduledOptions builds the default scope for scheduled runs: the current day,
-// honouring the configured voicetrack policy.
+// scheduledOptions builds the scope for scheduled runs: today (optionally
+// extended by LookaheadDays), honouring the configured voicetrack policy.
 func (s *MediaFileCheckService) scheduledOptions() database.MediaCheckOptions {
 	return database.MediaCheckOptions{
+		LookaheadDays:      s.config.MediaFileCheck.LookaheadDays,
 		IncludeVoicetracks: s.config.MediaFileCheck.IncludeVoicetracks,
 	}
 }
@@ -383,6 +385,7 @@ func scopeFromOptions(opts *database.MediaCheckOptions) MediaCheckScope {
 		From:               opts.From,
 		To:                 opts.To,
 		BlockID:            opts.BlockID,
+		LookaheadDays:      opts.LookaheadDays,
 		Limit:              opts.Limit,
 		ExcludeVoicetracks: !opts.IncludeVoicetracks,
 	}
@@ -431,6 +434,8 @@ func scopeDescription(scope *MediaCheckScope) string {
 		parts = append(parts, "date "+scope.Date)
 	case scope.From != "" || scope.To != "":
 		parts = append(parts, fmt.Sprintf("range %s..%s", scope.From, scope.To))
+	case scope.LookaheadDays > 0:
+		parts = append(parts, fmt.Sprintf("today +%d days", scope.LookaheadDays))
 	default:
 		parts = append(parts, "today")
 	}

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -219,13 +219,13 @@ func (s *MediaFileCheckService) executeRun(ctx context.Context, opts *database.M
 	return result
 }
 
-// buildMatcher opens the drive-mapping roots and returns a matcher plus a
+// buildMatcher opens the drive-mount targets and returns a matcher plus a
 // cleanup function that closes them.
 func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *mediaMatcher, cleanup func()) {
 	mfc := &s.config.MediaFileCheck
 
-	driveRoots := make(map[string]*rootDir, len(mfc.DriveMappings))
-	for drive, dir := range mfc.DriveMappings {
+	driveRoots := make(map[string]*rootDir, len(mfc.DriveMounts))
+	for drive, dir := range mfc.DriveMounts {
 		key := normalizeDriveKey(drive)
 		if key == "" {
 			continue
@@ -234,7 +234,7 @@ func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *medi
 		root, err := os.OpenRoot(dir)
 		if err != nil {
 			rd.openErr = err
-			slog.Warn("Media file check: drive mapping root unavailable", "drive", key, "dir", dir, "error", err)
+			slog.Warn("Media file check: drive mount target unavailable", "drive", key, "dir", dir, "error", err)
 		} else {
 			rd.root = root
 		}
@@ -243,7 +243,7 @@ func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *medi
 
 	matcher = &mediaMatcher{
 		driveRoots:      driveRoots,
-		roots:           mfc.Roots,
+		searchDirs:      mfc.SearchDirs,
 		caseInsensitive: mfc.IsCaseInsensitive(),
 		statTimeout:     mfc.StatTimeout(),
 		ctx:             ctx,

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -197,10 +197,11 @@ func (s *MediaFileCheckService) executeRun(ctx context.Context, opts *database.M
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
-		result.Error = err.Error()
-	}
-	if err := ctx.Err(); err != nil && result.Error == "" {
+	// Workers embed their verdict in results and never return an error, so Wait
+	// only blocks for completion. A run-level failure surfaces as a context error
+	// (timeout/cancel) or an index-build error, in that precedence.
+	_ = g.Wait()
+	if err := ctx.Err(); err != nil {
 		result.Error = err.Error()
 	}
 	if err := matcher.indexErr(); err != nil && result.Error == "" {

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -1,0 +1,419 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/async"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/database"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/notify"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
+)
+
+// mediaCheckParallelism caps how many items are stat'd concurrently per run.
+const mediaCheckParallelism = 8
+
+// mediaCheckRunTimeout bounds a single check run end-to-end. It is generous
+// because indexing a large network share can be slow; per-stat timeouts guard
+// against individually frozen files.
+const mediaCheckRunTimeout = 30 * time.Minute
+
+// mediaCheckNotifier is the slice of the notification service used by the media
+// file check. Defined as an interface so the service can be tested with a fake.
+type mediaCheckNotifier interface {
+	NotifyMediaCheckResult(*notify.MediaCheckResult)
+}
+
+// MediaCheckScope echoes the resolved scope of a check run.
+type MediaCheckScope struct {
+	Date               string `json:"date,omitempty"`
+	From               string `json:"from,omitempty"`
+	To                 string `json:"to,omitempty"`
+	BlockID            string `json:"block_id,omitempty"`
+	Limit              int    `json:"limit,omitempty"`
+	ExcludeVoicetracks bool   `json:"exclude_voicetracks"`
+}
+
+// MediaCheckSummary aggregates item outcomes for a run.
+type MediaCheckSummary struct {
+	Total       int `json:"total"`
+	Present     int `json:"present"`
+	Missing     int `json:"missing"`
+	Ambiguous   int `json:"ambiguous"`
+	NoReference int `json:"no_reference"`
+	Errors      int `json:"errors"`
+}
+
+// MediaCheckItemResult is the per-item outcome reported to operators.
+type MediaCheckItemResult struct {
+	TrackID      string          `json:"trackid"`
+	Artist       string          `json:"artist"`
+	TrackTitle   string          `json:"tracktitle"`
+	StartTime    string          `json:"start_time"`
+	BlockID      string          `json:"block_id,omitempty"`
+	Block        string          `json:"block"`
+	Status       MediaFileStatus `json:"status"`
+	DBReference  string          `json:"db_reference"`
+	CheckedPaths []string        `json:"checked_paths"`
+	Matches      []string        `json:"matches"`
+	MatchType    string          `json:"match_type,omitempty"`
+	Error        string          `json:"error,omitempty"`
+}
+
+// MediaCheckResult is the full result of one check run.
+type MediaCheckResult struct {
+	CheckedAt time.Time              `json:"checked_at"`
+	Scope     MediaCheckScope        `json:"scope"`
+	Summary   MediaCheckSummary      `json:"summary"`
+	Items     []MediaCheckItemResult `json:"items"`
+	Error     string                 `json:"error,omitempty"`
+}
+
+// MediaCheckStatus is the run-state snapshot returned by the status endpoint.
+//
+// Polling recipe after POST /check: read run_id from the response, then poll
+// /status until completed_run_id >= run_id && running == false. The Result then
+// reflects your run (or a later one that overtook it).
+type MediaCheckStatus struct {
+	Running        bool              `json:"running"`
+	RunID          uint64            `json:"run_id"`
+	CompletedRunID uint64            `json:"completed_run_id"`
+	StartedAt      *time.Time        `json:"started_at,omitempty"`
+	Result         *MediaCheckResult `json:"result"`
+}
+
+// MediaFileCheckService verifies that audio files referenced by the playlist
+// exist on disk. Runs are single-flighted through a Runner so a manual API
+// trigger and a scheduled run can never overlap.
+type MediaFileCheckService struct {
+	repo   *database.Repository
+	config *config.Config
+	notify mediaCheckNotifier
+
+	runner *async.Runner
+
+	publishedMu    sync.RWMutex
+	lastResult     *MediaCheckResult
+	startedAt      *time.Time
+	runID          uint64
+	completedRunID uint64
+}
+
+// newMediaFileCheckService constructs the service.
+func newMediaFileCheckService(
+	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
+) *MediaFileCheckService {
+	return &MediaFileCheckService{
+		repo:   repo,
+		config: cfg,
+		notify: notifySvc,
+		runner: async.New(),
+	}
+}
+
+// Close waits for any running check to finish.
+func (s *MediaFileCheckService) Close() {
+	s.runner.Close()
+}
+
+// TriggerCheck starts an API-initiated check for the given scope in the
+// background. The result is published for /status but no email is sent, because
+// ad-hoc scopes would corrupt the scheduled-run alert transition state.
+func (s *MediaFileCheckService) TriggerCheck(opts *database.MediaCheckOptions) (uint64, error) {
+	return s.trigger(opts, false)
+}
+
+// TriggerScheduled starts the scheduled check (default scope: today) and emails
+// alerts on transitions. Used by the cron scheduler.
+func (s *MediaFileCheckService) TriggerScheduled() (uint64, error) {
+	opts := s.scheduledOptions()
+	return s.trigger(&opts, true)
+}
+
+// scheduledOptions builds the default scope for scheduled runs: the current day,
+// honouring the configured voicetrack policy.
+func (s *MediaFileCheckService) scheduledOptions() database.MediaCheckOptions {
+	return database.MediaCheckOptions{
+		IncludeVoicetracks: s.config.MediaFileCheck.IncludeVoicetracks,
+	}
+}
+
+// trigger acquires the single-flight lock and runs the check in the background.
+func (s *MediaFileCheckService) trigger(opts *database.MediaCheckOptions, notifyResult bool) (uint64, error) {
+	if !s.runner.TryStart() {
+		return 0, types.NewConflictError("media_file_check", "media file check already running")
+	}
+	runID := s.startNewRun()
+	s.runner.Go(func() {
+		ctx, cancel := s.runner.Context(mediaCheckRunTimeout)
+		defer cancel()
+
+		result := s.executeRun(ctx, opts)
+		s.publishCompleted(result, runID)
+		if notifyResult {
+			s.notify.NotifyMediaCheckResult(buildNotifyResult(result))
+		}
+	})
+	return runID, nil
+}
+
+// executeRun fetches the in-scope items and classifies each against the disk.
+func (s *MediaFileCheckService) executeRun(ctx context.Context, opts *database.MediaCheckOptions) *MediaCheckResult {
+	result := &MediaCheckResult{
+		CheckedAt: time.Now(),
+		Scope:     scopeFromOptions(opts),
+		Items:     []MediaCheckItemResult{},
+	}
+
+	items, err := s.repo.GetMediaCheckItems(ctx, opts)
+	if err != nil {
+		slog.Error("Media file check: failed to fetch items", "error", err)
+		result.Error = err.Error()
+		return result
+	}
+
+	matcher, closeMatcher := s.buildMatcher(ctx)
+	defer closeMatcher()
+
+	results := make([]MediaCheckItemResult, len(items))
+	var g errgroup.Group
+	g.SetLimit(mediaCheckParallelism)
+	for i := range items {
+		item := &items[i]
+		g.Go(func() error {
+			outcome := matcher.match(toMatchInput(item))
+			results[i] = toItemResult(item, &outcome)
+			return nil
+		})
+	}
+	_ = g.Wait() // workers never return errors; outcomes are embedded in results.
+
+	result.Items = results
+	result.Summary = summarize(results)
+
+	slog.Info("Media file check completed",
+		"total", result.Summary.Total,
+		"present", result.Summary.Present,
+		"missing", result.Summary.Missing,
+		"ambiguous", result.Summary.Ambiguous,
+		"no_reference", result.Summary.NoReference,
+		"errors", result.Summary.Errors)
+
+	return result
+}
+
+// buildMatcher opens the drive-mapping roots and returns a matcher plus a
+// cleanup function that closes them.
+func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *mediaMatcher, cleanup func()) {
+	mfc := &s.config.MediaFileCheck
+
+	driveRoots := make(map[string]*rootDir, len(mfc.DriveMappings))
+	for drive, dir := range mfc.DriveMappings {
+		key := normalizeDriveKey(drive)
+		if key == "" {
+			continue
+		}
+		rd := &rootDir{dir: dir}
+		root, err := os.OpenRoot(dir)
+		if err != nil {
+			rd.openErr = err
+			slog.Warn("Media file check: drive mapping root unavailable", "drive", key, "dir", dir, "error", err)
+		} else {
+			rd.root = root
+		}
+		driveRoots[key] = rd
+	}
+
+	matcher = &mediaMatcher{
+		driveRoots:      driveRoots,
+		roots:           mfc.Roots,
+		caseInsensitive: mfc.IsCaseInsensitive(),
+		statTimeout:     mfc.StatTimeout(),
+		ctx:             ctx,
+	}
+
+	cleanup = func() {
+		for _, rd := range driveRoots {
+			if rd.root != nil {
+				if err := rd.root.Close(); err != nil {
+					slog.Debug("Media file check: failed to close drive root", "dir", rd.dir, "error", err)
+				}
+			}
+		}
+	}
+	return matcher, cleanup
+}
+
+// Status returns a consistent snapshot of run-state plus the most recent result.
+func (s *MediaFileCheckService) Status() *MediaCheckStatus {
+	s.publishedMu.RLock()
+	defer s.publishedMu.RUnlock()
+
+	snap := &MediaCheckStatus{
+		Running:        s.runner.IsRunning(),
+		RunID:          s.runID,
+		CompletedRunID: s.completedRunID,
+		Result:         s.lastResult,
+	}
+	if s.startedAt != nil {
+		t := *s.startedAt
+		snap.StartedAt = &t
+	}
+	return snap
+}
+
+// ProblemCount returns the number of missing, ambiguous and errored items in the
+// most recent completed run. Used by the health endpoint.
+func (s *MediaFileCheckService) ProblemCount() int {
+	s.publishedMu.RLock()
+	defer s.publishedMu.RUnlock()
+	if s.lastResult == nil {
+		return 0
+	}
+	sum := s.lastResult.Summary
+	return sum.Missing + sum.Ambiguous + sum.Errors
+}
+
+func (s *MediaFileCheckService) startNewRun() uint64 {
+	s.publishedMu.Lock()
+	defer s.publishedMu.Unlock()
+	s.runID++
+	now := time.Now()
+	s.startedAt = &now
+	return s.runID
+}
+
+func (s *MediaFileCheckService) publishCompleted(result *MediaCheckResult, runID uint64) {
+	s.publishedMu.Lock()
+	defer s.publishedMu.Unlock()
+	s.lastResult = result
+	s.completedRunID = runID
+}
+
+// Helpers (pure).
+
+func toMatchInput(item *database.MediaCheckItem) *matchInput {
+	return &matchInput{
+		FilePath:   item.FilePath,
+		FileName:   item.FileName,
+		AudioName:  item.AudioName,
+		Artist:     item.Artist,
+		TrackTitle: item.TrackTitle,
+		TrackFound: item.TrackFound,
+	}
+}
+
+func toItemResult(item *database.MediaCheckItem, out *matchOutcome) MediaCheckItemResult {
+	checked := out.CheckedPaths
+	if checked == nil {
+		checked = []string{}
+	}
+	matches := out.Matches
+	if matches == nil {
+		matches = []string{}
+	}
+	return MediaCheckItemResult{
+		TrackID:      item.TrackID,
+		Artist:       item.Artist,
+		TrackTitle:   item.TrackTitle,
+		StartTime:    item.StartTime,
+		BlockID:      item.BlockID,
+		Block:        item.BlockName,
+		Status:       out.Status,
+		DBReference:  out.DBReference,
+		CheckedPaths: checked,
+		Matches:      matches,
+		MatchType:    out.MatchType,
+		Error:        out.Error,
+	}
+}
+
+func summarize(items []MediaCheckItemResult) MediaCheckSummary {
+	sum := MediaCheckSummary{Total: len(items)}
+	for i := range items {
+		switch items[i].Status {
+		case MediaStatusPresent:
+			sum.Present++
+		case MediaStatusMissing:
+			sum.Missing++
+		case MediaStatusAmbiguous:
+			sum.Ambiguous++
+		case MediaStatusNoReference:
+			sum.NoReference++
+		case MediaStatusStatError:
+			sum.Errors++
+		}
+	}
+	return sum
+}
+
+func scopeFromOptions(opts *database.MediaCheckOptions) MediaCheckScope {
+	return MediaCheckScope{
+		Date:               opts.Date,
+		From:               opts.From,
+		To:                 opts.To,
+		BlockID:            opts.BlockID,
+		Limit:              opts.Limit,
+		ExcludeVoicetracks: !opts.IncludeVoicetracks,
+	}
+}
+
+// buildNotifyResult converts a run result into the notification input, listing
+// only the problem items (missing, ambiguous, stat_error). A run-level error is
+// surfaced as a single problem so a failed scheduled run still alerts.
+func buildNotifyResult(result *MediaCheckResult) *notify.MediaCheckResult {
+	nr := &notify.MediaCheckResult{
+		CheckedAt: result.CheckedAt,
+		Scope:     scopeDescription(&result.Scope),
+		Total:     result.Summary.Total,
+	}
+	if result.Error != "" {
+		nr.Problems = append(nr.Problems, notify.MediaCheckProblem{
+			Status:      "error",
+			DBReference: result.Error,
+		})
+		return nr
+	}
+	for i := range result.Items {
+		it := &result.Items[i]
+		switch it.Status {
+		case MediaStatusMissing, MediaStatusAmbiguous, MediaStatusStatError:
+			nr.Problems = append(nr.Problems, notify.MediaCheckProblem{
+				Artist:      it.Artist,
+				TrackTitle:  it.TrackTitle,
+				StartTime:   it.StartTime,
+				Block:       it.Block,
+				Status:      string(it.Status),
+				DBReference: it.DBReference,
+			})
+		}
+	}
+	return nr
+}
+
+// scopeDescription renders a short human-readable scope for emails/logs.
+func scopeDescription(scope *MediaCheckScope) string {
+	var parts []string
+	switch {
+	case scope.BlockID != "":
+		parts = append(parts, "block "+scope.BlockID)
+	case scope.Date != "":
+		parts = append(parts, "date "+scope.Date)
+	case scope.From != "" || scope.To != "":
+		parts = append(parts, fmt.Sprintf("range %s..%s", scope.From, scope.To))
+	default:
+		parts = append(parts, "today")
+	}
+	if scope.ExcludeVoicetracks {
+		parts = append(parts, "excl. voicetracks")
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -102,6 +102,7 @@ type MediaFileCheckService struct {
 
 	publishedMu    sync.RWMutex
 	lastResult     *MediaCheckResult
+	lastScheduled  *MediaCheckResult
 	startedAt      *time.Time
 	runID          uint64
 	completedRunID uint64
@@ -157,7 +158,7 @@ func (s *MediaFileCheckService) trigger(opts *database.MediaCheckOptions, notify
 		defer cancel()
 
 		result := s.executeRun(ctx, opts)
-		s.publishCompleted(result, runID)
+		s.publishCompleted(result, runID, notifyResult)
 		if notifyResult {
 			s.notify.NotifyMediaCheckResult(buildNotifyResult(result))
 		}
@@ -194,7 +195,15 @@ func (s *MediaFileCheckService) executeRun(ctx context.Context, opts *database.M
 			return nil
 		})
 	}
-	_ = g.Wait() // workers never return errors; outcomes are embedded in results.
+	if err := g.Wait(); err != nil {
+		result.Error = err.Error()
+	}
+	if err := ctx.Err(); err != nil && result.Error == "" {
+		result.Error = err.Error()
+	}
+	if err := matcher.indexErr(); err != nil && result.Error == "" {
+		result.Error = err.Error()
+	}
 
 	result.Items = results
 	result.Summary = summarize(results)
@@ -271,15 +280,15 @@ func (s *MediaFileCheckService) Status() *MediaCheckStatus {
 }
 
 // ProblemCount returns the number of missing, ambiguous and errored items in the
-// most recent completed run. Used by the health endpoint.
+// most recent scheduled run. Used by the health endpoint; ad-hoc API scopes are
+// intentionally excluded from the health signal.
 func (s *MediaFileCheckService) ProblemCount() int {
 	s.publishedMu.RLock()
 	defer s.publishedMu.RUnlock()
-	if s.lastResult == nil {
+	if s.lastScheduled == nil {
 		return 0
 	}
-	sum := s.lastResult.Summary
-	return sum.Missing + sum.Ambiguous + sum.Errors
+	return problemCount(s.lastScheduled)
 }
 
 func (s *MediaFileCheckService) startNewRun() uint64 {
@@ -291,10 +300,13 @@ func (s *MediaFileCheckService) startNewRun() uint64 {
 	return s.runID
 }
 
-func (s *MediaFileCheckService) publishCompleted(result *MediaCheckResult, runID uint64) {
+func (s *MediaFileCheckService) publishCompleted(result *MediaCheckResult, runID uint64, scheduled bool) {
 	s.publishedMu.Lock()
 	defer s.publishedMu.Unlock()
 	s.lastResult = result
+	if scheduled {
+		s.lastScheduled = result
+	}
 	s.completedRunID = runID
 }
 
@@ -307,7 +319,6 @@ func toMatchInput(item *database.MediaCheckItem) *matchInput {
 		AudioName:  item.AudioName,
 		Artist:     item.Artist,
 		TrackTitle: item.TrackTitle,
-		TrackFound: item.TrackFound,
 	}
 }
 
@@ -353,6 +364,17 @@ func summarize(items []MediaCheckItemResult) MediaCheckSummary {
 		}
 	}
 	return sum
+}
+
+func problemCount(result *MediaCheckResult) int {
+	if result == nil {
+		return 0
+	}
+	if result.Error != "" {
+		return 1
+	}
+	sum := result.Summary
+	return sum.Missing + sum.Ambiguous + sum.Errors
 }
 
 func scopeFromOptions(opts *database.MediaCheckOptions) MediaCheckScope {

--- a/internal/service/mediacheck_test.go
+++ b/internal/service/mediacheck_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/async"
+)
+
+func TestMediaFileCheckProblemCountUsesOnlyScheduledResult(t *testing.T) {
+	svc := &MediaFileCheckService{runner: async.New()}
+	defer svc.Close()
+
+	manual := &MediaCheckResult{
+		Summary: MediaCheckSummary{Missing: 3},
+	}
+	svc.publishCompleted(manual, 1, false)
+
+	if got := svc.Status().Result; got != manual {
+		t.Fatalf("status result = %p, want manual result %p", got, manual)
+	}
+	if got := svc.ProblemCount(); got != 0 {
+		t.Fatalf("manual ProblemCount = %d, want 0", got)
+	}
+
+	scheduled := &MediaCheckResult{
+		Summary: MediaCheckSummary{Missing: 1, Ambiguous: 2, Errors: 3},
+	}
+	svc.publishCompleted(scheduled, 2, true)
+
+	if got := svc.ProblemCount(); got != 6 {
+		t.Fatalf("scheduled ProblemCount = %d, want 6", got)
+	}
+}
+
+func TestProblemCountRunErrorCountsAsOneProblem(t *testing.T) {
+	result := &MediaCheckResult{
+		Error:   "context deadline exceeded",
+		Summary: MediaCheckSummary{Missing: 20},
+	}
+
+	if got := problemCount(result); got != 1 {
+		t.Fatalf("problemCount = %d, want 1", got)
+	}
+}

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -16,7 +16,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
-// MediaFileStatus classifies the on-disk outcome for a single playlist item.
+// MediaFileStatus classifies the on-disk verdict for a playlist item.
 type MediaFileStatus string
 
 const (
@@ -32,7 +32,7 @@ const (
 	MediaStatusStatError MediaFileStatus = "stat_error"
 )
 
-// Match strategy labels reported in MediaCheckItemResult.MatchType.
+// Match strategy labels stored in MediaCheckItemResult.MatchType.
 const (
 	matchTypeExactPath     = "exact_path"
 	matchTypeFilename      = "filename"
@@ -41,8 +41,8 @@ const (
 
 const maxFileIndexErrors = 5
 
-// normalizeDriveKey turns a Windows drive prefix ("O:", "o:\", "O") into the
-// canonical "O:" form. It returns "" when s is not a single-letter drive.
+// normalizeDriveKey converts a Windows drive prefix to canonical "O:" form.
+// It returns "" when s is not a single-letter drive.
 func normalizeDriveKey(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimSuffix(s, `\`)
@@ -57,8 +57,7 @@ func normalizeDriveKey(s string) string {
 	return strings.ToUpper(s) + ":"
 }
 
-// driveOf returns the canonical drive prefix of a Windows path, or "" if the
-// path has no drive letter.
+// driveOf returns the canonical drive prefix of a Windows path.
 func driveOf(winPath string) string {
 	if len(winPath) < 2 || winPath[1] != ':' {
 		return ""
@@ -66,9 +65,8 @@ func driveOf(winPath string) string {
 	return normalizeDriveKey(winPath[:2])
 }
 
-// winPathComponents strips the drive prefix from a Windows path and splits the
-// remainder into path components on either separator. Empty components and "."
-// are dropped. It returns nil when the path escapes its root via "..".
+// winPathComponents splits a Windows path into safe relative components.
+// It returns nil when the path escapes its root via "..".
 func winPathComponents(winPath string) []string {
 	rest := winPath
 	if d := driveOf(winPath); d != "" {
@@ -105,8 +103,7 @@ func stem(name string) string {
 	return strings.TrimSuffix(name, filepath.Ext(name))
 }
 
-// foldKey lowercases s when matching is case-insensitive, so lookups ignore the
-// casing differences between Windows references and a case-sensitive host FS.
+// foldKey lowercases s when lookups should ignore host filesystem casing.
 func foldKey(s string, caseInsensitive bool) string {
 	if caseInsensitive {
 		return strings.ToLower(s)
@@ -124,10 +121,8 @@ type fileIndex struct {
 	errors []string
 }
 
-// buildFileIndex walks each search dir recursively and indexes every regular
-// file by filename and by stem. Per-file walk errors are logged and skipped so
-// one unreadable subtree does not abort the whole index. The walk aborts early
-// if ctx is cancelled.
+// buildFileIndex indexes regular files by full filename and stem.
+// Per-file walk errors are logged and skipped; ctx cancellation aborts the walk.
 func buildFileIndex(ctx context.Context, dirs []string, caseInsensitive bool) *fileIndex {
 	idx := &fileIndex{
 		byName: make(map[string][]string),
@@ -219,8 +214,7 @@ type mediaMatcher struct {
 	indexOnce sync.Once
 }
 
-// matchInput is the per-item data the matcher classifies. It is decoupled from
-// the database row so the matcher can be unit-tested without a database.
+// matchInput is the database-free item data classified by mediaMatcher.
 type matchInput struct {
 	FilePath   string // audio.filepath (full Windows path)
 	FileName   string // audio.filename (full Windows path)
@@ -229,7 +223,7 @@ type matchInput struct {
 	TrackTitle string
 }
 
-// matchOutcome is the matcher's verdict for one item.
+// matchOutcome is the matcher verdict for one item.
 type matchOutcome struct {
 	Status       MediaFileStatus
 	DBReference  string
@@ -347,9 +341,8 @@ func finishIndexMatch(out *matchOutcome, matches []string, matchType string) {
 	}
 }
 
-// statDriveMapped translates a Windows reference through the drive mappings and
-// stats the resulting host path. It returns ("", false, nil) when no mapping
-// applies to the reference's drive.
+// statDriveMapped maps a Windows reference to a host path and stats it.
+// It returns ("", false, nil) when no drive mapping applies.
 func (m *mediaMatcher) statDriveMapped(ref string) (candidate string, exists bool, err error) {
 	drive := driveOf(ref)
 	if drive == "" {

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -1,0 +1,457 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MediaFileStatus classifies the on-disk outcome for a single playlist item.
+type MediaFileStatus string
+
+const (
+	// MediaStatusPresent means a file matching the reference was found on disk.
+	MediaStatusPresent MediaFileStatus = "present"
+	// MediaStatusMissing means no matching file was found.
+	MediaStatusMissing MediaFileStatus = "missing"
+	// MediaStatusAmbiguous means more than one file matched the reference.
+	MediaStatusAmbiguous MediaFileStatus = "ambiguous"
+	// MediaStatusNoReference means the item carries no usable file reference.
+	MediaStatusNoReference MediaFileStatus = "no_reference"
+	// MediaStatusStatError means a file could not be checked (timeout, permission, etc.).
+	MediaStatusStatError MediaFileStatus = "stat_error"
+)
+
+// Match strategy labels reported in MediaCheckItemResult.MatchType.
+const (
+	matchTypeExactPath     = "exact_path"
+	matchTypeFilename      = "filename"
+	matchTypeFilenameNoExt = "filename_noext"
+	matchTypeMetadata      = "metadata"
+)
+
+// normalizeDriveKey turns a Windows drive prefix ("O:", "o:\", "O") into the
+// canonical "O:" form. It returns "" when s is not a single-letter drive.
+func normalizeDriveKey(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, `\`)
+	s = strings.TrimSuffix(s, ":")
+	if len(s) != 1 {
+		return ""
+	}
+	c := s[0]
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+		return ""
+	}
+	return strings.ToUpper(s) + ":"
+}
+
+// driveOf returns the canonical drive prefix of a Windows path, or "" if the
+// path has no drive letter.
+func driveOf(winPath string) string {
+	if len(winPath) < 2 || winPath[1] != ':' {
+		return ""
+	}
+	return normalizeDriveKey(winPath[:2])
+}
+
+// winPathComponents strips the drive prefix from a Windows path and splits the
+// remainder into path components on either separator. Empty components and "."
+// are dropped. It returns nil when the path escapes its root via "..".
+func winPathComponents(winPath string) []string {
+	rest := winPath
+	if d := driveOf(winPath); d != "" {
+		rest = winPath[2:]
+	}
+	rest = strings.ReplaceAll(rest, `\`, "/")
+	var out []string
+	for _, part := range strings.Split(rest, "/") {
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			return nil // refuse traversal
+		default:
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// baseName returns the final path component of a Windows or Unix path.
+func baseName(p string) string {
+	p = strings.ReplaceAll(p, `\`, "/")
+	p = strings.TrimRight(p, "/")
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// stem returns a filename with its extension removed. Names without an
+// extension are returned unchanged.
+func stem(name string) string {
+	ext := filepath.Ext(name)
+	return name[:len(name)-len(ext)]
+}
+
+// foldKey lowercases s when matching is case-insensitive, so lookups ignore the
+// casing differences between Windows references and a case-sensitive host FS.
+func foldKey(s string, caseInsensitive bool) string {
+	if caseInsensitive {
+		return strings.ToLower(s)
+	}
+	return s
+}
+
+// fileIndex maps filename keys to the absolute on-disk paths that carry them.
+// byName is keyed by the full filename (with extension); byStem by the filename
+// without extension. Keys are folded according to the matcher's case setting.
+type fileIndex struct {
+	byName map[string][]string
+	byStem map[string][]string
+	count  int
+}
+
+// buildFileIndex walks each root recursively and indexes every regular file by
+// filename and by stem. Per-file walk errors are logged and skipped so one
+// unreadable subtree does not abort the whole index. The walk aborts early if
+// ctx is cancelled.
+func buildFileIndex(ctx contextLike, roots []string, caseInsensitive bool) *fileIndex {
+	idx := &fileIndex{
+		byName: make(map[string][]string),
+		byStem: make(map[string][]string),
+	}
+	add := func(m map[string][]string, key, full string) {
+		key = foldKey(key, caseInsensitive)
+		for _, existing := range m[key] {
+			if existing == full {
+				return
+			}
+		}
+		m[key] = append(m[key], full)
+	}
+
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if ctx != nil && ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if err != nil {
+				slog.Warn("Media file check: walk error", "path", path, "error", err)
+				if d != nil && d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.IsDir() || !d.Type().IsRegular() {
+				return nil
+			}
+			name := d.Name()
+			add(idx.byName, name, path)
+			add(idx.byStem, stem(name), path)
+			idx.count++
+			return nil
+		})
+		if err != nil {
+			slog.Warn("Media file check: index walk stopped", "root", root, "error", err)
+		}
+	}
+	return idx
+}
+
+// contextLike is the minimal context surface buildFileIndex needs. It avoids a
+// hard context import here while letting callers pass a real context.Context.
+type contextLike interface {
+	Err() error
+}
+
+// rootDir is an opened drive-mapping target. root is nil when the directory
+// could not be opened (e.g. the mount is down); openErr then explains why.
+type rootDir struct {
+	dir     string
+	root    *os.Root
+	openErr error
+}
+
+// mediaMatcher resolves database references to files on disk using two
+// strategies: exact path translation via drive mappings, then a filename index
+// over the configured roots (built lazily on first fallback).
+type mediaMatcher struct {
+	driveRoots      map[string]*rootDir
+	roots           []string
+	caseInsensitive bool
+	statTimeout     time.Duration
+
+	ctx       contextLike
+	index     *fileIndex
+	indexOnce sync.Once
+}
+
+// matchInput is the per-item data the matcher classifies. It is decoupled from
+// the database row so the matcher can be unit-tested without a database.
+type matchInput struct {
+	FilePath   string // audio.filepath (full Windows path)
+	FileName   string // audio.filename (full Windows path)
+	AudioName  string // audio.name (basename without extension)
+	Artist     string
+	TrackTitle string
+	TrackFound bool
+}
+
+// matchOutcome is the matcher's verdict for one item.
+type matchOutcome struct {
+	Status       MediaFileStatus
+	DBReference  string
+	CheckedPaths []string
+	Matches      []string
+	MatchType    string
+	Error        string
+}
+
+// dbReference picks the most meaningful reference string for display.
+func (in *matchInput) dbReference() string {
+	switch {
+	case in.FilePath != "":
+		return in.FilePath
+	case in.FileName != "":
+		return in.FileName
+	case in.AudioName != "":
+		return "name: " + in.AudioName
+	case in.Artist != "" || in.TrackTitle != "":
+		return "metadata: " + metadataLabel(in.Artist, in.TrackTitle)
+	default:
+		return ""
+	}
+}
+
+// metadataLabel renders the "artist - title" (or bare title) label.
+func metadataLabel(artist, title string) string {
+	if artist != "" && title != "" {
+		return artist + " - " + title
+	}
+	if title != "" {
+		return title
+	}
+	return artist
+}
+
+// winRefs returns the distinct full Windows-path references for an item.
+func (in *matchInput) winRefs() []string {
+	var refs []string
+	for _, r := range []string{in.FilePath, in.FileName} {
+		if r == "" {
+			continue
+		}
+		if !sliceContains(refs, r) {
+			refs = append(refs, r)
+		}
+	}
+	return refs
+}
+
+// match classifies a single item across both resolution strategies.
+func (m *mediaMatcher) match(in *matchInput) matchOutcome {
+	out := matchOutcome{DBReference: in.dbReference()}
+
+	winRefs := in.winRefs()
+	hasRef := len(winRefs) > 0 || in.AudioName != "" || in.Artist != "" || in.TrackTitle != ""
+	if !hasRef {
+		out.Status = MediaStatusNoReference
+		return out
+	}
+
+	// Strategy 1: exact path via drive mapping.
+	var statErr string
+	for _, ref := range winRefs {
+		candidate, exists, err := m.statDriveMapped(ref)
+		if candidate == "" {
+			continue // no mapping for this drive
+		}
+		out.CheckedPaths = append(out.CheckedPaths, candidate)
+		switch {
+		case err != nil:
+			statErr = err.Error()
+		case exists:
+			out.Status = MediaStatusPresent
+			out.MatchType = matchTypeExactPath
+			out.Matches = []string{candidate}
+			return out
+		}
+	}
+
+	// Strategy 2: filename index over roots (exact filename, then ext-independent).
+	if idx := m.getIndex(); idx != nil {
+		// Exact filename (with extension).
+		var names []string
+		for _, ref := range winRefs {
+			names = appendUnique(names, baseName(ref))
+		}
+		if matches := idx.lookup(idx.byName, names, m.caseInsensitive); len(matches) > 0 {
+			out.CheckedPaths = append(out.CheckedPaths, describeSearch("by name", names))
+			finishIndexMatch(&out, matches, matchTypeFilename)
+			return out
+		}
+
+		// Extension-independent: stems from filenames, audio.name and metadata.
+		var stems []string
+		for _, ref := range winRefs {
+			stems = appendUnique(stems, stem(baseName(ref)))
+		}
+		fileStemCount := len(stems)
+		if in.AudioName != "" {
+			stems = appendUnique(stems, in.AudioName)
+		}
+		if label := metadataLabel(in.Artist, in.TrackTitle); label != "" {
+			stems = appendUnique(stems, label)
+		}
+		if in.TrackTitle != "" {
+			stems = appendUnique(stems, in.TrackTitle)
+		}
+		if matches := idx.lookup(idx.byStem, stems, m.caseInsensitive); len(matches) > 0 {
+			out.CheckedPaths = append(out.CheckedPaths, describeSearch("by name (any extension)", stems))
+			mt := matchTypeFilenameNoExt
+			if fileStemCount == 0 {
+				mt = matchTypeMetadata
+			}
+			finishIndexMatch(&out, matches, mt)
+			return out
+		}
+		out.CheckedPaths = append(out.CheckedPaths, describeSearch("by name", names))
+	}
+
+	// No match: a stat error outranks a clean "missing" because the file may in
+	// fact exist but could not be verified.
+	if statErr != "" {
+		out.Status = MediaStatusStatError
+		out.Error = statErr
+		return out
+	}
+	out.Status = MediaStatusMissing
+	return out
+}
+
+// finishIndexMatch sets present/ambiguous based on how many files matched.
+func finishIndexMatch(out *matchOutcome, matches []string, matchType string) {
+	out.Matches = matches
+	out.MatchType = matchType
+	if len(matches) == 1 {
+		out.Status = MediaStatusPresent
+	} else {
+		out.Status = MediaStatusAmbiguous
+	}
+}
+
+// statDriveMapped translates a Windows reference through the drive mappings and
+// stats the resulting host path. It returns ("", false, nil) when no mapping
+// applies to the reference's drive.
+func (m *mediaMatcher) statDriveMapped(ref string) (candidate string, exists bool, err error) {
+	drive := driveOf(ref)
+	if drive == "" {
+		return "", false, nil
+	}
+	rd, ok := m.driveRoots[drive]
+	if !ok {
+		return "", false, nil
+	}
+
+	components := winPathComponents(ref)
+	if len(components) == 0 {
+		return "", false, nil
+	}
+	rel := filepath.Join(components...)
+	candidate = filepath.Join(rd.dir, rel)
+
+	if rd.root == nil {
+		return candidate, false, fmt.Errorf("drive %s root unavailable: %w", drive, rd.openErr)
+	}
+
+	exists, err = statRootWithTimeout(rd.root, rel, m.statTimeout)
+	return candidate, exists, err
+}
+
+// getIndex returns the lazily-built filename index, or nil when no roots are
+// configured. The index is built at most once per matcher; concurrent callers
+// that fall through to the index strategy block on the same build via Once.
+func (m *mediaMatcher) getIndex() *fileIndex {
+	m.indexOnce.Do(func() {
+		if len(m.roots) == 0 {
+			return
+		}
+		start := time.Now()
+		m.index = buildFileIndex(m.ctx, m.roots, m.caseInsensitive)
+		slog.Info("Media file check: index built",
+			"files", m.index.count, "roots", len(m.roots),
+			"duration", time.Since(start).Round(time.Millisecond).String())
+	})
+	return m.index
+}
+
+// lookup collects the distinct on-disk paths matching any of the given keys.
+func (idx *fileIndex) lookup(table map[string][]string, keys []string, caseInsensitive bool) []string {
+	var matches []string
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		for _, full := range table[foldKey(key, caseInsensitive)] {
+			matches = appendUnique(matches, full)
+		}
+	}
+	return matches
+}
+
+// statRootWithTimeout stats name within root, bounding the call with timeout so
+// a frozen mount cannot stall the worker. A timeout is reported as an error
+// (the file's existence is unknown), a genuine absence as (false, nil).
+func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (bool, error) {
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		_, err := root.Stat(name)
+		ch <- result{err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case r := <-ch:
+		if r.err == nil {
+			return true, nil
+		}
+		if errors.Is(r.err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, r.err
+	case <-timer.C:
+		return false, fmt.Errorf("stat timeout after %s", timeout)
+	}
+}
+
+// describeSearch renders an operator-facing note about an index lookup.
+func describeSearch(how string, keys []string) string {
+	return fmt.Sprintf("roots (%s): %s", how, strings.Join(keys, ", "))
+}
+
+func appendUnique(s []string, v string) []string {
+	if v == "" || sliceContains(s, v) {
+		return s
+	}
+	return append(s, v)
+}
+
+func sliceContains(s []string, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -123,11 +123,11 @@ type fileIndex struct {
 	errors []string
 }
 
-// buildFileIndex walks each root recursively and indexes every regular file by
-// filename and by stem. Per-file walk errors are logged and skipped so one
-// unreadable subtree does not abort the whole index. The walk aborts early if
-// ctx is cancelled.
-func buildFileIndex(ctx context.Context, roots []string, caseInsensitive bool) *fileIndex {
+// buildFileIndex walks each search dir recursively and indexes every regular
+// file by filename and by stem. Per-file walk errors are logged and skipped so
+// one unreadable subtree does not abort the whole index. The walk aborts early
+// if ctx is cancelled.
+func buildFileIndex(ctx context.Context, dirs []string, caseInsensitive bool) *fileIndex {
 	idx := &fileIndex{
 		byName: make(map[string][]string),
 		byStem: make(map[string][]string),
@@ -142,12 +142,12 @@ func buildFileIndex(ctx context.Context, roots []string, caseInsensitive bool) *
 		m[key] = append(m[key], full)
 	}
 
-	for _, root := range roots {
+	for _, dir := range dirs {
 		if ctx != nil && ctx.Err() != nil {
-			idx.addError(fmt.Sprintf("index build canceled before %s: %v", root, ctx.Err()))
+			idx.addError(fmt.Sprintf("index build canceled before %s: %v", dir, ctx.Err()))
 			break
 		}
-		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if ctx != nil && ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -169,8 +169,8 @@ func buildFileIndex(ctx context.Context, roots []string, caseInsensitive bool) *
 			return nil
 		})
 		if err != nil {
-			idx.addError(fmt.Sprintf("%s: %v", root, err))
-			slog.Warn("Media file check: index walk stopped", "root", root, "error", err)
+			idx.addError(fmt.Sprintf("%s: %v", dir, err))
+			slog.Warn("Media file check: index walk stopped", "dir", dir, "error", err)
 			if ctx != nil && ctx.Err() != nil {
 				break
 			}
@@ -205,11 +205,11 @@ type rootDir struct {
 }
 
 // mediaMatcher resolves database references to files on disk using two
-// strategies: exact path translation via drive mappings, then a filename index
-// over the configured roots (built lazily on first fallback).
+// strategies: exact path translation via drive mounts, then a filename index
+// over the configured search dirs (built lazily on first fallback).
 type mediaMatcher struct {
 	driveRoots      map[string]*rootDir
-	roots           []string
+	searchDirs      []string
 	caseInsensitive bool
 	statTimeout     time.Duration
 
@@ -314,7 +314,7 @@ func (m *mediaMatcher) match(in *matchInput) matchOutcome {
 		return out
 	}
 
-	// Strategy 2: filename index over roots (exact filename, then ext-independent).
+	// Strategy 2: filename index over search dirs (exact filename, then ext-independent).
 	if idx := m.getIndex(); idx != nil {
 		// Exact filename (with extension).
 		var names []string
@@ -385,25 +385,25 @@ func (m *mediaMatcher) statDriveMapped(ref string) (candidate string, exists boo
 	return candidate, exists, err
 }
 
-// getIndex returns the lazily-built filename index, or nil when no roots are
-// configured. The index is built at most once per matcher; concurrent callers
-// that fall through to the index strategy block on the same build via Once.
+// getIndex returns the lazily-built filename index, or nil when no search dirs
+// are configured. The index is built at most once per matcher; concurrent
+// callers that fall through to the index strategy block on the same build via Once.
 func (m *mediaMatcher) getIndex() *fileIndex {
 	m.indexOnce.Do(func() {
-		if len(m.roots) == 0 {
+		if len(m.searchDirs) == 0 {
 			return
 		}
 		start := time.Now()
-		m.index = buildFileIndex(m.ctx, m.roots, m.caseInsensitive)
+		m.index = buildFileIndex(m.ctx, m.searchDirs, m.caseInsensitive)
 		if err := m.index.err(); err != nil {
 			slog.Warn("Media file check: index built with errors",
-				"files", m.index.count, "roots", len(m.roots),
+				"files", m.index.count, "search_dirs", len(m.searchDirs),
 				"duration", time.Since(start).Round(time.Millisecond).String(),
 				"error", err)
 			return
 		}
 		slog.Info("Media file check: index built",
-			"files", m.index.count, "roots", len(m.roots),
+			"files", m.index.count, "search_dirs", len(m.searchDirs),
 			"duration", time.Since(start).Round(time.Millisecond).String())
 	})
 	return m.index
@@ -464,7 +464,7 @@ func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (boo
 
 // describeSearch renders an operator-facing note about an index lookup.
 func describeSearch(how string, keys []string) string {
-	return fmt.Sprintf("roots (%s): %s", how, strings.Join(keys, ", "))
+	return fmt.Sprintf("search_dirs (%s): %s", how, strings.Join(keys, ", "))
 }
 
 func appendUnique(s []string, v string) []string {

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -33,8 +35,9 @@ const (
 	matchTypeExactPath     = "exact_path"
 	matchTypeFilename      = "filename"
 	matchTypeFilenameNoExt = "filename_noext"
-	matchTypeMetadata      = "metadata"
 )
+
+const maxFileIndexErrors = 5
 
 // normalizeDriveKey turns a Windows drive prefix ("O:", "o:\", "O") into the
 // canonical "O:" form. It returns "" when s is not a single-letter drive.
@@ -117,13 +120,14 @@ type fileIndex struct {
 	byName map[string][]string
 	byStem map[string][]string
 	count  int
+	errors []string
 }
 
 // buildFileIndex walks each root recursively and indexes every regular file by
 // filename and by stem. Per-file walk errors are logged and skipped so one
 // unreadable subtree does not abort the whole index. The walk aborts early if
 // ctx is cancelled.
-func buildFileIndex(ctx contextLike, roots []string, caseInsensitive bool) *fileIndex {
+func buildFileIndex(ctx context.Context, roots []string, caseInsensitive bool) *fileIndex {
 	idx := &fileIndex{
 		byName: make(map[string][]string),
 		byStem: make(map[string][]string),
@@ -139,11 +143,16 @@ func buildFileIndex(ctx contextLike, roots []string, caseInsensitive bool) *file
 	}
 
 	for _, root := range roots {
+		if ctx != nil && ctx.Err() != nil {
+			idx.addError(fmt.Sprintf("index build canceled before %s: %v", root, ctx.Err()))
+			break
+		}
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if ctx != nil && ctx.Err() != nil {
 				return ctx.Err()
 			}
 			if err != nil {
+				idx.addError(fmt.Sprintf("%s: %v", path, err))
 				slog.Warn("Media file check: walk error", "path", path, "error", err)
 				if d != nil && d.IsDir() {
 					return filepath.SkipDir
@@ -160,16 +169,31 @@ func buildFileIndex(ctx contextLike, roots []string, caseInsensitive bool) *file
 			return nil
 		})
 		if err != nil {
+			idx.addError(fmt.Sprintf("%s: %v", root, err))
 			slog.Warn("Media file check: index walk stopped", "root", root, "error", err)
+			if ctx != nil && ctx.Err() != nil {
+				break
+			}
 		}
 	}
 	return idx
 }
 
-// contextLike is the minimal context surface buildFileIndex needs. It avoids a
-// hard context import here while letting callers pass a real context.Context.
-type contextLike interface {
-	Err() error
+func (idx *fileIndex) addError(msg string) {
+	if len(idx.errors) < maxFileIndexErrors {
+		idx.errors = append(idx.errors, msg)
+		return
+	}
+	if len(idx.errors) == maxFileIndexErrors {
+		idx.errors = append(idx.errors, "additional index errors omitted")
+	}
+}
+
+func (idx *fileIndex) err() error {
+	if idx == nil || len(idx.errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("media file index incomplete: %s", strings.Join(idx.errors, "; "))
 }
 
 // rootDir is an opened drive-mapping target. root is nil when the directory
@@ -189,7 +213,7 @@ type mediaMatcher struct {
 	caseInsensitive bool
 	statTimeout     time.Duration
 
-	ctx       contextLike
+	ctx       context.Context
 	index     *fileIndex
 	indexOnce sync.Once
 }
@@ -202,7 +226,6 @@ type matchInput struct {
 	AudioName  string // audio.name (basename without extension)
 	Artist     string
 	TrackTitle string
-	TrackFound bool
 }
 
 // matchOutcome is the matcher's verdict for one item.
@@ -249,7 +272,7 @@ func (in *matchInput) winRefs() []string {
 		if r == "" {
 			continue
 		}
-		if !sliceContains(refs, r) {
+		if !slices.Contains(refs, r) {
 			refs = append(refs, r)
 		}
 	}
@@ -261,7 +284,7 @@ func (m *mediaMatcher) match(in *matchInput) matchOutcome {
 	out := matchOutcome{DBReference: in.dbReference()}
 
 	winRefs := in.winRefs()
-	hasRef := len(winRefs) > 0 || in.AudioName != "" || in.Artist != "" || in.TrackTitle != ""
+	hasRef := len(winRefs) > 0 || in.AudioName != ""
 	if !hasRef {
 		out.Status = MediaStatusNoReference
 		return out
@@ -285,6 +308,11 @@ func (m *mediaMatcher) match(in *matchInput) matchOutcome {
 			return out
 		}
 	}
+	if statErr != "" {
+		out.Status = MediaStatusStatError
+		out.Error = statErr
+		return out
+	}
 
 	// Strategy 2: filename index over roots (exact filename, then ext-independent).
 	if idx := m.getIndex(); idx != nil {
@@ -299,39 +327,20 @@ func (m *mediaMatcher) match(in *matchInput) matchOutcome {
 			return out
 		}
 
-		// Extension-independent: stems from filenames, audio.name and metadata.
+		// Extension-independent: stems from filenames and audio.name.
 		var stems []string
 		for _, ref := range winRefs {
 			stems = appendUnique(stems, stem(baseName(ref)))
 		}
-		fileStemCount := len(stems)
 		if in.AudioName != "" {
 			stems = appendUnique(stems, in.AudioName)
 		}
-		if label := metadataLabel(in.Artist, in.TrackTitle); label != "" {
-			stems = appendUnique(stems, label)
-		}
-		if in.TrackTitle != "" {
-			stems = appendUnique(stems, in.TrackTitle)
-		}
 		if matches := idx.lookup(idx.byStem, stems, m.caseInsensitive); len(matches) > 0 {
 			out.CheckedPaths = append(out.CheckedPaths, describeSearch("by name (any extension)", stems))
-			mt := matchTypeFilenameNoExt
-			if fileStemCount == 0 {
-				mt = matchTypeMetadata
-			}
-			finishIndexMatch(&out, matches, mt)
+			finishIndexMatch(&out, matches, matchTypeFilenameNoExt)
 			return out
 		}
 		out.CheckedPaths = append(out.CheckedPaths, describeSearch("by name", names))
-	}
-
-	// No match: a stat error outranks a clean "missing" because the file may in
-	// fact exist but could not be verified.
-	if statErr != "" {
-		out.Status = MediaStatusStatError
-		out.Error = statErr
-		return out
 	}
 	out.Status = MediaStatusMissing
 	return out
@@ -386,11 +395,25 @@ func (m *mediaMatcher) getIndex() *fileIndex {
 		}
 		start := time.Now()
 		m.index = buildFileIndex(m.ctx, m.roots, m.caseInsensitive)
+		if err := m.index.err(); err != nil {
+			slog.Warn("Media file check: index built with errors",
+				"files", m.index.count, "roots", len(m.roots),
+				"duration", time.Since(start).Round(time.Millisecond).String(),
+				"error", err)
+			return
+		}
 		slog.Info("Media file check: index built",
 			"files", m.index.count, "roots", len(m.roots),
 			"duration", time.Since(start).Round(time.Millisecond).String())
 	})
 	return m.index
+}
+
+func (m *mediaMatcher) indexErr() error {
+	if m == nil || m.index == nil {
+		return nil
+	}
+	return m.index.err()
 }
 
 // lookup collects the distinct on-disk paths matching any of the given keys.
@@ -414,6 +437,8 @@ func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (boo
 	type result struct{ err error }
 	ch := make(chan result, 1)
 	go func() {
+		// A frozen mount can leave this goroutine stuck in Stat after the caller
+		// times out; the buffered channel prevents an additional blocked send.
 		_, err := root.Stat(name)
 		ch <- result{err: err}
 	}()
@@ -427,6 +452,8 @@ func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (boo
 			return true, nil
 		}
 		if errors.Is(r.err, fs.ErrNotExist) {
+			// A stale mount that appears as an empty directory is indistinguishable
+			// from a genuine absence at this layer.
 			return false, nil
 		}
 		return false, r.err
@@ -441,17 +468,8 @@ func describeSearch(how string, keys []string) string {
 }
 
 func appendUnique(s []string, v string) []string {
-	if v == "" || sliceContains(s, v) {
+	if v == "" || slices.Contains(s, v) {
 		return s
 	}
 	return append(s, v)
-}
-
-func sliceContains(s []string, v string) bool {
-	for _, e := range s {
-		if e == v {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
 // MediaFileStatus classifies the on-disk outcome for a single playlist item.
@@ -100,8 +102,7 @@ func baseName(p string) string {
 // stem returns a filename with its extension removed. Names without an
 // extension are returned unchanged.
 func stem(name string) string {
-	ext := filepath.Ext(name)
-	return name[:len(name)-len(ext)]
+	return strings.TrimSuffix(name, filepath.Ext(name))
 }
 
 // foldKey lowercases s when matching is case-insensitive, so lookups ignore the
@@ -248,21 +249,10 @@ func (in *matchInput) dbReference() string {
 	case in.AudioName != "":
 		return "name: " + in.AudioName
 	case in.Artist != "" || in.TrackTitle != "":
-		return "metadata: " + metadataLabel(in.Artist, in.TrackTitle)
+		return "metadata: " + util.FormatArtistTitle(in.Artist, in.TrackTitle)
 	default:
 		return ""
 	}
-}
-
-// metadataLabel renders the "artist - title" (or bare title) label.
-func metadataLabel(artist, title string) string {
-	if artist != "" && title != "" {
-		return artist + " - " + title
-	}
-	if title != "" {
-		return title
-	}
-	return artist
 }
 
 // winRefs returns the distinct full Windows-path references for an item.

--- a/internal/service/mediamatch_test.go
+++ b/internal/service/mediamatch_test.go
@@ -1,0 +1,264 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNormalizeDriveKey(t *testing.T) {
+	cases := map[string]string{
+		"O:":    "O:",
+		"o:":    "O:",
+		`O:\`:   "O:",
+		"O":     "O:",
+		"  o  ": "O:",
+		"OO:":   "",
+		"1:":    "",
+		"":      "",
+	}
+	for in, want := range cases {
+		if got := normalizeDriveKey(in); got != want {
+			t.Errorf("normalizeDriveKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDriveOf(t *testing.T) {
+	cases := map[string]string{
+		`O:\Audio\x.wav`: "O:",
+		`y:\a\b.mp3`:     "Y:",
+		`\\server\share`: "",
+		`/mnt/audio/x`:   "",
+		`relative\x`:     "",
+	}
+	for in, want := range cases {
+		if got := driveOf(in); got != want {
+			t.Errorf("driveOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWinPathComponents(t *testing.T) {
+	got := winPathComponents(`O:\Audio\85\Artist - Title.wav`)
+	want := []string{"Audio", "85", "Artist - Title.wav"}
+	if len(got) != len(want) {
+		t.Fatalf("components = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("components = %v, want %v", got, want)
+		}
+	}
+
+	if winPathComponents(`O:\Audio\..\..\etc\passwd`) != nil {
+		t.Error("expected nil components for path containing '..'")
+	}
+}
+
+func TestBaseNameAndStem(t *testing.T) {
+	if got := baseName(`O:\Audio\85\Artist - Title.wav`); got != "Artist - Title.wav" {
+		t.Errorf("baseName = %q", got)
+	}
+	if got := baseName("/mnt/x/song.flac"); got != "song.flac" {
+		t.Errorf("baseName = %q", got)
+	}
+	if got := stem("Artist - Title.wav"); got != "Artist - Title" {
+		t.Errorf("stem = %q", got)
+	}
+	if got := stem("no_extension"); got != "no_extension" {
+		t.Errorf("stem = %q", got)
+	}
+}
+
+// buildTestMatcher constructs a matcher for tests, opening an os.Root per drive
+// mapping. Missing directories are stored as unopened roots (root == nil).
+func buildTestMatcher(t *testing.T, driveDirs map[string]string, roots []string, caseInsensitive bool) *mediaMatcher {
+	t.Helper()
+	driveRoots := make(map[string]*rootDir)
+	for drive, dir := range driveDirs {
+		rd := &rootDir{dir: dir}
+		if root, err := os.OpenRoot(dir); err == nil {
+			rd.root = root
+			t.Cleanup(func() { _ = root.Close() })
+		} else {
+			rd.openErr = err
+		}
+		driveRoots[normalizeDriveKey(drive)] = rd
+	}
+	return &mediaMatcher{
+		driveRoots:      driveRoots,
+		roots:           roots,
+		caseInsensitive: caseInsensitive,
+		statTimeout:     5 * time.Second,
+	}
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMatch_DriveMappingExactPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "Audio", "85", "Artist - Title.wav"))
+
+	m := buildTestMatcher(t, map[string]string{"O:": dir}, nil, true)
+	out := m.match(&matchInput{FilePath: `O:\Audio\85\Artist - Title.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusPresent {
+		t.Fatalf("status = %q, want present", out.Status)
+	}
+	if out.MatchType != matchTypeExactPath {
+		t.Errorf("matchType = %q, want %q", out.MatchType, matchTypeExactPath)
+	}
+	if len(out.Matches) != 1 {
+		t.Errorf("matches = %v, want one entry", out.Matches)
+	}
+}
+
+func TestMatch_DriveMappingMissing(t *testing.T) {
+	dir := t.TempDir()
+	m := buildTestMatcher(t, map[string]string{"O:": dir}, nil, true)
+	out := m.match(&matchInput{FilePath: `O:\Audio\nope.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusMissing {
+		t.Fatalf("status = %q, want missing", out.Status)
+	}
+}
+
+func TestMatch_IndexByFilename(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "sub", "unique.wav"))
+
+	m := buildTestMatcher(t, nil, []string{root}, true)
+	// No drive mapping for O: -> falls through to the index.
+	out := m.match(&matchInput{FilePath: `O:\elsewhere\unique.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusPresent {
+		t.Fatalf("status = %q, want present", out.Status)
+	}
+	if out.MatchType != matchTypeFilename {
+		t.Errorf("matchType = %q, want %q", out.MatchType, matchTypeFilename)
+	}
+}
+
+func TestMatch_IndexAmbiguous(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a", "dup.wav"))
+	writeFile(t, filepath.Join(root, "b", "dup.wav"))
+
+	m := buildTestMatcher(t, nil, []string{root}, true)
+	out := m.match(&matchInput{FileName: `O:\x\dup.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusAmbiguous {
+		t.Fatalf("status = %q, want ambiguous", out.Status)
+	}
+	if len(out.Matches) != 2 {
+		t.Errorf("matches = %v, want two entries", out.Matches)
+	}
+}
+
+func TestMatch_ExtensionIndependent(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "song.flac")) // DB says .wav, disk has .flac
+
+	m := buildTestMatcher(t, nil, []string{root}, true)
+	out := m.match(&matchInput{FilePath: `O:\Audio\song.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusPresent {
+		t.Fatalf("status = %q, want present", out.Status)
+	}
+	if out.MatchType != matchTypeFilenameNoExt {
+		t.Errorf("matchType = %q, want %q", out.MatchType, matchTypeFilenameNoExt)
+	}
+}
+
+func TestMatch_MetadataFallback(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "Artist - Title.mp3"))
+
+	m := buildTestMatcher(t, nil, []string{root}, true)
+	// No path references at all; only metadata is available.
+	out := m.match(&matchInput{Artist: "Artist", TrackTitle: "Title", TrackFound: true})
+
+	if out.Status != MediaStatusPresent {
+		t.Fatalf("status = %q, want present", out.Status)
+	}
+	if out.MatchType != matchTypeMetadata {
+		t.Errorf("matchType = %q, want %q", out.MatchType, matchTypeMetadata)
+	}
+}
+
+func TestMatch_NoReference(t *testing.T) {
+	m := buildTestMatcher(t, nil, nil, true)
+	out := m.match(&matchInput{TrackFound: false})
+
+	if out.Status != MediaStatusNoReference {
+		t.Fatalf("status = %q, want no_reference", out.Status)
+	}
+}
+
+func TestMatch_CaseSensitivity(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "MixedCase.WAV"))
+
+	ci := buildTestMatcher(t, nil, []string{root}, true)
+	if out := ci.match(&matchInput{FileName: `O:\x\mixedcase.wav`}); out.Status != MediaStatusPresent {
+		t.Errorf("case-insensitive: status = %q, want present", out.Status)
+	}
+
+	cs := buildTestMatcher(t, nil, []string{root}, false)
+	if out := cs.match(&matchInput{FileName: `O:\x\mixedcase.wav`}); out.Status != MediaStatusMissing {
+		t.Errorf("case-sensitive: status = %q, want missing", out.Status)
+	}
+}
+
+func TestMatch_StatErrorWhenRootUnavailable(t *testing.T) {
+	// Drive mapped to a directory that cannot be opened -> stat error, not missing.
+	m := buildTestMatcher(t, map[string]string{"O:": filepath.Join(t.TempDir(), "does-not-exist")}, nil, true)
+	out := m.match(&matchInput{FilePath: `O:\Audio\x.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusStatError {
+		t.Fatalf("status = %q, want stat_error", out.Status)
+	}
+	if out.Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestMatch_DriveMappingPrefersExactOverIndex(t *testing.T) {
+	// A correct exact path must win even when an index also has the basename.
+	driveDir := t.TempDir()
+	writeFile(t, filepath.Join(driveDir, "Audio", "hit.wav"))
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "other", "hit.wav"))
+
+	m := buildTestMatcher(t, map[string]string{"O:": driveDir}, []string{root}, true)
+	out := m.match(&matchInput{FilePath: `O:\Audio\hit.wav`, TrackFound: true})
+
+	if out.Status != MediaStatusPresent || out.MatchType != matchTypeExactPath {
+		t.Fatalf("status=%q matchType=%q, want present/exact_path", out.Status, out.MatchType)
+	}
+}
+
+func TestSummarizeCountsByStatus(t *testing.T) {
+	items := []MediaCheckItemResult{
+		{Status: MediaStatusPresent},
+		{Status: MediaStatusPresent},
+		{Status: MediaStatusMissing},
+		{Status: MediaStatusAmbiguous},
+		{Status: MediaStatusNoReference},
+		{Status: MediaStatusStatError},
+	}
+	sum := summarize(items)
+	if sum.Total != 6 || sum.Present != 2 || sum.Missing != 1 || sum.Ambiguous != 1 || sum.NoReference != 1 || sum.Errors != 1 {
+		t.Errorf("summary = %+v", sum)
+	}
+}

--- a/internal/service/mediamatch_test.go
+++ b/internal/service/mediamatch_test.go
@@ -74,8 +74,8 @@ func TestBaseNameAndStem(t *testing.T) {
 }
 
 // buildTestMatcher constructs a matcher for tests, opening an os.Root per drive
-// mapping. Missing directories are stored as unopened roots (root == nil).
-func buildTestMatcher(t *testing.T, driveDirs map[string]string, roots []string, caseInsensitive bool) *mediaMatcher {
+// mount. Missing directories are stored as unopened roots (root == nil).
+func buildTestMatcher(t *testing.T, driveDirs map[string]string, searchDirs []string, caseInsensitive bool) *mediaMatcher {
 	t.Helper()
 	driveRoots := make(map[string]*rootDir)
 	for drive, dir := range driveDirs {
@@ -90,7 +90,7 @@ func buildTestMatcher(t *testing.T, driveDirs map[string]string, roots []string,
 	}
 	return &mediaMatcher{
 		driveRoots:      driveRoots,
-		roots:           roots,
+		searchDirs:      searchDirs,
 		caseInsensitive: caseInsensitive,
 		statTimeout:     5 * time.Second,
 	}

--- a/internal/service/mediamatch_test.go
+++ b/internal/service/mediamatch_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -110,7 +111,7 @@ func TestMatch_DriveMappingExactPath(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "Audio", "85", "Artist - Title.wav"))
 
 	m := buildTestMatcher(t, map[string]string{"O:": dir}, nil, true)
-	out := m.match(&matchInput{FilePath: `O:\Audio\85\Artist - Title.wav`, TrackFound: true})
+	out := m.match(&matchInput{FilePath: `O:\Audio\85\Artist - Title.wav`})
 
 	if out.Status != MediaStatusPresent {
 		t.Fatalf("status = %q, want present", out.Status)
@@ -126,7 +127,7 @@ func TestMatch_DriveMappingExactPath(t *testing.T) {
 func TestMatch_DriveMappingMissing(t *testing.T) {
 	dir := t.TempDir()
 	m := buildTestMatcher(t, map[string]string{"O:": dir}, nil, true)
-	out := m.match(&matchInput{FilePath: `O:\Audio\nope.wav`, TrackFound: true})
+	out := m.match(&matchInput{FilePath: `O:\Audio\nope.wav`})
 
 	if out.Status != MediaStatusMissing {
 		t.Fatalf("status = %q, want missing", out.Status)
@@ -139,7 +140,7 @@ func TestMatch_IndexByFilename(t *testing.T) {
 
 	m := buildTestMatcher(t, nil, []string{root}, true)
 	// No drive mapping for O: -> falls through to the index.
-	out := m.match(&matchInput{FilePath: `O:\elsewhere\unique.wav`, TrackFound: true})
+	out := m.match(&matchInput{FilePath: `O:\elsewhere\unique.wav`})
 
 	if out.Status != MediaStatusPresent {
 		t.Fatalf("status = %q, want present", out.Status)
@@ -155,7 +156,7 @@ func TestMatch_IndexAmbiguous(t *testing.T) {
 	writeFile(t, filepath.Join(root, "b", "dup.wav"))
 
 	m := buildTestMatcher(t, nil, []string{root}, true)
-	out := m.match(&matchInput{FileName: `O:\x\dup.wav`, TrackFound: true})
+	out := m.match(&matchInput{FileName: `O:\x\dup.wav`})
 
 	if out.Status != MediaStatusAmbiguous {
 		t.Fatalf("status = %q, want ambiguous", out.Status)
@@ -170,7 +171,7 @@ func TestMatch_ExtensionIndependent(t *testing.T) {
 	writeFile(t, filepath.Join(root, "song.flac")) // DB says .wav, disk has .flac
 
 	m := buildTestMatcher(t, nil, []string{root}, true)
-	out := m.match(&matchInput{FilePath: `O:\Audio\song.wav`, TrackFound: true})
+	out := m.match(&matchInput{FilePath: `O:\Audio\song.wav`})
 
 	if out.Status != MediaStatusPresent {
 		t.Fatalf("status = %q, want present", out.Status)
@@ -180,28 +181,44 @@ func TestMatch_ExtensionIndependent(t *testing.T) {
 	}
 }
 
-func TestMatch_MetadataFallback(t *testing.T) {
+func TestMatch_MetadataOnlyIsNotAFileReference(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "Artist - Title.mp3"))
 
 	m := buildTestMatcher(t, nil, []string{root}, true)
-	// No path references at all; only metadata is available.
-	out := m.match(&matchInput{Artist: "Artist", TrackTitle: "Title", TrackFound: true})
+	out := m.match(&matchInput{Artist: "Artist", TrackTitle: "Title"})
 
-	if out.Status != MediaStatusPresent {
-		t.Fatalf("status = %q, want present", out.Status)
-	}
-	if out.MatchType != matchTypeMetadata {
-		t.Errorf("matchType = %q, want %q", out.MatchType, matchTypeMetadata)
+	if out.Status != MediaStatusNoReference {
+		t.Fatalf("status = %q, want no_reference", out.Status)
 	}
 }
 
 func TestMatch_NoReference(t *testing.T) {
 	m := buildTestMatcher(t, nil, nil, true)
-	out := m.match(&matchInput{TrackFound: false})
+	out := m.match(&matchInput{})
 
 	if out.Status != MediaStatusNoReference {
 		t.Fatalf("status = %q, want no_reference", out.Status)
+	}
+}
+
+func TestMatch_ConcretePathIgnoresBareTitleIndexHit(t *testing.T) {
+	driveDir := t.TempDir()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "jingles", "Liefdedealer.mp3"))
+
+	m := buildTestMatcher(t, map[string]string{"O:": driveDir}, []string{root}, true)
+	out := m.match(&matchInput{
+		FilePath:   `O:\Audio\85\Blof - Liefdedealer.wav`,
+		Artist:     "Blof",
+		TrackTitle: "Liefdedealer",
+	})
+
+	if out.Status != MediaStatusMissing {
+		t.Fatalf("status = %q, want missing", out.Status)
+	}
+	if len(out.Matches) != 0 {
+		t.Fatalf("matches = %v, want none", out.Matches)
 	}
 }
 
@@ -223,13 +240,28 @@ func TestMatch_CaseSensitivity(t *testing.T) {
 func TestMatch_StatErrorWhenRootUnavailable(t *testing.T) {
 	// Drive mapped to a directory that cannot be opened -> stat error, not missing.
 	m := buildTestMatcher(t, map[string]string{"O:": filepath.Join(t.TempDir(), "does-not-exist")}, nil, true)
-	out := m.match(&matchInput{FilePath: `O:\Audio\x.wav`, TrackFound: true})
+	out := m.match(&matchInput{FilePath: `O:\Audio\x.wav`})
 
 	if out.Status != MediaStatusStatError {
 		t.Fatalf("status = %q, want stat_error", out.Status)
 	}
 	if out.Error == "" {
 		t.Error("expected non-empty error message")
+	}
+}
+
+func TestMatch_StatErrorWinsOverIndexFallback(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "x.wav"))
+
+	m := buildTestMatcher(t, map[string]string{"O:": filepath.Join(t.TempDir(), "does-not-exist")}, []string{root}, true)
+	out := m.match(&matchInput{FilePath: `O:\Audio\x.wav`})
+
+	if out.Status != MediaStatusStatError {
+		t.Fatalf("status = %q, want stat_error", out.Status)
+	}
+	if len(out.Matches) != 0 {
+		t.Fatalf("matches = %v, want none", out.Matches)
 	}
 }
 
@@ -241,10 +273,18 @@ func TestMatch_DriveMappingPrefersExactOverIndex(t *testing.T) {
 	writeFile(t, filepath.Join(root, "other", "hit.wav"))
 
 	m := buildTestMatcher(t, map[string]string{"O:": driveDir}, []string{root}, true)
-	out := m.match(&matchInput{FilePath: `O:\Audio\hit.wav`, TrackFound: true})
+	out := m.match(&matchInput{FilePath: `O:\Audio\hit.wav`})
 
 	if out.Status != MediaStatusPresent || out.MatchType != matchTypeExactPath {
 		t.Fatalf("status=%q matchType=%q, want present/exact_path", out.Status, out.MatchType)
+	}
+}
+
+func TestBuildFileIndexRecordsWalkError(t *testing.T) {
+	idx := buildFileIndex(context.Background(), []string{filepath.Join(t.TempDir(), "missing")}, true)
+
+	if err := idx.err(); err == nil {
+		t.Fatal("expected index error for missing root, got nil")
 	}
 }
 

--- a/internal/service/s3.go
+++ b/internal/service/s3.go
@@ -15,7 +15,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// s3Service manages uploads and deletions of backup files to S3-compatible storage.
+// s3Service syncs managed backup files to S3-compatible storage.
 type s3Service struct {
 	tm     *transfermanager.Client
 	client *s3.Client
@@ -23,8 +23,8 @@ type s3Service struct {
 	prefix string
 }
 
-// newS3Service creates an S3 client for backup synchronization, or returns nil if disabled.
-func newS3Service(cfg *config.S3Config) (*s3Service, error) { //nolint:unparam // error return kept for future use
+// newS3Service returns an S3 sync client, or nil when disabled.
+func newS3Service(cfg *config.S3Config) (*s3Service, error) { //nolint:unparam // error result reserved for future client validation
 	if !cfg.Enabled {
 		return nil, nil
 	}
@@ -54,7 +54,7 @@ func newS3Service(cfg *config.S3Config) (*s3Service, error) { //nolint:unparam /
 	}, nil
 }
 
-// ptrOrNil returns nil for empty strings, otherwise a pointer to the string.
+// ptrOrNil returns nil for an empty string and an AWS string pointer otherwise.
 func ptrOrNil(s string) *string {
 	if s == "" {
 		return nil
@@ -62,9 +62,9 @@ func ptrOrNil(s string) *string {
 	return aws.String(s)
 }
 
-// upload transfers a backup file to S3 storage.
+// upload streams one local backup file to remote storage.
 func (s *s3Service) upload(ctx context.Context, filename, localPath string) (err error) {
-	file, err := os.Open(localPath) //nolint:gosec // localPath is constructed from validated backup filename
+	file, err := os.Open(localPath) //nolint:gosec // G304: localPath is built from a validated managed backup filename
 	if err != nil {
 		return types.NewOperationError("S3 upload", fmt.Errorf("open file: %w", err))
 	}
@@ -93,7 +93,7 @@ func (s *s3Service) upload(ctx context.Context, filename, localPath string) (err
 	return nil
 }
 
-// delete removes a backup file from S3 storage.
+// delete removes one backup object from remote storage.
 func (s *s3Service) delete(ctx context.Context, filename string) error {
 	key := s.prefix + filename
 

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -61,6 +61,13 @@ func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 		}
 	}
 
+	// Register media file check job if enabled.
+	if cfg.MediaFileCheck.Enabled && cfg.MediaFileCheck.Scheduler.Enabled {
+		if err := s.addJob(cfg.MediaFileCheck.Scheduler.Schedule, "media-file-check", s.runMediaFileCheck); err != nil {
+			return nil, err
+		}
+	}
+
 	return s, nil
 }
 
@@ -129,6 +136,23 @@ func (s *Scheduler) runFileMonitor(_ context.Context) {
 		return
 	}
 	slog.Info("Scheduled file monitor check started")
+}
+
+// runMediaFileCheck verifies that today's playlist audio files exist on disk.
+// It funnels through TriggerScheduled so a manual API trigger and a cron tick
+// cannot overlap, and so the scheduled run (which emails alerts) keeps a stable
+// today-scope for the failure/recovery transition.
+func (s *Scheduler) runMediaFileCheck(_ context.Context) {
+	if _, err := s.service.MediaFileCheck.TriggerScheduled(); err != nil {
+		var conflict *types.ConflictError
+		if errors.As(err, &conflict) {
+			slog.Info("Scheduled media file check skipped (already running)")
+			return
+		}
+		slog.Error("Scheduled media file check failed to start", "error", err)
+		return
+	}
+	slog.Info("Scheduled media file check started")
 }
 
 // healthCheckTimeout is the maximum time allowed for a scheduled health check.

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -12,16 +12,14 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// Scheduler manages cron-based scheduled jobs for the application.
-// It consolidates all scheduled tasks into a single cron instance.
+// Scheduler runs all enabled cron jobs on one shared cron instance.
 type Scheduler struct {
 	cron    *cron.Cron
 	service *AeronService
 	jobs    []string // names of registered jobs for logging
 }
 
-// NewScheduler creates a scheduler and registers all enabled scheduled jobs.
-// The scheduler uses the system's local timezone (set via TZ environment variable).
+// NewScheduler registers enabled jobs using the local system timezone (TZ).
 func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -39,21 +37,18 @@ func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 
 	s := &Scheduler{cron: c, service: svc}
 
-	// Register backup job if enabled
 	if cfg.Backup.Enabled && cfg.Backup.Scheduler.Enabled {
 		if err := s.addJob(cfg.Backup.Scheduler.Schedule, "backup", s.runBackup); err != nil {
 			return nil, err
 		}
 	}
 
-	// Register health check job if enabled
 	if cfg.Maintenance.Scheduler.Enabled {
 		if err := s.addJob(cfg.Maintenance.Scheduler.Schedule, "health-check", s.runHealthCheck); err != nil {
 			return nil, err
 		}
 	}
 
-	// Register file monitor job if enabled (cadence from FileMonitor.Interval()).
 	if cfg.FileMonitor.Enabled {
 		schedule := fmt.Sprintf("@every %s", cfg.FileMonitor.Interval())
 		if err := s.addJob(schedule, "file-monitor", s.runFileMonitor); err != nil {
@@ -61,7 +56,6 @@ func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 		}
 	}
 
-	// Register media file check job if enabled.
 	if cfg.MediaFileCheck.Enabled && cfg.MediaFileCheck.Scheduler.Enabled {
 		if err := s.addJob(cfg.MediaFileCheck.Scheduler.Schedule, "media-file-check", s.runMediaFileCheck); err != nil {
 			return nil, err
@@ -71,7 +65,7 @@ func NewScheduler(ctx context.Context, svc *AeronService) (*Scheduler, error) {
 	return s, nil
 }
 
-// addJob registers a context-aware scheduled job with a name for observability.
+// addJob registers a named job whose context follows the scheduler lifecycle.
 // The context passed to the job function is derived from the cron's base context,
 // enabling graceful shutdown propagation to running jobs.
 func (s *Scheduler) addJob(schedule, name string, job func(context.Context)) error {
@@ -84,7 +78,7 @@ func (s *Scheduler) addJob(schedule, name string, job func(context.Context)) err
 	return nil
 }
 
-// Start activates all scheduled jobs.
+// Start activates the cron runner when at least one job is registered.
 func (s *Scheduler) Start() {
 	if len(s.jobs) == 0 {
 		return
@@ -93,7 +87,7 @@ func (s *Scheduler) Start() {
 	slog.Info("Scheduler started", "jobs", s.jobs)
 }
 
-// Stop halts the scheduler and waits for running jobs to finish.
+// Stop halts the cron runner and returns a context that closes after jobs drain.
 func (s *Scheduler) Stop() context.Context {
 	if len(s.jobs) == 0 {
 		return context.Background()
@@ -102,7 +96,7 @@ func (s *Scheduler) Stop() context.Context {
 	return s.cron.Stop()
 }
 
-// HasJobs returns true if any jobs are registered.
+// HasJobs reports whether the scheduler has registered work.
 func (s *Scheduler) HasJobs() bool {
 	return len(s.jobs) > 0
 }
@@ -158,7 +152,7 @@ func (s *Scheduler) runMediaFileCheck(_ context.Context) {
 // healthCheckTimeout is the maximum time allowed for a scheduled health check.
 const healthCheckTimeout = 2 * time.Minute
 
-// runHealthCheck performs a scheduled database health check and sends alerts if issues are detected.
+// runHealthCheck runs the scheduled database health check and alert pass.
 func (s *Scheduler) runHealthCheck(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
 	defer cancel()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,4 +1,4 @@
-// Package service provides business logic for the Aeron Toolbox.
+// Package service coordinates media, backup, monitoring, and notification workflows.
 package service
 
 import (
@@ -12,7 +12,7 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/notify"
 )
 
-// AeronService is the main service that provides access to all sub-services.
+// AeronService owns the application sub-services and shared dependencies.
 type AeronService struct {
 	Media          *MediaService
 	Backup         *BackupService
@@ -25,7 +25,7 @@ type AeronService struct {
 	config *config.Config
 }
 
-// New creates a new AeronService instance with all sub-services.
+// New wires the service layer around db and cfg.
 func New(db *sqlx.DB, cfg *config.Config) (*AeronService, error) {
 	repo := database.NewRepository(db, cfg.Database.Schema)
 	notifySvc := notify.New(cfg)
@@ -52,17 +52,17 @@ func New(db *sqlx.DB, cfg *config.Config) (*AeronService, error) {
 	}, nil
 }
 
-// Config returns the service configuration.
+// Config returns the shared configuration.
 func (s *AeronService) Config() *config.Config {
 	return s.config
 }
 
-// Repository returns the database repository.
+// Repository returns the shared database repository.
 func (s *AeronService) Repository() *database.Repository {
 	return s.repo
 }
 
-// Close gracefully shuts down all services.
+// Close drains background work owned by sub-services.
 func (s *AeronService) Close() {
 	s.Backup.Close()
 	s.FileMonitor.Close()
@@ -70,7 +70,7 @@ func (s *AeronService) Close() {
 	s.Notify.Close()
 }
 
-// DecodeBase64 decodes a base64 string, stripping any data URL prefix if present.
+// DecodeBase64 decodes raw base64 or a data URL payload.
 func DecodeBase64(data string) ([]byte, error) {
 	if _, after, found := strings.Cut(data, ","); found {
 		data = after

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -14,11 +14,12 @@ import (
 
 // AeronService is the main service that provides access to all sub-services.
 type AeronService struct {
-	Media       *MediaService
-	Backup      *BackupService
-	Maintenance *MaintenanceService
-	FileMonitor *FileMonitorService
-	Notify      *notify.NotificationService
+	Media          *MediaService
+	Backup         *BackupService
+	Maintenance    *MaintenanceService
+	FileMonitor    *FileMonitorService
+	MediaFileCheck *MediaFileCheckService
+	Notify         *notify.NotificationService
 
 	repo   *database.Repository
 	config *config.Config
@@ -40,13 +41,14 @@ func New(db *sqlx.DB, cfg *config.Config) (*AeronService, error) {
 	}
 
 	return &AeronService{
-		Media:       newMediaService(repo, cfg),
-		Backup:      backupSvc,
-		Maintenance: newMaintenanceService(repo, cfg, notifySvc),
-		FileMonitor: fileMonitorSvc,
-		Notify:      notifySvc,
-		repo:        repo,
-		config:      cfg,
+		Media:          newMediaService(repo, cfg),
+		Backup:         backupSvc,
+		Maintenance:    newMaintenanceService(repo, cfg, notifySvc),
+		FileMonitor:    fileMonitorSvc,
+		MediaFileCheck: newMediaFileCheckService(repo, cfg, notifySvc),
+		Notify:         notifySvc,
+		repo:           repo,
+		config:         cfg,
 	}, nil
 }
 
@@ -64,6 +66,7 @@ func (s *AeronService) Repository() *database.Repository {
 func (s *AeronService) Close() {
 	s.Backup.Close()
 	s.FileMonitor.Close()
+	s.MediaFileCheck.Close()
 	s.Notify.Close()
 }
 

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -2,27 +2,27 @@ package types
 
 import "fmt"
 
-// EntityType identifies the type of entity (artist or track).
+// EntityType identifies the media entity kind used by API routes.
 type EntityType string
 
 const (
-	// EntityTypeArtist represents an artist entity.
+	// EntityTypeArtist selects artist records.
 	EntityTypeArtist EntityType = "artist"
-	// EntityTypeTrack represents a track entity.
+	// EntityTypeTrack selects track records.
 	EntityTypeTrack EntityType = "track"
 )
 
-// Table represents a database table name.
+// Table is a validated Aeron table selector.
 type Table string
 
 const (
-	// TableArtist is the database table name for artist records.
+	// TableArtist selects the artist table.
 	TableArtist Table = "artist"
-	// TableTrack is the database table name for track records.
+	// TableTrack selects the track table.
 	TableTrack Table = "track"
 )
 
-// LongRunningQuery represents a query that has been running longer than the configured threshold.
+// LongRunningQuery is a database query exceeding the configured duration threshold.
 type LongRunningQuery struct {
 	PID      int    `db:"pid" json:"pid"`
 	Duration string `db:"duration" json:"duration"`
@@ -36,7 +36,7 @@ const VoicetrackUserID = "021F097E-B504-49BB-9B89-16B64D2E8422"
 // SupportedFormats lists the image formats that can be processed.
 var SupportedFormats = []string{"jpeg", "jpg", "png"}
 
-// IDColumnForTable returns the primary key column name for the given table.
+// IDColumnForTable returns the Aeron primary-key column for table.
 func IDColumnForTable(table Table) string {
 	if table == TableTrack {
 		return "titleid"
@@ -44,7 +44,7 @@ func IDColumnForTable(table Table) string {
 	return "artistid"
 }
 
-// IsValidIdentifier reports whether name contains only valid SQL identifier characters.
+// IsValidIdentifier reports whether name is a non-empty SQL identifier.
 func IsValidIdentifier(name string) bool {
 	if name == "" {
 		return false

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -1,4 +1,4 @@
-// Package types provides shared type definitions used across the application.
+// Package types defines shared API, database, and error contracts.
 package types
 
 import (
@@ -29,7 +29,7 @@ func (e *NotFoundError) Error() string {
 // StatusCode implements HTTPError.
 func (e *NotFoundError) StatusCode() int { return http.StatusNotFound }
 
-// NewNotFoundError creates a NotFoundError for the specified resource type and ID.
+// NewNotFoundError returns a 404-mapped error for resource and id.
 func NewNotFoundError(resource, id string) *NotFoundError {
 	return &NotFoundError{Resource: resource, ID: id}
 }
@@ -51,7 +51,7 @@ func (e *ValidationError) Error() string {
 // StatusCode implements HTTPError.
 func (e *ValidationError) StatusCode() int { return http.StatusBadRequest }
 
-// NewValidationError creates a ValidationError for the specified field.
+// NewValidationError returns a 400-mapped error for a field-level problem.
 func NewValidationError(field, message string) *ValidationError {
 	return &ValidationError{Field: field, Message: message}
 }
@@ -78,7 +78,7 @@ func (e *OperationError) Unwrap() error {
 // StatusCode implements HTTPError.
 func (e *OperationError) StatusCode() int { return http.StatusInternalServerError }
 
-// NewOperationError creates an OperationError wrapping the given error.
+// NewOperationError wraps err with an operation label.
 func NewOperationError(operation string, err error) *OperationError {
 	return &OperationError{Operation: operation, Err: err}
 }
@@ -97,7 +97,7 @@ func (e *ConflictError) Error() string {
 // StatusCode implements HTTPError.
 func (e *ConflictError) StatusCode() int { return http.StatusConflict }
 
-// NewConflictError creates a ConflictError for the specified resource.
+// NewConflictError returns a 409-mapped error for a conflicting resource action.
 func NewConflictError(resource, message string) *ConflictError {
 	return &ConflictError{Resource: resource, Message: message}
 }
@@ -116,7 +116,7 @@ func (e *ConfigError) Error() string {
 // StatusCode implements HTTPError.
 func (e *ConfigError) StatusCode() int { return http.StatusInternalServerError }
 
-// NewConfigError creates a ConfigError for the specified configuration field.
+// NewConfigError returns a configuration error for field.
 func NewConfigError(field, message string) *ConfigError {
 	return &ConfigError{Field: field, Message: message}
 }

--- a/internal/util/formatters.go
+++ b/internal/util/formatters.go
@@ -2,6 +2,19 @@ package util
 
 import "fmt"
 
+// FormatArtistTitle renders an "artist - title" label, falling back to whichever
+// of the two is present (title preferred) and to "" when both are empty.
+func FormatArtistTitle(artist, title string) string {
+	switch {
+	case artist != "" && title != "":
+		return artist + " - " + title
+	case title != "":
+		return title
+	default:
+		return artist
+	}
+}
+
 // FormatBytes converts bytes to a human-readable string with binary prefixes.
 func FormatBytes(bytes int64) string {
 	const (

--- a/internal/util/validators.go
+++ b/internal/util/validators.go
@@ -1,4 +1,4 @@
-// Package util provides utility functions for input validation and HTTP operations.
+// Package util groups validation, formatting, and guarded HTTP helpers.
 package util
 
 import (
@@ -18,15 +18,15 @@ import (
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
-// uuidRegex is a lazily-initialized pattern for validating UUID v4 format.
+// uuidRegex lazily compiles the UUID v4 validator.
 var uuidRegex = sync.OnceValue(func() *regexp.Regexp {
 	return regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 })
 
-// GUIDPattern matches the standard GUID format (less strict than UUID v4).
+// GUIDPattern matches the standard GUID shape without UUID-version checks.
 var GUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
-// ValidateEntityID validates that an ID is a proper UUID v4 format.
+// ValidateEntityID rejects empty or non-UUID-v4 entity IDs.
 func ValidateEntityID(id, entityLabel string) error {
 	if id == "" {
 		return types.NewValidationError("id", fmt.Sprintf("invalid %s ID: must not be empty", entityLabel))
@@ -39,13 +39,13 @@ func ValidateEntityID(id, entityLabel string) error {
 	return nil
 }
 
-// safeHTTPClient returns a reusable HTTP client with SSRF protection.
+// safeHTTPClient returns the shared SSRF-protected HTTP client.
 var safeHTTPClient = sync.OnceValue(func() *safeurl.WrappedClient {
 	cfg := safeurl.GetConfigBuilder().Build()
 	return safeurl.Client(cfg)
 })
 
-// ValidateURL validates a URL for allowed schemes and hostname presence.
+// ValidateURL allows only HTTP(S) URLs with a hostname.
 func ValidateURL(urlString string) error {
 	if urlString == "" {
 		return types.NewValidationError("url", "empty URL")
@@ -67,7 +67,7 @@ func ValidateURL(urlString string) error {
 	return nil
 }
 
-// ValidateContentType validates that a Content-Type header indicates an image.
+// ValidateContentType rejects non-image Content-Type values when present.
 func ValidateContentType(contentType string) error {
 	if contentType != "" && !strings.HasPrefix(contentType, "image/") {
 		return types.NewValidationError("image", fmt.Sprintf("not an image content-type: %s", contentType))
@@ -75,7 +75,7 @@ func ValidateContentType(contentType string) error {
 	return nil
 }
 
-// ValidateImageData validates that byte data represents a valid image.
+// ValidateImageData rejects empty or undecodable image bytes.
 func ValidateImageData(data []byte) error {
 	if len(data) == 0 {
 		return types.NewValidationError("image", "image is empty")
@@ -89,7 +89,7 @@ func ValidateImageData(data []byte) error {
 	return nil
 }
 
-// ValidateImageFormat validates that an image format is supported.
+// ValidateImageFormat rejects formats outside types.SupportedFormats.
 func ValidateImageFormat(format string) error {
 	if !slices.Contains(types.SupportedFormats, format) {
 		return types.NewValidationError("image",
@@ -98,7 +98,7 @@ func ValidateImageFormat(format string) error {
 	return nil
 }
 
-// ValidateAndDownloadImage validates and securely downloads an image from a URL.
+// ValidateAndDownloadImage validates, downloads, and decodes a remote image.
 func ValidateAndDownloadImage(urlString string, maxSize int64) ([]byte, error) {
 	if err := ValidateURL(urlString); err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -1,11 +1,5 @@
-// Package main implements the Aeron Toolbox API server.
-//
-// This server provides an unofficial REST API for the Aeron radio automation system.
-// It offers image management, database browsing, database maintenance, and backup
-// functionality through direct database access.
-//
-// The API server can be configured via JSON configuration file and supports
-// optional API key authentication for secure access.
+// Package main wires configuration, storage, scheduling, and HTTP serving for
+// the Aeron Toolbox API.
 package main
 
 import (
@@ -34,7 +28,7 @@ func main() {
 	}
 }
 
-// run executes the server lifecycle from initialization through graceful shutdown.
+// run initializes dependencies and blocks until the server exits or shuts down.
 func run() error {
 	configFile := flag.String("config", "", "Path to config file (default: config.json)")
 	port := flag.String("port", "8080", "API server port (default: 8080)")
@@ -67,7 +61,7 @@ func run() error {
 	}
 	defer svc.Close()
 
-	// Start background refresh of secret expiry info so health checks don't block
+	// Start background secret-expiry refresh so health checks do not block.
 	svc.Notify.StartExpiryChecker()
 
 	// Create a root context that cancels on SIGINT/SIGTERM.
@@ -88,7 +82,7 @@ func run() error {
 	return serveUntilShutdown(server, *port, scheduler, ctx)
 }
 
-// printVersion prints the application version, commit hash, and build time.
+// printVersion writes build metadata and exits without starting the server.
 func printVersion() {
 	fmt.Printf("Aeron Toolbox %s (%s)\n", Version, Commit)
 	fmt.Printf("Build time: %s\n", BuildTime)
@@ -110,7 +104,7 @@ func initLogger(cfg *config.Config) {
 	slog.Info("Logger initialized", "level", level.String(), "format", cfg.Log.GetFormat())
 }
 
-// setupDatabase establishes a database connection pool and returns a cleanup function.
+// setupDatabase opens the configured PostgreSQL pool and returns its cleanup function.
 func setupDatabase(cfg *config.Config) (*sqlx.DB, func(), error) {
 	db, err := sqlx.Open("postgres", cfg.Database.ConnectionString())
 	if err != nil {
@@ -144,8 +138,7 @@ func setupDatabase(cfg *config.Config) (*sqlx.DB, func(), error) {
 	return db, cleanup, nil
 }
 
-// serveUntilShutdown runs the API server until a shutdown signal or error occurs.
-// The ctx parameter is the application lifecycle context, canceled on SIGINT/SIGTERM.
+// serveUntilShutdown runs the API server until ctx is cancelled or serving fails.
 func serveUntilShutdown(server *api.Server, port string, scheduler *service.Scheduler, ctx context.Context) error {
 	serverErr := make(chan error, 1)
 	go func() {
@@ -166,9 +159,8 @@ func serveUntilShutdown(server *api.Server, port string, scheduler *service.Sche
 	return gracefulShutdown(server, scheduler)
 }
 
-// gracefulShutdown performs orderly shutdown of the scheduler and server.
+// gracefulShutdown drains scheduled jobs before stopping the HTTP server.
 func gracefulShutdown(server *api.Server, scheduler *service.Scheduler) error {
-	// Stop scheduler (handles both backup and maintenance jobs)
 	ctx := scheduler.Stop()
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Checks whether the audio files the playlist references actually exist on disk. Same idea as `file_monitor`, but database-driven: it reads the playlist items plus their track/audio metadata and looks each reference up on the filesystem.

Aeron stores Windows paths (`O:\Audio\85\Artist - Title.wav`) and we run on Linux, so matching is two passes. `drive_mounts` translates the drive (`O:` → `/mnt/aeron-o`) for an exact stat, and on a miss `search_dirs` are indexed and matched by filename, with and without extension. It won't fall back to artist/title, so a same-named file can't mask a missing one. Each item ends up `present`, `missing`, `ambiguous`, `no_reference` or `stat_error`.

Endpoints (async, single-flight):
- `POST /api/media/files/check` with optional `date`, `from`+`to`, `block_id`, `limit`, `include_voicetracks` → `202` + `run_id`
- `GET /api/media/files/check/status`

An optional cron runs it over today + `lookahead_days`, mails failure/recovery alerts, and sets a `media_file_check` block in `/api/health` (scheduled run only). Tested with unit tests and an end-to-end run against a production dump; `go fmt`, `vet`, `golangci-lint` and `go test` are green. `config.example.json` and `API.md` updated.