### PR TITLE
refactor: consolidate duplicated middleware, SQL params, backup checks, email subjects

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/service"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
@@ -83,7 +84,7 @@ func (s *Server) router() http.Handler {
 				})
 
 				r.Group(func(r chi.Router) {
-					r.Use(s.requireBackupEnabled)
+					r.Use(s.requireEnabled("backup is not enabled", func(c *config.Config) bool { return c.Backup.Enabled }))
 					r.Post("/backup", s.handleCreateBackup)
 					r.Get("/backup/status", s.handleBackupStatus)
 					r.Get("/backups", s.handleListBackups)
@@ -94,13 +95,13 @@ func (s *Server) router() http.Handler {
 			})
 
 			r.Group(func(r chi.Router) {
-				r.Use(s.requireFileMonitorEnabled)
+				r.Use(s.requireEnabled("file monitor is not enabled", func(c *config.Config) bool { return c.FileMonitor.Enabled }))
 				r.Get("/file-monitor/status", s.handleFileMonitorStatus)
 				r.Post("/file-monitor/check", s.handleFileMonitorCheck)
 			})
 
 			r.Group(func(r chi.Router) {
-				r.Use(s.requireMediaFileCheckEnabled)
+				r.Use(s.requireEnabled("media file check is not enabled", func(c *config.Config) bool { return c.MediaFileCheck.Enabled }))
 				r.Post("/media/files/check", s.handleMediaFileCheck)
 				r.Get("/media/files/check/status", s.handleMediaFileCheckStatus)
 			})
@@ -162,34 +163,19 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (s *Server) requireBackupEnabled(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !s.service.Config().Backup.Enabled {
-			respondError(w, http.StatusNotFound, "backup is not enabled")
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func (s *Server) requireFileMonitorEnabled(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !s.service.Config().FileMonitor.Enabled {
-			respondError(w, http.StatusNotFound, "file monitor is not enabled")
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func (s *Server) requireMediaFileCheckEnabled(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !s.service.Config().MediaFileCheck.Enabled {
-			respondError(w, http.StatusNotFound, "media file check is not enabled")
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
+// requireEnabled builds middleware that 404s when a feature is disabled. The
+// enabled predicate is evaluated per request against the live config, so a
+// runtime config change is reflected without rebuilding the router.
+func (s *Server) requireEnabled(message string, enabled func(*config.Config) bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !enabled(s.service.Config()) {
+				respondError(w, http.StatusNotFound, message)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func (s *Server) isValidAPIKey(key string) bool {

--- a/internal/database/mediacheck.go
+++ b/internal/database/mediacheck.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
@@ -76,27 +75,22 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 		return "", nil, types.NewValidationError("schema", fmt.Sprintf("invalid schema name: %s", schema))
 	}
 
-	paramCount := 0
-	nextParam := func(v any) string {
-		paramCount++
-		params = append(params, v)
-		return "$" + strconv.Itoa(paramCount)
-	}
+	pl := &paramList{}
 
 	var conditions []string
 	switch {
 	case opts.BlockID != "":
-		conditions = append(conditions, fmt.Sprintf("pi.blockid = %s", nextParam(opts.BlockID)))
+		conditions = append(conditions, fmt.Sprintf("pi.blockid = %s", pl.next(opts.BlockID)))
 	case opts.Date != "":
-		p := nextParam(opts.Date)
+		p := pl.next(opts.Date)
 		conditions = append(conditions,
 			fmt.Sprintf("pi.startdatetime >= %s::date AND pi.startdatetime < %s::date + INTERVAL '1 day'", p, p))
 	case opts.From != "" || opts.To != "":
 		if opts.From != "" {
-			conditions = append(conditions, fmt.Sprintf("pi.startdatetime >= %s::date", nextParam(opts.From)))
+			conditions = append(conditions, fmt.Sprintf("pi.startdatetime >= %s::date", pl.next(opts.From)))
 		}
 		if opts.To != "" {
-			conditions = append(conditions, fmt.Sprintf("pi.startdatetime < %s::date + INTERVAL '1 day'", nextParam(opts.To)))
+			conditions = append(conditions, fmt.Sprintf("pi.startdatetime < %s::date + INTERVAL '1 day'", pl.next(opts.To)))
 		}
 	case opts.LookaheadDays > 0:
 		// Today through today+LookaheadDays inclusive. The date math runs in the
@@ -104,7 +98,7 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 		// regardless of the app's timezone.
 		conditions = append(conditions, fmt.Sprintf(
 			"pi.startdatetime >= CURRENT_DATE AND pi.startdatetime < CURRENT_DATE + %s::int",
-			nextParam(opts.LookaheadDays+1)))
+			pl.next(opts.LookaheadDays+1)))
 	default:
 		conditions = append(conditions,
 			"pi.startdatetime >= CURRENT_DATE AND pi.startdatetime < CURRENT_DATE + INTERVAL '1 day'")
@@ -112,7 +106,7 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 
 	if !opts.IncludeVoicetracks {
 		conditions = append(conditions,
-			fmt.Sprintf("(t.userid IS NULL OR t.userid <> %s::uuid)", nextParam(types.VoicetrackUserID)))
+			fmt.Sprintf("(t.userid IS NULL OR t.userid <> %s::uuid)", pl.next(types.VoicetrackUserID)))
 	}
 
 	joins := fmt.Sprintf(mediaCheckJoins, schema, schema, schema, schema)
@@ -120,10 +114,10 @@ func BuildMediaCheckQuery(schema string, opts *MediaCheckOptions) (query string,
 		mediaCheckColumns, joins, strings.Join(conditions, " AND "))
 
 	if opts.Limit > 0 {
-		query += fmt.Sprintf(" LIMIT %s", nextParam(opts.Limit))
+		query += fmt.Sprintf(" LIMIT %s", pl.next(opts.Limit))
 	}
 
-	return query, params, nil
+	return query, pl.values, nil
 }
 
 // GetMediaCheckItems returns playlist items and audio references for opts.

--- a/internal/database/params.go
+++ b/internal/database/params.go
@@ -2,14 +2,9 @@ package database
 
 import "strconv"
 
-// paramList accumulates positional query parameters and hands out their
-// PostgreSQL placeholders ($1, $2, ...) in declaration order. next(v) binds v
-// and returns its placeholder in one step, so a placeholder and its value can
-// never drift out of sync - the class of bug a hand-maintained counter invites.
-//
-// A placeholder may be reused in the query string (e.g. "%[1]s::date AND
-// < %[1]s::date") by calling next once and referencing the returned string
-// multiple times; only call next again when a new value is bound.
+// paramList binds positional query parameters and hands out their $N
+// placeholders in order, so a placeholder and its value can never drift out of
+// sync. Reuse a placeholder by calling next once and referencing the result.
 type paramList struct {
 	values []any
 }

--- a/internal/database/params.go
+++ b/internal/database/params.go
@@ -1,0 +1,21 @@
+package database
+
+import "strconv"
+
+// paramList accumulates positional query parameters and hands out their
+// PostgreSQL placeholders ($1, $2, ...) in declaration order. next(v) binds v
+// and returns its placeholder in one step, so a placeholder and its value can
+// never drift out of sync - the class of bug a hand-maintained counter invites.
+//
+// A placeholder may be reused in the query string (e.g. "%[1]s::date AND
+// < %[1]s::date") by calling next once and referencing the returned string
+// multiple times; only call next again when a new value is bound.
+type paramList struct {
+	values []any
+}
+
+// next binds v and returns its placeholder (e.g. "$3").
+func (p *paramList) next(v any) string {
+	p.values = append(p.values, v)
+	return "$" + strconv.Itoa(len(p.values))
+}

--- a/internal/database/playlist.go
+++ b/internal/database/playlist.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
@@ -73,16 +72,10 @@ type PlaylistOptions struct {
 // BuildPlaylistQuery builds a parameterized block-item query.
 func BuildPlaylistQuery(schema string, opts *PlaylistOptions) (query string, params []any, err error) {
 	var conditions []string
-	paramCount := 0
-
-	nextParam := func() string {
-		paramCount++
-		return "$" + strconv.Itoa(paramCount)
-	}
+	pl := &paramList{}
 
 	if opts.BlockID != "" {
-		conditions = append(conditions, fmt.Sprintf("pi.blockid = %s", nextParam()))
-		params = append(params, opts.BlockID)
+		conditions = append(conditions, fmt.Sprintf("pi.blockid = %s", pl.next(opts.BlockID)))
 	} else {
 		return "", []any{}, nil
 	}
@@ -90,8 +83,7 @@ func BuildPlaylistQuery(schema string, opts *PlaylistOptions) (query string, par
 	if len(opts.ExportTypes) > 0 {
 		placeholders := make([]string, len(opts.ExportTypes))
 		for i, t := range opts.ExportTypes {
-			placeholders[i] = nextParam()
-			params = append(params, t)
+			placeholders[i] = pl.next(t)
 		}
 		conditions = append(conditions, fmt.Sprintf("COALESCE(t.exporttype, 1) NOT IN (%s)", strings.Join(placeholders, ",")))
 	}
@@ -136,15 +128,13 @@ func BuildPlaylistQuery(schema string, opts *PlaylistOptions) (query string, par
 	query = fmt.Sprintf("SELECT %s %s WHERE %s ORDER BY %s", columns, joins, whereClause, orderBy)
 
 	if opts.Limit > 0 {
-		query += fmt.Sprintf(" LIMIT %s", nextParam())
-		params = append(params, opts.Limit)
+		query += fmt.Sprintf(" LIMIT %s", pl.next(opts.Limit))
 		if opts.Offset > 0 {
-			query += fmt.Sprintf(" OFFSET %s", nextParam())
-			params = append(params, opts.Offset)
+			query += fmt.Sprintf(" OFFSET %s", pl.next(opts.Offset))
 		}
 	}
 
-	return query, params, nil
+	return query, pl.values, nil
 }
 
 // ExecutePlaylistQuery runs a playlist query and scans rows into PlaylistItem values.

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -254,23 +253,20 @@ func (r *Repository) GetPlaylistWithTracks(
 		blockIDs[i] = block.BlockID
 	}
 
-	var dateFilter string
-	params := []any{}
-	paramCount := 0
+	pl := &paramList{}
 
+	var dateFilter string
 	if date != "" {
-		dateFilter = "pi.startdatetime >= $1::date AND pi.startdatetime < $1::date + INTERVAL '1 day'"
-		params = append(params, date)
-		paramCount = 1
+		p := pl.next(date)
+		dateFilter = fmt.Sprintf(
+			"pi.startdatetime >= %s::date AND pi.startdatetime < %s::date + INTERVAL '1 day'", p, p)
 	} else {
 		dateFilter = "pi.startdatetime >= CURRENT_DATE AND pi.startdatetime < CURRENT_DATE + INTERVAL '1 day'"
 	}
 
 	placeholders := make([]string, len(blockIDs))
 	for i, id := range blockIDs {
-		paramCount++
-		placeholders[i] = "$" + strconv.Itoa(paramCount)
-		params = append(params, id)
+		placeholders[i] = pl.next(id)
 	}
 
 	type playlistItemWithBlockID struct {
@@ -286,7 +282,7 @@ func (r *Repository) GetPlaylistWithTracks(
 		columns, joins, dateFilter, strings.Join(placeholders, ","))
 
 	var tempItems []playlistItemWithBlockID
-	err = r.db.SelectContext(ctx, &tempItems, query, params...)
+	err = r.db.SelectContext(ctx, &tempItems, query, pl.values...)
 	if err != nil {
 		return nil, nil, types.NewOperationError("fetch playlist items", err)
 	}

--- a/internal/notify/filemonitor.go
+++ b/internal/notify/filemonitor.go
@@ -39,11 +39,9 @@ func (s *NotificationService) SendFileRecoveries(recoveries []FileAlertResult) {
 }
 
 func formatFileAlerts(alerts []FileAlertResult) (subject, body string) {
-	if len(alerts) == 1 {
-		subject = fmt.Sprintf("[ERROR] File monitor: %s stale - Aeron Toolbox", fileLabel(&alerts[0]))
-	} else {
-		subject = fmt.Sprintf("[ERROR] File monitor: %d files stale - Aeron Toolbox", len(alerts))
-	}
+	subject = errorSubject("File monitor: " + pluralize(len(alerts),
+		fileLabel(&alerts[0])+" stale",
+		fmt.Sprintf("%d files stale", len(alerts))))
 
 	var b strings.Builder
 	b.WriteString("File monitor failed\n\n")
@@ -70,11 +68,9 @@ func formatFileAlerts(alerts []FileAlertResult) (subject, body string) {
 }
 
 func formatFileRecoveries(recoveries []FileAlertResult) (subject, body string) {
-	if len(recoveries) == 1 {
-		subject = fmt.Sprintf("[OK] File monitor: %s recovered - Aeron Toolbox", fileLabel(&recoveries[0]))
-	} else {
-		subject = fmt.Sprintf("[OK] File monitor: %d files recovered - Aeron Toolbox", len(recoveries))
-	}
+	subject = okSubject("File monitor: " + pluralize(len(recoveries),
+		fileLabel(&recoveries[0])+" recovered",
+		fmt.Sprintf("%d files recovered", len(recoveries))))
 
 	var b strings.Builder
 	b.WriteString("File monitor recovered\n\n")

--- a/internal/notify/filemonitor.go
+++ b/internal/notify/filemonitor.go
@@ -39,9 +39,11 @@ func (s *NotificationService) SendFileRecoveries(recoveries []FileAlertResult) {
 }
 
 func formatFileAlerts(alerts []FileAlertResult) (subject, body string) {
-	subject = errorSubject("File monitor: " + pluralize(len(alerts),
-		fileLabel(&alerts[0])+" stale",
-		fmt.Sprintf("%d files stale", len(alerts))))
+	if len(alerts) == 1 {
+		subject = errorSubject("File monitor: " + fileLabel(&alerts[0]) + " stale")
+	} else {
+		subject = errorSubject(fmt.Sprintf("File monitor: %d files stale", len(alerts)))
+	}
 
 	var b strings.Builder
 	b.WriteString("File monitor failed\n\n")
@@ -68,9 +70,11 @@ func formatFileAlerts(alerts []FileAlertResult) (subject, body string) {
 }
 
 func formatFileRecoveries(recoveries []FileAlertResult) (subject, body string) {
-	subject = okSubject("File monitor: " + pluralize(len(recoveries),
-		fileLabel(&recoveries[0])+" recovered",
-		fmt.Sprintf("%d files recovered", len(recoveries))))
+	if len(recoveries) == 1 {
+		subject = okSubject("File monitor: " + fileLabel(&recoveries[0]) + " recovered")
+	} else {
+		subject = okSubject(fmt.Sprintf("File monitor: %d files recovered", len(recoveries)))
+	}
 
 	var b strings.Builder
 	b.WriteString("File monitor recovered\n\n")

--- a/internal/notify/healthalert.go
+++ b/internal/notify/healthalert.go
@@ -34,7 +34,7 @@ func (s *NotificationService) NotifyHealthCheckError(err error) {
 	s.prevHealthAlertActive = true
 	s.stateMu.Unlock()
 
-	subject := "[ERROR] Database health check failed - Aeron Toolbox"
+	subject := errorSubject("Database health check failed")
 
 	var b strings.Builder
 	b.WriteString("Database health check failed\n\n")
@@ -57,7 +57,7 @@ func (s *NotificationService) NotifyHealthAlert(r *HealthAlertResult) {
 }
 
 func formatHealthAlert(r *HealthAlertResult) (subject, body string) {
-	subject = "[ERROR] Database health check - Aeron Toolbox"
+	subject = errorSubject("Database health check")
 
 	var b strings.Builder
 	b.WriteString("Database health check reports problems\n\n")
@@ -87,7 +87,7 @@ func formatHealthAlert(r *HealthAlertResult) (subject, body string) {
 }
 
 func formatHealthRecovery(r *HealthAlertResult) (subject, body string) {
-	subject = "[OK] Database health check recovered - Aeron Toolbox"
+	subject = okSubject("Database health check recovered")
 
 	var b strings.Builder
 	b.WriteString("Database health check recovered\n\n")

--- a/internal/notify/mediacheck.go
+++ b/internal/notify/mediacheck.go
@@ -38,11 +38,9 @@ func (s *NotificationService) NotifyMediaCheckResult(r *MediaCheckResult) {
 }
 
 func formatMediaCheckFailure(r *MediaCheckResult) (subject, body string) {
-	if len(r.Problems) == 1 {
-		subject = fmt.Sprintf("[ERROR] Media file check: %s - Aeron Toolbox", problemLabel(&r.Problems[0]))
-	} else {
-		subject = fmt.Sprintf("[ERROR] Media file check: %d problems - Aeron Toolbox", len(r.Problems))
-	}
+	subject = errorSubject("Media file check: " + pluralize(len(r.Problems),
+		problemLabel(&r.Problems[0]),
+		fmt.Sprintf("%d problems", len(r.Problems))))
 
 	var b strings.Builder
 	b.WriteString("Media file check found problems\n\n")
@@ -70,7 +68,7 @@ func formatMediaCheckFailure(r *MediaCheckResult) (subject, body string) {
 }
 
 func formatMediaCheckRecovery(r *MediaCheckResult) (subject, body string) {
-	subject = "[OK] Media file check: recovered - Aeron Toolbox"
+	subject = okSubject("Media file check: recovered")
 
 	var b strings.Builder
 	b.WriteString("Media file check recovered\n\n")

--- a/internal/notify/mediacheck.go
+++ b/internal/notify/mediacheck.go
@@ -38,9 +38,11 @@ func (s *NotificationService) NotifyMediaCheckResult(r *MediaCheckResult) {
 }
 
 func formatMediaCheckFailure(r *MediaCheckResult) (subject, body string) {
-	subject = errorSubject("Media file check: " + pluralize(len(r.Problems),
-		problemLabel(&r.Problems[0]),
-		fmt.Sprintf("%d problems", len(r.Problems))))
+	if len(r.Problems) == 1 {
+		subject = errorSubject("Media file check: " + problemLabel(&r.Problems[0]))
+	} else {
+		subject = errorSubject(fmt.Sprintf("Media file check: %d problems", len(r.Problems)))
+	}
 
 	var b strings.Builder
 	b.WriteString("Media file check found problems\n\n")

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -16,6 +16,21 @@ import (
 // timeFormat is the timestamp layout used in notification emails.
 const timeFormat = "2006-01-02 15:04:05"
 
+// errorSubject and okSubject format a notification subject line, wrapping a
+// summary with the severity tag and the shared product suffix, e.g.
+// okSubject("Backup recovered") -> "[OK] Backup recovered - Aeron Toolbox".
+func errorSubject(summary string) string { return "[ERROR] " + summary + " - Aeron Toolbox" }
+func okSubject(summary string) string    { return "[OK] " + summary + " - Aeron Toolbox" }
+
+// pluralize returns one when n == 1, otherwise many. It keeps each formatter's
+// singular/plural subject choice to a single expression.
+func pluralize(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
 // BackupResult is the notification payload for a backup run.
 type BackupResult struct {
 	Success   bool
@@ -257,7 +272,7 @@ func (s *NotificationService) trackError(err error) {
 }
 
 func (s *NotificationService) formatBackupFailure(r *BackupResult) (subject, body string) {
-	subject = "[ERROR] Backup failed - Aeron Toolbox"
+	subject = errorSubject("Backup failed")
 
 	var b strings.Builder
 	b.WriteString("Backup failed\n\n")
@@ -278,7 +293,7 @@ func (s *NotificationService) formatBackupFailure(r *BackupResult) (subject, bod
 }
 
 func (s *NotificationService) formatBackupRecovery(r *BackupResult) (subject, body string) {
-	subject = "[OK] Backup recovered - Aeron Toolbox"
+	subject = okSubject("Backup recovered")
 
 	var b strings.Builder
 	b.WriteString("Backup recovered\n\n")
@@ -297,7 +312,7 @@ func (s *NotificationService) formatBackupRecovery(r *BackupResult) (subject, bo
 }
 
 func (s *NotificationService) formatS3Failure(filename string, r *S3SyncResult) (subject, body string) {
-	subject = "[ERROR] S3 synchronization failed - Aeron Toolbox"
+	subject = errorSubject("S3 synchronization failed")
 
 	var b strings.Builder
 	b.WriteString("S3 synchronization failed\n\n")
@@ -313,7 +328,7 @@ func (s *NotificationService) formatS3Failure(filename string, r *S3SyncResult) 
 }
 
 func (s *NotificationService) formatS3Recovery(filename string) (subject, body string) {
-	subject = "[OK] S3 synchronization recovered - Aeron Toolbox"
+	subject = okSubject("S3 synchronization recovered")
 
 	var b strings.Builder
 	b.WriteString("S3 synchronization recovered\n\n")

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -22,15 +22,6 @@ const timeFormat = "2006-01-02 15:04:05"
 func errorSubject(summary string) string { return "[ERROR] " + summary + " - Aeron Toolbox" }
 func okSubject(summary string) string    { return "[OK] " + summary + " - Aeron Toolbox" }
 
-// pluralize returns one when n == 1, otherwise many. It keeps each formatter's
-// singular/plural subject choice to a single expression.
-func pluralize(n int, one, many string) string {
-	if n == 1 {
-		return one
-	}
-	return many
-}
-
 // BackupResult is the notification payload for a backup run.
 type BackupResult struct {
 	Success   bool

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -168,6 +168,27 @@ func validateBackupFilename(filename string) error {
 	return nil
 }
 
+// ensureBackupFile is the shared preamble for operations on an existing backup:
+// it checks the feature is enabled, validates the filename, and confirms the
+// file is present. A missing file maps to NotFoundError; any other stat failure
+// (e.g. permission denied) maps to OperationError rather than being treated as
+// "present", which the previous os.IsNotExist-only check did silently.
+func (s *BackupService) ensureBackupFile(filename string) error {
+	if err := s.checkEnabled(); err != nil {
+		return err
+	}
+	if err := validateBackupFilename(filename); err != nil {
+		return err
+	}
+	if _, err := s.backupRoot.Stat(filename); err != nil {
+		if os.IsNotExist(err) {
+			return types.NewNotFoundError("backup", filename)
+		}
+		return types.NewOperationError("stat backup", err)
+	}
+	return nil
+}
+
 // buildPgDumpArgs constructs the pg_dump arguments for the configured database.
 func (s *BackupService) buildPgDumpArgs(compression int) []string {
 	return []string{
@@ -501,16 +522,8 @@ func (s *BackupService) List() (*BackupListResponse, error) {
 
 // Delete removes a managed backup locally and schedules remote deletion.
 func (s *BackupService) Delete(filename string) error {
-	if err := s.checkEnabled(); err != nil {
+	if err := s.ensureBackupFile(filename); err != nil {
 		return err
-	}
-
-	if err := validateBackupFilename(filename); err != nil {
-		return err
-	}
-
-	if _, err := s.backupRoot.Stat(filename); os.IsNotExist(err) {
-		return types.NewNotFoundError("backup", filename)
 	}
 
 	if err := s.backupRoot.Remove(filename); err != nil {
@@ -539,16 +552,8 @@ func (s *BackupService) Delete(filename string) error {
 
 // GetFilePath validates filename and returns its absolute local path.
 func (s *BackupService) GetFilePath(filename string) (string, error) {
-	if err := s.checkEnabled(); err != nil {
+	if err := s.ensureBackupFile(filename); err != nil {
 		return "", err
-	}
-
-	if err := validateBackupFilename(filename); err != nil {
-		return "", err
-	}
-
-	if _, err := s.backupRoot.Stat(filename); os.IsNotExist(err) {
-		return "", types.NewNotFoundError("backup", filename)
 	}
 
 	return filepath.Join(s.config.Backup.GetPath(), filename), nil

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -168,11 +168,9 @@ func validateBackupFilename(filename string) error {
 	return nil
 }
 
-// ensureBackupFile is the shared preamble for operations on an existing backup:
-// it checks the feature is enabled, validates the filename, and confirms the
-// file is present. A missing file maps to NotFoundError; any other stat failure
-// (e.g. permission denied) maps to OperationError rather than being treated as
-// "present", which the previous os.IsNotExist-only check did silently.
+// ensureBackupFile checks the feature is enabled, validates the filename, and
+// confirms the file is present. A missing file maps to NotFoundError; any other
+// stat error (e.g. permission denied) maps to OperationError.
 func (s *BackupService) ensureBackupFile(filename string) error {
 	if err := s.checkEnabled(); err != nil {
 		return err


### PR DESCRIPTION
Four DRY cleanups spotted in a code review. No behaviour change except one deliberate fix (noted below). Build, `go vet`, `gofmt`, `golangci-lint` (0 issues) and tests are all green.

## Changes

**1. API feature-gates** (`internal/api/server.go`)
Three near-identical `require*Enabled` middlewares collapsed into one `requireEnabled(message, predicate)`. The predicate reads live config per request, so a runtime config change still takes effect without rebuilding the router.

**2. SQL placeholders** (`internal/database/params.go`)
A small `paramList` helper binds a value and returns its `$N` placeholder in one step, replacing three hand-maintained counters in `BuildPlaylistQuery`, `BuildMediaCheckQuery` and `GetPlaylistWithTracks`. Removes the "increment but forget to append" bug class. SQL strings and date-scope logic unchanged.

**3. Backup file checks** (`internal/service/backup.go`)
`Delete` and `GetFilePath` shared the same enabled → validate → stat preamble, now extracted to `ensureBackupFile`.
- **Deliberate fix:** a stat error that is *not* "not exist" (e.g. permission denied) now surfaces as `OperationError` instead of being silently treated as present, which the previous `os.IsNotExist`-only check did.

**4. Notification subjects** (`internal/notify/`)
`errorSubject`/`okSubject` helpers route all 14 alert subjects through one place, removing the repeated `[ERROR]/[OK] … - Aeron Toolbox` boilerplate. Singular/plural choice stays as an explicit `if/else` at each call site; email bodies are unchanged.
