### PR TITLE
fix(docker): update Alpine base image tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
       interval: "weekly"
       day: "monday"
 
+  - package-ecosystem: "docker"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine3.24 AS builder
+FROM golang:1.26.4-alpine3.24 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o zwfm-aerontoolbox .
 
 # Runtime stage
-FROM alpine:3.24
+FROM alpine:3.24.1
 
 LABEL org.opencontainers.image.source="https://github.com/oszuidwest/zwfm-aerontoolbox"
 LABEL org.opencontainers.image.description="Headless REST API toolbox for the Aeron radio automation system"


### PR DESCRIPTION
## Summary
- Update the root Dockerfile builder image to the concrete latest Go/Alpine tag: `golang:1.26.4-alpine3.24`.
- Update the root Dockerfile runtime image to the concrete latest Alpine tag: `alpine:3.24.1`.
- Extend Dependabot Docker monitoring to `/tests`; the existing `directory: "/"` entry already covers the root Dockerfile, while `/tests` covers `tests/Dockerfile.testdb`.
- Leave the test Postgres image tag unchanged.

## Verification
- `docker buildx imagetools inspect golang:1.26.4-alpine3.24`
- `docker buildx imagetools inspect alpine:3.24.1`
- `hadolint Dockerfile`
- `yamllint .github/dependabot.yml`
- `docker compose -f docker-compose.example.yml config --quiet`
- `go test ./...`
- `docker build --pull -t zwfm-aerontoolbox:issue-168 .`
- `docker run --rm --entrypoint sh zwfm-aerontoolbox:issue-168 -c 'cat /etc/alpine-release && pg_dump --version'` returned Alpine `3.24.1` and PostgreSQL client `16.14`.

Closes #168