### PR TITLE
Align Docker builder and runtime Alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine3.23 AS builder
+FROM golang:1.26-alpine3.24 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata


### PR DESCRIPTION
## Summary
- Update the builder image to `golang:1.26-alpine3.24` so it matches the runtime `alpine:3.24` base.
- Keep Dockerfile behavior unchanged aside from the Alpine version alignment.

## Testing
- `go test ./...`
- `hadolint Dockerfile`
- `docker compose -f docker-compose.example.yml config --quiet`

Closes #158