### PR TITLE
fix: reject oversized image dimensions

### DIFF
--- a/API.md
+++ b/API.md
@@ -1668,7 +1668,8 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
     "target_height": 640,
     "quality": 85,
     "reject_smaller": false,
-    "max_image_download_size_bytes": 52428800
+    "max_image_download_size_bytes": 52428800,
+    "max_pixels": 25000000
   },
   "api": {
     "enabled": true,
@@ -1741,6 +1742,10 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   }
 }
 ```
+
+**Instellingen voor afbeeldingen:**
+- `image.max_image_download_size_bytes`: Maximale downloadgrootte voor externe image-URL's (standaard 52428800, 50 MiB).
+- `image.max_pixels`: Maximale gedecodeerde afbeeldingsgrootte in pixels vóór optimalisatie (standaard 25000000). Grotere afbeeldingen worden na `DecodeConfig` afgewezen voordat de volledige pixelbuffer wordt gedecodeerd.
 
 **Instellingen voor bestandscontrole:**
 - `file_monitor.enabled`: Schakel de bestandscontrole in.

--- a/API.md
+++ b/API.md
@@ -1441,7 +1441,7 @@ Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra 
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de gezondheidsstatus niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope die status niet beïnvloeden.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@
 ## Inhoudsopgave
 
 - [Overzicht](#overzicht)
-- [Snel overzicht endpoints](#snel-overzicht-endpoints)
+- [Snel overzicht van de endpoints](#snel-overzicht-van-de-endpoints)
 - [Authenticatie](#authenticatie)
 - [Response-formaat](#response-formaat)
 - [Foutmeldingen](#foutmeldingen)
@@ -15,18 +15,18 @@
   - [Database onderhoud](#database-onderhoud)
   - [Backup-endpoints](#backup-endpoints)
   - [Bestandscontrole](#bestandscontrole)
-  - [Mediabestandcontrole](#mediabestandcontrole)
+  - [Aanwezigheidscontrole](#aanwezigheidscontrole)
   - [Notificaties](#notificaties)
 - [Codevoorbeelden](#codevoorbeelden)
 - [Configuratie](#configuratie)
 
 ## Overzicht
 
-De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem. De API biedt directe databasetoegang voor afbeeldingenbeheer, mediabrowser, database-onderhoud en backup-management.
+De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem en geeft directe databasetoegang voor afbeeldingenbeheer, het doorzoeken van media, database-onderhoud en backupbeheer.
 
 **Basis-URL:** `http://localhost:8080/api`
 
-## Snel overzicht endpoints
+## Snel overzicht van de endpoints
 
 | Endpoint | Methode | Beschrijving | Auth |
 |----------|---------|--------------|------|
@@ -54,9 +54,9 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 | **Bestandscontrole** |
 | `/api/file-monitor/status` | GET | Status bestandscontrole | Ja |
 | `/api/file-monitor/check` | POST | Handmatige bestandscontrole starten | Ja |
-| **Mediabestandcontrole** |
+| **Aanwezigheidscontrole** |
 | `/api/media/files/check` | POST | Controle op ontbrekende audiobestanden starten | Ja |
-| `/api/media/files/check/status` | GET | Resultaat van de mediabestandcontrole | Ja |
+| `/api/media/files/check/status` | GET | Resultaat van de aanwezigheidscontrole | Ja |
 | **Backups** |
 | `/api/db/backup` | POST | Nieuwe backup aanmaken | Ja |
 | `/api/db/backup/status` | GET | Backup status opvragen | Ja |
@@ -73,7 +73,7 @@ Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoint
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
-Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropy (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
+Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropie (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
 
 **Response bij ontbrekende autorisatie:**
 ```json
@@ -190,7 +190,7 @@ De `status`-waarden hebben een vaste prioriteitsvolgorde: `"unhealthy"` > `"degr
 | `checks_alerting` groter dan `0` | `"degraded"` |
 | Geen van bovenstaande | `"healthy"` |
 
-Een database-uitval overschrijft altijd een eventuele `"degraded"`-signaal van notificaties of de bestandscontrole.
+Een database-uitval overschrijft altijd een eventueel `"degraded"`-signaal van notificaties of de bestandscontrole.
 
 ---
 
@@ -687,7 +687,7 @@ De health check kan automatisch worden uitgevoerd via de ingebouwde scheduler. B
 - `scheduler.enabled`: Schakel automatische health checks in/uit
 - `scheduler.schedule`: Cron-expressie (zie backup-sectie voor voorbeelden)
 
-Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via `TZ` environment variable).
+Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via de `TZ`-omgevingsvariabele).
 
 ---
 
@@ -711,7 +711,7 @@ Backups worden asynchroon uitgevoerd:
 Na het aanmaken van een backup wordt deze automatisch gevalideerd via `pg_restore --list` (controleert TOC en checksums). Alleen gevalideerde backups worden als succesvol gemarkeerd en naar S3 gesynchroniseerd.
 
 Deze aanpak biedt voordelen:
-- Request retourneert direct (geen timeout issues)
+- Request retourneert direct (geen problemen met time-outs)
 - Fouten zijn zichtbaar via het status endpoint
 - Er kan slechts één backup tegelijk draaien
 - Bij connectieverlies loopt backup door op de server
@@ -738,7 +738,7 @@ Backups kunnen automatisch worden uitgevoerd via de ingebouwde scheduler. Config
 - `enabled`: Schakel automatische backups in/uit
 - `schedule`: Cron-expressie voor het backup-schema
 
-De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als environment variable.
+De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als omgevingsvariabele.
 
 **Cron-expressieformaat:** `minuut uur dag maand weekdag`
 
@@ -794,7 +794,7 @@ Backups kunnen automatisch worden gesynchroniseerd naar S3-compatibele storage (
 
 **Gedrag:**
 - Na elke succesvolle backup wordt het bestand asynchroon naar S3 geüpload
-- Bij het verwijderen van lokale backups (handmatig of door retention) wordt ook de S3-kopie verwijderd
+- Bij het verwijderen van lokale backups (handmatig of door retentie) wordt ook de S3-kopie verwijderd
 - S3-fouten blokkeren de backup niet; de status is zichtbaar via `GET /api/db/backup/status`
 - Uploads gebruiken multipart voor grote bestanden
 
@@ -1202,8 +1202,8 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 - `path`: Bestandspad op schijf.
 - `max_age_minutes`: Maximaal toegestane leeftijd.
 - `file_exists`: Of het bestand bestaat (`true`, `false`, of `null` bij fouten).
-- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
-- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
+- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
+- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
 - `is_stale`: Of het bestand te oud is of niet bereikbaar is.
 - `in_alert`: Of voor dit bestand momenteel een alert actief is. Buiten de geconfigureerde `active_window` is dit altijd `false`, ook als `is_stale` `true` is.
 - `error`: Leesbare foutmelding bij toegangsproblemen (ontbreekt bij normaal gebruik).
@@ -1214,7 +1214,7 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 
 ### Handmatig een bestandscontrole starten
 
-Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande tick.
+Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande controle.
 
 **Endpoint:** `POST /api/file-monitor/check`
 **Authenticatie:** Vereist
@@ -1252,9 +1252,9 @@ De handmatige trigger en de cronjob gebruiken dezelfde single-flight gate. Daard
 
 Strikte gelijkheid (`completed_run_id == myRunID`) bevestigt dat de zichtbare `checks` exact door jouw run zijn geproduceerd. Een hogere waarde betekent dat een latere run, bijvoorbeeld via cron, jouw run heeft ingehaald. Dat is prima voor de vraag "is het systeem nu gezond?", maar verliest de exacte correlatie. Gebruik voor nauwkeurige troubleshooting daarom de strikte vergelijking en houd rekening met een mogelijke race.
 
-### Integratie met de health-endpoint (bestandscontrole)
+### Integratie met het health-endpoint (bestandscontrole)
 
-Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
+Als de bestandscontrole is ingeschakeld, geeft het health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
 
 ```json
 {
@@ -1276,9 +1276,9 @@ Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/hea
 
 ---
 
-## Mediabestandcontrole
+## Aanwezigheidscontrole
 
-Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, is de mediabestandcontrole **database-gestuurd**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks vóórdat ze in de uitzending vallen.
+Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, werkt de aanwezigheidscontrole **op basis van de database**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks voordat ze worden uitgezonden.
 
 De controle draait asynchroon: een `POST` start een run op de achtergrond en geeft direct een `run_id` terug; het resultaat lees je op met `GET .../status`.
 
@@ -1300,7 +1300,7 @@ Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de 
 - `no_reference` — het playlistitem heeft geen bruikbare referentie (bijv. de track bestaat niet meer in de database).
 - `stat_error` — het bestand kon niet gecontroleerd worden (time-out, geen rechten, mount onbereikbaar).
 
-### Mediabestandcontrole starten
+### Aanwezigheidscontrole starten
 
 Start een controle op de achtergrond voor de opgegeven scope.
 
@@ -1346,7 +1346,7 @@ Start een controle op de achtergrond voor de opgegeven scope.
 
 De handmatige trigger en de geplande cronrun delen dezelfde single-flight gate; ze kunnen elkaar dus niet overlappen.
 
-### Resultaat van de mediabestandcontrole
+### Resultaat van de aanwezigheidscontrole
 
 Toont de runstatus plus het resultaat van de meest recente run.
 
@@ -1416,17 +1416,17 @@ Toont de runstatus plus het resultaat van de meest recente run.
 - `checked_paths`: De concrete paden en zoekacties die zijn geprobeerd.
 - `matches`: De gevonden bestanden op schijf (één bij `present`, meerdere bij `ambiguous`).
 - `match_type`: Hoe gematcht is: `exact_path`, `filename` of `filename_noext` (ontbreekt bij geen match).
-- `error`: Foutmelding bij `stat_error` (ontbreekt verder).
+- `error`: Foutmelding bij `stat_error` (ontbreekt in andere gevallen).
 
 **Pollingrecept:** lees `run_id` uit de `POST`-response (`myRunID`), poll daarna `GET .../status` tot `completed_run_id >= myRunID && running == false`.
 
 ### Geplande controle en e-mailnotificaties
 
-Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` checkt de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
+Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` controleert de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
 
-### Integratie met de health-endpoint (mediabestandcontrole)
+### Integratie met het health-endpoint (aanwezigheidscontrole)
 
-Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
+Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
 
 ```json
 {
@@ -1441,7 +1441,7 @@ Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de gezondheidsstatus niet beïnvloeden.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@
 ## Inhoudsopgave
 
 - [Overzicht](#overzicht)
-- [Snel overzicht endpoints](#snel-overzicht-endpoints)
+- [Snel overzicht van de endpoints](#snel-overzicht-van-de-endpoints)
 - [Authenticatie](#authenticatie)
 - [Response-formaat](#response-formaat)
 - [Foutmeldingen](#foutmeldingen)
@@ -15,18 +15,18 @@
   - [Database onderhoud](#database-onderhoud)
   - [Backup-endpoints](#backup-endpoints)
   - [Bestandscontrole](#bestandscontrole)
-  - [Mediabestandcontrole](#mediabestandcontrole)
+  - [Aanwezigheidscontrole](#aanwezigheidscontrole)
   - [Notificaties](#notificaties)
 - [Codevoorbeelden](#codevoorbeelden)
 - [Configuratie](#configuratie)
 
 ## Overzicht
 
-De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem. De API biedt directe databasetoegang voor afbeeldingenbeheer, mediabrowser, database-onderhoud en backup-management.
+De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem en geeft directe databasetoegang voor afbeeldingenbeheer, het doorzoeken van media, database-onderhoud en backupbeheer.
 
 **Basis-URL:** `http://localhost:8080/api`
 
-## Snel overzicht endpoints
+## Snel overzicht van de endpoints
 
 | Endpoint | Methode | Beschrijving | Auth |
 |----------|---------|--------------|------|
@@ -54,9 +54,9 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 | **Bestandscontrole** |
 | `/api/file-monitor/status` | GET | Status bestandscontrole | Ja |
 | `/api/file-monitor/check` | POST | Handmatige bestandscontrole starten | Ja |
-| **Mediabestandcontrole** |
+| **Aanwezigheidscontrole** |
 | `/api/media/files/check` | POST | Controle op ontbrekende audiobestanden starten | Ja |
-| `/api/media/files/check/status` | GET | Resultaat van de mediabestandcontrole | Ja |
+| `/api/media/files/check/status` | GET | Resultaat van de aanwezigheidscontrole | Ja |
 | **Backups** |
 | `/api/db/backup` | POST | Nieuwe backup aanmaken | Ja |
 | `/api/db/backup/status` | GET | Backup status opvragen | Ja |
@@ -73,7 +73,7 @@ Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoint
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
-Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropy (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
+Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropie (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
 
 **Response bij ontbrekende autorisatie:**
 ```json
@@ -190,7 +190,7 @@ De `status`-waarden hebben een vaste prioriteitsvolgorde: `"unhealthy"` > `"degr
 | `checks_alerting` groter dan `0` | `"degraded"` |
 | Geen van bovenstaande | `"healthy"` |
 
-Een database-uitval overschrijft altijd een eventuele `"degraded"`-signaal van notificaties of de bestandscontrole.
+Een database-uitval overschrijft altijd een eventueel `"degraded"`-signaal van notificaties of de bestandscontrole.
 
 ---
 
@@ -687,7 +687,7 @@ De health check kan automatisch worden uitgevoerd via de ingebouwde scheduler. B
 - `scheduler.enabled`: Schakel automatische health checks in/uit
 - `scheduler.schedule`: Cron-expressie (zie backup-sectie voor voorbeelden)
 
-Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via `TZ` environment variable).
+Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via de `TZ`-omgevingsvariabele).
 
 ---
 
@@ -711,7 +711,7 @@ Backups worden asynchroon uitgevoerd:
 Na het aanmaken van een backup wordt deze automatisch gevalideerd via `pg_restore --list` (controleert TOC en checksums). Alleen gevalideerde backups worden als succesvol gemarkeerd en naar S3 gesynchroniseerd.
 
 Deze aanpak biedt voordelen:
-- Request retourneert direct (geen timeout issues)
+- Request retourneert direct (geen problemen met time-outs)
 - Fouten zijn zichtbaar via het status endpoint
 - Er kan slechts één backup tegelijk draaien
 - Bij connectieverlies loopt backup door op de server
@@ -738,7 +738,7 @@ Backups kunnen automatisch worden uitgevoerd via de ingebouwde scheduler. Config
 - `enabled`: Schakel automatische backups in/uit
 - `schedule`: Cron-expressie voor het backup-schema
 
-De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als environment variable.
+De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als omgevingsvariabele.
 
 **Cron-expressieformaat:** `minuut uur dag maand weekdag`
 
@@ -794,7 +794,7 @@ Backups kunnen automatisch worden gesynchroniseerd naar S3-compatibele storage (
 
 **Gedrag:**
 - Na elke succesvolle backup wordt het bestand asynchroon naar S3 geüpload
-- Bij het verwijderen van lokale backups (handmatig of door retention) wordt ook de S3-kopie verwijderd
+- Bij het verwijderen van lokale backups (handmatig of door retentie) wordt ook de S3-kopie verwijderd
 - S3-fouten blokkeren de backup niet; de status is zichtbaar via `GET /api/db/backup/status`
 - Uploads gebruiken multipart voor grote bestanden
 
@@ -1202,8 +1202,8 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 - `path`: Bestandspad op schijf.
 - `max_age_minutes`: Maximaal toegestane leeftijd.
 - `file_exists`: Of het bestand bestaat (`true`, `false`, of `null` bij fouten).
-- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
-- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
+- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
+- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
 - `is_stale`: Of het bestand te oud is of niet bereikbaar is.
 - `in_alert`: Of voor dit bestand momenteel een alert actief is. Buiten de geconfigureerde `active_window` is dit altijd `false`, ook als `is_stale` `true` is.
 - `error`: Leesbare foutmelding bij toegangsproblemen (ontbreekt bij normaal gebruik).
@@ -1214,7 +1214,7 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 
 ### Handmatig een bestandscontrole starten
 
-Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande tick.
+Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande controle.
 
 **Endpoint:** `POST /api/file-monitor/check`
 **Authenticatie:** Vereist
@@ -1252,9 +1252,9 @@ De handmatige trigger en de cronjob gebruiken dezelfde single-flight gate. Daard
 
 Strikte gelijkheid (`completed_run_id == myRunID`) bevestigt dat de zichtbare `checks` exact door jouw run zijn geproduceerd. Een hogere waarde betekent dat een latere run, bijvoorbeeld via cron, jouw run heeft ingehaald. Dat is prima voor de vraag "is het systeem nu gezond?", maar verliest de exacte correlatie. Gebruik voor nauwkeurige troubleshooting daarom de strikte vergelijking en houd rekening met een mogelijke race.
 
-### Integratie met de health-endpoint (bestandscontrole)
+### Integratie met het health-endpoint (bestandscontrole)
 
-Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
+Als de bestandscontrole is ingeschakeld, geeft het health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
 
 ```json
 {
@@ -1276,9 +1276,9 @@ Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/hea
 
 ---
 
-## Mediabestandcontrole
+## Aanwezigheidscontrole
 
-Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, is de mediabestandcontrole **database-gestuurd**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks vóórdat ze in de uitzending vallen.
+Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, werkt de aanwezigheidscontrole **op basis van de database**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks voordat ze worden uitgezonden.
 
 De controle draait asynchroon: een `POST` start een run op de achtergrond en geeft direct een `run_id` terug; het resultaat lees je op met `GET .../status`.
 
@@ -1300,7 +1300,7 @@ Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de 
 - `no_reference` — het playlistitem heeft geen bruikbare referentie (bijv. de track bestaat niet meer in de database).
 - `stat_error` — het bestand kon niet gecontroleerd worden (time-out, geen rechten, mount onbereikbaar).
 
-### Mediabestandcontrole starten
+### Aanwezigheidscontrole starten
 
 Start een controle op de achtergrond voor de opgegeven scope.
 
@@ -1346,7 +1346,7 @@ Start een controle op de achtergrond voor de opgegeven scope.
 
 De handmatige trigger en de geplande cronrun delen dezelfde single-flight gate; ze kunnen elkaar dus niet overlappen.
 
-### Resultaat van de mediabestandcontrole
+### Resultaat van de aanwezigheidscontrole
 
 Toont de runstatus plus het resultaat van de meest recente run.
 
@@ -1416,17 +1416,17 @@ Toont de runstatus plus het resultaat van de meest recente run.
 - `checked_paths`: De concrete paden en zoekacties die zijn geprobeerd.
 - `matches`: De gevonden bestanden op schijf (één bij `present`, meerdere bij `ambiguous`).
 - `match_type`: Hoe gematcht is: `exact_path`, `filename` of `filename_noext` (ontbreekt bij geen match).
-- `error`: Foutmelding bij `stat_error` (ontbreekt verder).
+- `error`: Foutmelding bij `stat_error` (ontbreekt in andere gevallen).
 
 **Pollingrecept:** lees `run_id` uit de `POST`-response (`myRunID`), poll daarna `GET .../status` tot `completed_run_id >= myRunID && running == false`.
 
 ### Geplande controle en e-mailnotificaties
 
-Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` checkt de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
+Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` controleert de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
 
-### Integratie met de health-endpoint (mediabestandcontrole)
+### Integratie met het health-endpoint (aanwezigheidscontrole)
 
-Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
+Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
 
 ```json
 {
@@ -1441,7 +1441,7 @@ Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope die status niet beïnvloeden.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 
 - **Afbeeldingen:** upload en optimaliseer albumhoezen en artiestfoto's
 - **Media:** doorzoek artiesten, tracks en playlists met metadata
-- **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
+- **Onderhoud:** bewaak de conditie van de database en ontvang automatisch een melding bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
 - **Mediabestanden:** controleer op basis van de database of de audio uit de playlist daadwerkelijk op schijf staat

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 
 - **Afbeeldingen:** upload en optimaliseer albumhoezen en artiestfoto's
 - **Media:** doorzoek artiesten, tracks en playlists met metadata
-- **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
+- **Onderhoud:** bewaak de conditie van de database en ontvang automatisch een melding bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
-- **Mediabestanden:** controleer database-gestuurd of de audio uit de playlist daadwerkelijk op schijf staat
+- **Mediabestanden:** controleer op basis van de database of de audio uit de playlist daadwerkelijk op schijf staat
 
 ## Snel starten
 
@@ -23,7 +23,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/config.example.json -O config.json
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-compose.example.yml -O docker-compose.yml
 
-# Pas config.json aan naar jouw situatie, dan:
+# Stem config.json af op jouw situatie, dan:
 docker compose up -d
 ```
 
@@ -40,7 +40,7 @@ docker run -d -p 8080:8080 \
 ```
 
 > [!NOTE]
-> De `TZ` omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
+> De `TZ`-omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
 
 ### Binary
 
@@ -70,11 +70,11 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `maintenance` | Drempelwaarden en automatische scheduler voor database health checks |
 | `backup` | Pad naar backups, retentie, scheduler en optionele S3-sync |
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
-| `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
+| `media_file_check` | Controleert op basis van de database of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
 
-Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropy, bijvoorbeeld via `openssl rand -base64 32`.
+Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropie, bijvoorbeeld via `openssl rand -base64 32`.
 
 ### Backupfunctionaliteit
 
@@ -112,7 +112,7 @@ Dit controleert elke zondag om 04:00 de database en stuurt een melding bij probl
 
 ### E-mailnotificaties
 
-Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send` permissie.
+Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send`-machtiging.
 
 ```json
 "notifications": {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 - **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
-- **Mediabestanden:** controleer database-gestuurd of de audio uit de playlist daadwerkelijk op schijf staat
+- **Mediabestanden:** controleer op basis van de database of de audio uit de playlist daadwerkelijk op schijf staat
 
 ## Snel starten
 
@@ -23,7 +23,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/config.example.json -O config.json
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-compose.example.yml -O docker-compose.yml
 
-# Pas config.json aan naar jouw situatie, dan:
+# Stem config.json af op jouw situatie, dan:
 docker compose up -d
 ```
 
@@ -40,7 +40,7 @@ docker run -d -p 8080:8080 \
 ```
 
 > [!NOTE]
-> De `TZ` omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
+> De `TZ`-omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
 
 ### Binary
 
@@ -70,11 +70,11 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `maintenance` | Drempelwaarden en automatische scheduler voor database health checks |
 | `backup` | Pad naar backups, retentie, scheduler en optionele S3-sync |
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
-| `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
+| `media_file_check` | Controleert op basis van de database of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
 
-Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropy, bijvoorbeeld via `openssl rand -base64 32`.
+Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropie, bijvoorbeeld via `openssl rand -base64 32`.
 
 ### Backupfunctionaliteit
 
@@ -112,7 +112,7 @@ Dit controleert elke zondag om 04:00 de database en stuurt een melding bij probl
 
 ### E-mailnotificaties
 
-Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send` permissie.
+Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send`-machtiging.
 
 ```json
 "notifications": {

--- a/config.example.json
+++ b/config.example.json
@@ -16,7 +16,8 @@
     "target_height": 640,
     "quality": 85,
     "reject_smaller": false,
-    "max_image_download_size_bytes": 52428800
+    "max_image_download_size_bytes": 52428800,
+    "max_pixels": 25000000
   },
   "api": {
     "enabled": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type ImageConfig struct {
 	Quality                   int   `json:"quality" validate:"required,min=1,max=100"`
 	RejectSmaller             bool  `json:"reject_smaller"`
 	MaxImageDownloadSizeBytes int64 `json:"max_image_download_size_bytes" validate:"gte=0"`
+	MaxPixels                 int64 `json:"max_pixels" validate:"gte=0"`
 }
 
 // APIConfig controls API authentication and request timeouts.
@@ -242,6 +243,7 @@ const (
 	DefaultMaxIdleConnections          = 5
 	DefaultConnMaxLifetimeMinutes      = 5
 	DefaultMaxImageDownloadSizeBytes   = 50 * 1024 * 1024
+	DefaultMaxImagePixels              = 25_000_000
 	DefaultRequestTimeoutSeconds       = 30
 	DefaultBloatThreshold              = 10.0
 	DefaultDeadTupleThreshold          = 10000
@@ -262,6 +264,11 @@ const (
 // GetMaxDownloadBytes returns the configured image download cap or its default.
 func (c *ImageConfig) GetMaxDownloadBytes() int64 {
 	return cmp.Or(c.MaxImageDownloadSizeBytes, DefaultMaxImageDownloadSizeBytes)
+}
+
+// GetMaxPixels returns the decoded image pixel cap or its default.
+func (c *ImageConfig) GetMaxPixels() int64 {
+	return cmp.Or(c.MaxPixels, DefaultMaxImagePixels)
 }
 
 // GetRequestTimeout returns the configured HTTP timeout or its default.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,18 @@ func TestInterval_ZeroFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestImageConfigMaxPixels(t *testing.T) {
+	cfg := &ImageConfig{}
+	if got, want := cfg.GetMaxPixels(), int64(DefaultMaxImagePixels); got != want {
+		t.Errorf("GetMaxPixels() = %d, want %d", got, want)
+	}
+
+	cfg.MaxPixels = 123
+	if got := cfg.GetMaxPixels(); got != 123 {
+		t.Errorf("GetMaxPixels() = %d, want configured value 123", got)
+	}
+}
+
 func TestFileMonitorValidation_DuplicatePaths(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.FileMonitor.Enabled = true

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -190,11 +190,9 @@ func extractImageInfo(imageData []byte) (*Info, error) {
 // validateImageDimensions checks minimum and maximum size requirements.
 func validateImageDimensions(info *Info, config Config) error {
 	if exceedsMaxPixels(info.Width, info.Height, config.MaxPixels) {
-		return &types.ValidationError{
-			Field: "dimensions",
-			Message: fmt.Sprintf("image is too large: %dx%d (maximum %d pixels)",
-				info.Width, info.Height, config.MaxPixels),
-		}
+		return types.NewValidationError("dimensions", fmt.Sprintf(
+			"image is too large: %dx%d (maximum %d pixels)",
+			info.Width, info.Height, config.MaxPixels))
 	}
 
 	if config.RejectSmaller && (info.Width < config.TargetWidth || info.Height < config.TargetHeight) {

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -19,6 +19,7 @@ type Config struct {
 	TargetHeight  int
 	Quality       int
 	RejectSmaller bool
+	MaxPixels     int64
 }
 
 // ProcessingResult reports original and stored image characteristics.
@@ -186,8 +187,16 @@ func extractImageInfo(imageData []byte) (*Info, error) {
 	}, nil
 }
 
-// validateImageDimensions checks minimum size requirements when RejectSmaller is set.
+// validateImageDimensions checks minimum and maximum size requirements.
 func validateImageDimensions(info *Info, config Config) error {
+	if exceedsMaxPixels(info.Width, info.Height, config.MaxPixels) {
+		return &types.ValidationError{
+			Field: "dimensions",
+			Message: fmt.Sprintf("image is too large: %dx%d (maximum %d pixels)",
+				info.Width, info.Height, config.MaxPixels),
+		}
+	}
+
 	if config.RejectSmaller && (info.Width < config.TargetWidth || info.Height < config.TargetHeight) {
 		return &types.ValidationError{
 			Field: "dimensions",
@@ -196,6 +205,13 @@ func validateImageDimensions(info *Info, config Config) error {
 		}
 	}
 	return nil
+}
+
+func exceedsMaxPixels(width, height int, maxPixels int64) bool {
+	if maxPixels <= 0 || width <= 0 || height <= 0 {
+		return false
+	}
+	return int64(width) > maxPixels/int64(height)
 }
 
 // isAlreadyTargetSize returns true if image matches target dimensions exactly.

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -7,7 +7,6 @@ import (
 	"image"
 	"image/jpeg"
 	"image/png"
-	"math/big"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
@@ -192,8 +191,8 @@ func extractImageInfo(imageData []byte) (*Info, error) {
 func validateImageDimensions(info *Info, config Config) error {
 	if exceedsMaxPixels(info.Width, info.Height, config.MaxPixels) {
 		return types.NewValidationError("dimensions", fmt.Sprintf(
-			"image is too large: %dx%d (%s pixels exceeds maximum %d)",
-			info.Width, info.Height, pixelCountString(info.Width, info.Height), config.MaxPixels))
+			"image is too large: %dx%d (%d pixels exceeds maximum %d)",
+			info.Width, info.Height, int64(info.Width)*int64(info.Height), config.MaxPixels))
 	}
 
 	if config.RejectSmaller && (info.Width < config.TargetWidth || info.Height < config.TargetHeight) {
@@ -211,11 +210,6 @@ func exceedsMaxPixels(width, height int, maxPixels int64) bool {
 		return false
 	}
 	return int64(width) > maxPixels/int64(height)
-}
-
-func pixelCountString(width, height int) string {
-	pixels := new(big.Int).Mul(big.NewInt(int64(width)), big.NewInt(int64(height)))
-	return pixels.String()
 }
 
 // isAlreadyTargetSize returns true if image matches target dimensions exactly.

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -81,7 +81,11 @@ func pngWithDimensions(t *testing.T, width, height uint32) []byte {
 func writePNGChunk(t *testing.T, dst *bytes.Buffer, chunkType string, data []byte) {
 	t.Helper()
 
-	if err := binary.Write(dst, binary.BigEndian, uint32(len(data))); err != nil {
+	if uint64(len(data)) > uint64(^uint32(0)) {
+		t.Fatalf("chunk data too large: %d", len(data))
+	}
+	chunkLength := uint32(len(data)) //nolint:gosec // checked above against PNG's uint32 chunk length limit.
+	if err := binary.Write(dst, binary.BigEndian, chunkLength); err != nil {
 		t.Fatalf("write chunk length: %v", err)
 	}
 	writeString(t, dst, chunkType)

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -234,15 +234,15 @@ func jpegWithDimensions(t *testing.T, width, height uint16) []byte {
 	t.Helper()
 
 	data := []byte{0xff, 0xd8}
-	sof0 := []byte{
-		8,
-		byte(height >> 8), byte(height),
-		byte(width >> 8), byte(width),
+	sof0 := []byte{8}
+	sof0 = binary.BigEndian.AppendUint16(sof0, height)
+	sof0 = binary.BigEndian.AppendUint16(sof0, width)
+	sof0 = append(sof0,
 		3,
 		1, 0x11, 0,
 		2, 0x11, 0,
 		3, 0x11, 0,
-	}
+	)
 	data = appendJPEGMarker(data, 0xc0, sof0)
 	sos := []byte{
 		3,

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -1,0 +1,108 @@
+package image
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	stdimage "image"
+	"image/color"
+	stdpng "image/png"
+	"strings"
+	"testing"
+)
+
+func TestProcessRejectsOversizedDimensionsBeforeDecode(t *testing.T) {
+	data := pngWithDimensions(t, 10_000, 10_000)
+
+	_, err := Process(data, Config{
+		TargetWidth:  640,
+		TargetHeight: 640,
+		Quality:      85,
+		MaxPixels:    1_000_000,
+	})
+	if err == nil {
+		t.Fatal("Process returned nil error, want oversized dimensions error")
+	}
+	if !strings.Contains(err.Error(), "image is too large") {
+		t.Fatalf("error = %q, want oversized dimensions error", err.Error())
+	}
+	if strings.Contains(err.Error(), "failed to decode PNG") {
+		t.Fatalf("error = %q, oversized image should be rejected before full PNG decode", err.Error())
+	}
+}
+
+func TestProcessAllowsImageAtPixelLimit(t *testing.T) {
+	var buf bytes.Buffer
+	img := stdimage.NewRGBA(stdimage.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+	if err := stdpng.Encode(&buf, img); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	result, err := Process(buf.Bytes(), Config{
+		TargetWidth:  1,
+		TargetHeight: 1,
+		Quality:      85,
+		MaxPixels:    1,
+	})
+	if err != nil {
+		t.Fatalf("Process returned error: %v", err)
+	}
+	if result.Original.Width != 1 || result.Original.Height != 1 {
+		t.Fatalf("original dimensions = %dx%d, want 1x1", result.Original.Width, result.Original.Height)
+	}
+}
+
+func TestExceedsMaxPixelsAvoidsOverflow(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	if !exceedsMaxPixels(maxInt, maxInt, 1) {
+		t.Fatal("exceedsMaxPixels = false, want true for huge dimensions")
+	}
+}
+
+func pngWithDimensions(t *testing.T, width, height uint32) []byte {
+	t.Helper()
+
+	var data bytes.Buffer
+	writeBytes(t, &data, []byte{137, 80, 78, 71, 13, 10, 26, 10})
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], width)
+	binary.BigEndian.PutUint32(ihdr[4:8], height)
+	ihdr[8] = 8 // bit depth
+	ihdr[9] = 2 // truecolor
+
+	writePNGChunk(t, &data, "IHDR", ihdr)
+	writePNGChunk(t, &data, "IEND", nil)
+
+	return data.Bytes()
+}
+
+func writePNGChunk(t *testing.T, dst *bytes.Buffer, chunkType string, data []byte) {
+	t.Helper()
+
+	if err := binary.Write(dst, binary.BigEndian, uint32(len(data))); err != nil {
+		t.Fatalf("write chunk length: %v", err)
+	}
+	writeString(t, dst, chunkType)
+	writeBytes(t, dst, data)
+
+	crcData := append([]byte(chunkType), data...)
+	if err := binary.Write(dst, binary.BigEndian, crc32.ChecksumIEEE(crcData)); err != nil {
+		t.Fatalf("write chunk crc: %v", err)
+	}
+}
+
+func writeString(t *testing.T, dst *bytes.Buffer, value string) {
+	t.Helper()
+	if _, err := dst.WriteString(value); err != nil {
+		t.Fatalf("write string: %v", err)
+	}
+}
+
+func writeBytes(t *testing.T, dst *bytes.Buffer, value []byte) {
+	t.Helper()
+	if _, err := dst.Write(value); err != nil {
+		t.Fatalf("write bytes: %v", err)
+	}
+}

--- a/internal/service/media.go
+++ b/internal/service/media.go
@@ -110,6 +110,7 @@ func (s *MediaService) UploadImage(ctx context.Context, params *ImageUploadParam
 		TargetHeight:  s.config.Image.TargetHeight,
 		Quality:       s.config.Image.Quality,
 		RejectSmaller: s.config.Image.RejectSmaller,
+		MaxPixels:     s.config.Image.GetMaxPixels(),
 	}
 	slog.Debug("Image processing started",
 		"inputSize", len(imageData),


### PR DESCRIPTION
## Fact check
- Confirmed `extractImageInfo` already uses `image.DecodeConfig`, so dimensions are available before full decode.
- Confirmed validation only enforced minimum dimensions when `reject_smaller` is set.
- Confirmed JPEG/PNG optimization then calls full decoders that allocate based on decoded dimensions.

## Fix
- Added configurable `image.max_pixels` with a 25,000,000 pixel default.
- Pass the configured cap from media uploads into the image processor.
- Reject oversized dimensions immediately after `DecodeConfig`, before JPEG/PNG full decode.
- Use an overflow-safe `width > max/height` check for maliciously huge dimensions.
- Documented the setting in `config.example.json` and API docs.

## Verification
- `go test ./internal/image ./internal/config ./internal/service`
- `go test ./...`

Closes #160