### PR TITLE
fix: keep backup file operations rooted

### DIFF
--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -50,18 +50,18 @@ func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDownloadBackupFile(w http.ResponseWriter, r *http.Request) {
 	filename := chi.URLParam(r, "filename")
 
-	filePath, err := s.service.Backup.GetFilePath(filename)
+	file, info, err := s.service.Backup.OpenFile(filename)
 	if err != nil {
 		statusCode := errorCode(err)
 		respondError(w, statusCode, err.Error())
 		return
 	}
+	defer file.Close()
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", "attachment; filename="+filename)
 
-	//nolint:gosec // G703: filePath comes from Backup.GetFilePath after filename validation and os.Root lookup.
-	http.ServeFile(w, r, filePath)
+	http.ServeContent(w, r, filename, info.ModTime(), file)
 }
 
 func (s *Server) handleDeleteBackup(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -56,7 +57,11 @@ func (s *Server) handleDownloadBackupFile(w http.ResponseWriter, r *http.Request
 		respondError(w, statusCode, err.Error())
 		return
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			slog.Debug("Failed to close backup download file", "filename", filename, "error", err)
+		}
+	}()
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", "attachment; filename="+filename)

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -176,7 +176,9 @@ func validateBackupFilename(filename string) error {
 	return nil
 }
 
-func (s *BackupService) validateBackupFileName(filename string) error {
+// checkBackupAccess verifies backup support is enabled and filename names a
+// managed backup file.
+func (s *BackupService) checkBackupAccess(filename string) error {
 	if err := s.checkEnabled(); err != nil {
 		return err
 	}
@@ -190,7 +192,7 @@ func (s *BackupService) validateBackupFileName(filename string) error {
 // confirms the file is present. A missing file maps to NotFoundError; any other
 // stat error (e.g. permission denied) maps to OperationError.
 func (s *BackupService) ensureBackupFile(filename string) error {
-	if err := s.validateBackupFileName(filename); err != nil {
+	if err := s.checkBackupAccess(filename); err != nil {
 		return err
 	}
 	if _, err := s.backupRoot.Stat(filename); err != nil {
@@ -230,7 +232,7 @@ func (s *BackupService) compressionLevel(requested int) (int, error) {
 
 // OpenFile opens a managed backup file through the backup root.
 func (s *BackupService) OpenFile(filename string) (*os.File, os.FileInfo, error) {
-	if err := s.validateBackupFileName(filename); err != nil {
+	if err := s.checkBackupAccess(filename); err != nil {
 		return nil, nil, err
 	}
 
@@ -257,6 +259,8 @@ func (s *BackupService) OpenFile(filename string) (*os.File, os.FileInfo, error)
 
 // validateBackupFile checks backup integrity with pg_restore --list.
 func (s *BackupService) validateBackupFile(ctx context.Context, file *os.File) error {
+	// pg_restore inherits the current file offset from stdin, so rewind before
+	// validating in case a future caller has already read from the handle.
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return types.NewOperationError("backup validation", fmt.Errorf("seek file: %w", err))
 	}
@@ -275,14 +279,14 @@ func (s *BackupService) validateBackupFile(ctx context.Context, file *os.File) e
 	return nil
 }
 
-func (s *BackupService) validateManagedBackupFile(ctx context.Context, filename string) (err error) {
+func (s *BackupService) validateManagedBackupFile(ctx context.Context, filename string) error {
 	file, _, err := s.OpenFile(filename)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = types.NewOperationError("backup validation", fmt.Errorf("close file: %w", closeErr))
+		if closeErr := file.Close(); closeErr != nil {
+			slog.Warn("Failed to close backup validation file", "filename", filename, "error", closeErr)
 		}
 	}()
 
@@ -472,14 +476,14 @@ func (s *BackupService) Status() *BackupStatus {
 	return &status
 }
 
-func (s *BackupService) uploadBackupToS3(ctx context.Context, filename string) (err error) {
+func (s *BackupService) uploadBackupToS3(ctx context.Context, filename string) error {
 	file, _, err := s.OpenFile(filename)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = types.NewOperationError("S3 upload", fmt.Errorf("close file: %w", closeErr))
+		if closeErr := file.Close(); closeErr != nil {
+			slog.Warn("Failed to close backup upload file", "filename", filename, "error", closeErr)
 		}
 	}()
 

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -104,6 +106,12 @@ func newBackupService(
 // Close waits for any running backup or tracked follow-up work.
 func (s *BackupService) Close() {
 	s.runner.Close()
+	if s.backupRoot != nil {
+		if err := s.backupRoot.Close(); err != nil {
+			slog.Warn("Failed to close backup root", "error", err)
+		}
+		s.backupRoot = nil
+	}
 }
 
 // BackupRequest selects optional backup parameters.
@@ -168,14 +176,21 @@ func validateBackupFilename(filename string) error {
 	return nil
 }
 
-// ensureBackupFile checks the feature is enabled, validates the filename, and
-// confirms the file is present. A missing file maps to NotFoundError; any other
-// stat error (e.g. permission denied) maps to OperationError.
-func (s *BackupService) ensureBackupFile(filename string) error {
+func (s *BackupService) validateBackupFileName(filename string) error {
 	if err := s.checkEnabled(); err != nil {
 		return err
 	}
 	if err := validateBackupFilename(filename); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureBackupFile checks the feature is enabled, validates the filename, and
+// confirms the file is present. A missing file maps to NotFoundError; any other
+// stat error (e.g. permission denied) maps to OperationError.
+func (s *BackupService) ensureBackupFile(filename string) error {
+	if err := s.validateBackupFileName(filename); err != nil {
 		return err
 	}
 	if _, err := s.backupRoot.Stat(filename); err != nil {
@@ -213,10 +228,42 @@ func (s *BackupService) compressionLevel(requested int) (int, error) {
 	return level, nil
 }
 
+// OpenFile opens a managed backup file through the backup root.
+func (s *BackupService) OpenFile(filename string) (*os.File, os.FileInfo, error) {
+	if err := s.validateBackupFileName(filename); err != nil {
+		return nil, nil, err
+	}
+
+	file, err := s.backupRoot.Open(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, types.NewNotFoundError("backup", filename)
+		}
+		return nil, nil, types.NewOperationError("open backup", err)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, types.NewOperationError("stat backup", err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, nil, types.NewValidationError("filename", "not a regular backup file")
+	}
+
+	return file, info, nil
+}
+
 // validateBackupFile checks backup integrity with pg_restore --list.
-func (s *BackupService) validateBackupFile(ctx context.Context, filePath string) error {
+func (s *BackupService) validateBackupFile(ctx context.Context, file *os.File) error {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return types.NewOperationError("backup validation", fmt.Errorf("seek file: %w", err))
+	}
+
 	//nolint:gosec // G204: pgRestorePath is resolved from config/PATH at startup.
-	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list", filePath)
+	cmd := exec.CommandContext(ctx, s.pgRestorePath, "--list")
+	cmd.Stdin = file
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		errMsg := strings.TrimSpace(string(output))
@@ -226,6 +273,20 @@ func (s *BackupService) validateBackupFile(ctx context.Context, filePath string)
 		return types.NewOperationError("backup validation", fmt.Errorf("file is corrupt or unreadable: %s", errMsg))
 	}
 	return nil
+}
+
+func (s *BackupService) validateManagedBackupFile(ctx context.Context, filename string) (err error) {
+	file, _, err := s.OpenFile(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = types.NewOperationError("backup validation", fmt.Errorf("close file: %w", closeErr))
+		}
+	}()
+
+	return s.validateBackupFile(ctx, file)
 }
 
 // generateBackupFilename returns a managed timestamped .dump filename.
@@ -353,7 +414,7 @@ func (s *BackupService) execute(ctx context.Context, req BackupRequest) error {
 	validateCtx, validateCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer validateCancel()
 
-	if err := s.validateBackupFile(validateCtx, fullPath); err != nil {
+	if err := s.validateManagedBackupFile(validateCtx, filename); err != nil {
 		slog.Error("Backup validation failed", "filename", filename, "error", err)
 		s.setStatusDone(false, filename, err.Error())
 		s.notifyBackup()
@@ -382,7 +443,7 @@ func (s *BackupService) execute(ctx context.Context, req BackupRequest) error {
 			uploadCtx, cancel := context.WithTimeout(context.Background(), s.config.Backup.GetTimeout())
 			defer cancel()
 
-			if err := s.s3.upload(uploadCtx, filename, fullPath); err != nil {
+			if err := s.uploadBackupToS3(uploadCtx, filename); err != nil {
 				slog.Error("S3 synchronization failed", "filename", filename, "error", err)
 				s.setS3SyncStatus(false, err.Error())
 				s.notify.NotifyS3SyncResult(filename, &notify.S3SyncResult{Synced: false, Error: err.Error()})
@@ -409,6 +470,20 @@ func (s *BackupService) Status() *BackupStatus {
 	status := *s.status
 	status.Running = s.runner.IsRunning()
 	return &status
+}
+
+func (s *BackupService) uploadBackupToS3(ctx context.Context, filename string) (err error) {
+	file, _, err := s.OpenFile(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = types.NewOperationError("S3 upload", fmt.Errorf("close file: %w", closeErr))
+		}
+	}()
+
+	return s.s3.upload(ctx, filename, file)
 }
 
 func (s *BackupService) setStatusStarted() {
@@ -467,8 +542,7 @@ func (s *BackupService) List() (*BackupListResponse, error) {
 		return nil, err
 	}
 
-	backupPath := s.config.Backup.GetPath()
-	entries, err := os.ReadDir(backupPath)
+	entries, err := fs.ReadDir(s.backupRoot.FS(), ".")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &BackupListResponse{
@@ -548,15 +622,6 @@ func (s *BackupService) Delete(filename string) error {
 	return nil
 }
 
-// GetFilePath validates filename and returns its absolute local path.
-func (s *BackupService) GetFilePath(filename string) (string, error) {
-	if err := s.ensureBackupFile(filename); err != nil {
-		return "", err
-	}
-
-	return filepath.Join(s.config.Backup.GetPath(), filename), nil
-}
-
 // ValidationResult is the on-demand backup validation result.
 type ValidationResult struct {
 	Filename string `json:"filename"`
@@ -566,11 +631,6 @@ type ValidationResult struct {
 
 // Validate checks a managed backup with pg_restore --list.
 func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
-	fullPath, err := s.GetFilePath(filename)
-	if err != nil {
-		return nil, err
-	}
-
 	result := &ValidationResult{
 		Filename: filename,
 	}
@@ -578,7 +638,7 @@ func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := s.validateBackupFile(ctx, fullPath); err != nil {
+	if err := s.validateManagedBackupFile(ctx, filename); err != nil {
 		result.Valid = false
 		result.Error = err.Error()
 	} else {

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -103,14 +103,14 @@ func newBackupService(
 	return svc, nil
 }
 
-// Close waits for any running backup or tracked follow-up work.
+// Close waits for any running backup or tracked follow-up work and releases
+// the backup root.
 func (s *BackupService) Close() {
 	s.runner.Close()
 	if s.backupRoot != nil {
 		if err := s.backupRoot.Close(); err != nil {
 			slog.Warn("Failed to close backup root", "error", err)
 		}
-		s.backupRoot = nil
 	}
 }
 
@@ -230,7 +230,12 @@ func (s *BackupService) compressionLevel(requested int) (int, error) {
 	return level, nil
 }
 
-// OpenFile opens a managed backup file through the backup root.
+// OpenFile opens a managed backup file through the backup root. The caller
+// owns the returned file and must close it.
+//
+// It returns ConfigError when backups are disabled, ValidationError for invalid
+// backup names or non-regular files, NotFoundError for missing backups, and
+// OperationError for other open/stat failures.
 func (s *BackupService) OpenFile(filename string) (*os.File, os.FileInfo, error) {
 	if err := s.checkBackupAccess(filename); err != nil {
 		return nil, nil, err
@@ -259,8 +264,8 @@ func (s *BackupService) OpenFile(filename string) (*os.File, os.FileInfo, error)
 
 // validateBackupFile checks backup integrity with pg_restore --list.
 func (s *BackupService) validateBackupFile(ctx context.Context, file *os.File) error {
-	// pg_restore inherits the current file offset from stdin, so rewind before
-	// validating in case a future caller has already read from the handle.
+	// The pg_restore child reads from the same open-file-description offset as
+	// the parent fd assigned to stdin, so validation must start from byte zero.
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return types.NewOperationError("backup validation", fmt.Errorf("seek file: %w", err))
 	}
@@ -286,7 +291,7 @@ func (s *BackupService) validateManagedBackupFile(ctx context.Context, filename 
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			slog.Warn("Failed to close backup validation file", "filename", filename, "error", closeErr)
+			slog.Debug("Failed to close backup validation file", "filename", filename, "error", closeErr)
 		}
 	}()
 
@@ -483,7 +488,7 @@ func (s *BackupService) uploadBackupToS3(ctx context.Context, filename string) e
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			slog.Warn("Failed to close backup upload file", "filename", filename, "error", closeErr)
+			slog.Debug("Failed to close backup upload file", "filename", filename, "error", closeErr)
 		}
 	}()
 
@@ -641,7 +646,7 @@ func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			slog.Warn("Failed to close backup validation file", "filename", filename, "error", closeErr)
+			slog.Debug("Failed to close backup validation file", "filename", filename, "error", closeErr)
 		}
 	}()
 

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -631,6 +631,16 @@ type ValidationResult struct {
 
 // Validate checks a managed backup with pg_restore --list.
 func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
+	file, _, err := s.OpenFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			slog.Warn("Failed to close backup validation file", "filename", filename, "error", closeErr)
+		}
+	}()
+
 	result := &ValidationResult{
 		Filename: filename,
 	}
@@ -638,7 +648,7 @@ func (s *BackupService) Validate(filename string) (*ValidationResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := s.validateManagedBackupFile(ctx, filename); err != nil {
+	if err := s.validateBackupFile(ctx, file); err != nil {
 		result.Valid = false
 		result.Error = err.Error()
 	} else {

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -33,6 +34,30 @@ func newBackupTestService(t *testing.T, backupPath string) *BackupService {
 		backupRoot: root,
 		runner:     async.New(),
 	}
+}
+
+func writePgRestoreStub(t *testing.T) string {
+	t.Helper()
+
+	pgRestorePath := filepath.Join(t.TempDir(), "pg_restore")
+	script := `#!/bin/sh
+if [ "$#" -ne 1 ] || [ "$1" != "--list" ]; then
+  echo "unexpected args: $*" >&2
+  exit 3
+fi
+input=$(cat)
+if [ "$input" != "backup-data" ]; then
+  echo "unexpected stdin: $input" >&2
+  exit 4
+fi
+`
+	if err := os.WriteFile(pgRestorePath, []byte(script), 0o600); err != nil {
+		t.Fatalf("write pg_restore helper: %v", err)
+	}
+	if err := os.Chmod(pgRestorePath, 0o700); err != nil { //nolint:gosec // test helper script must be executable.
+		t.Fatalf("chmod pg_restore helper: %v", err)
+	}
+	return pgRestorePath
 }
 
 func TestBackupServiceOpenFileReadsManagedBackup(t *testing.T) {
@@ -77,6 +102,10 @@ func TestBackupServiceOpenFileRejectsInvalidFilename(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("OpenFile accepted path traversal filename")
+	}
+	var validationErr *types.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("OpenFile error = %T %[1]v, want *types.ValidationError", err)
 	}
 }
 
@@ -172,28 +201,9 @@ func TestBackupServiceValidateStreamsRootedFileToPgRestore(t *testing.T) {
 		t.Fatalf("write backup file: %v", err)
 	}
 
-	pgRestorePath := filepath.Join(t.TempDir(), "pg_restore")
-	script := `#!/bin/sh
-if [ "$#" -ne 1 ] || [ "$1" != "--list" ]; then
-  echo "unexpected args: $*" >&2
-  exit 3
-fi
-input=$(cat)
-if [ "$input" != "backup-data" ]; then
-  echo "unexpected stdin: $input" >&2
-  exit 4
-fi
-`
-	if err := os.WriteFile(pgRestorePath, []byte(script), 0o600); err != nil {
-		t.Fatalf("write pg_restore helper: %v", err)
-	}
-	if err := os.Chmod(pgRestorePath, 0o700); err != nil { //nolint:gosec // test helper script must be executable.
-		t.Fatalf("chmod pg_restore helper: %v", err)
-	}
-
 	svc := newBackupTestService(t, backupPath)
 	t.Cleanup(svc.Close)
-	svc.pgRestorePath = pgRestorePath
+	svc.pgRestorePath = writePgRestoreStub(t)
 
 	result, err := svc.Validate(testBackupFilename)
 	if err != nil {
@@ -201,6 +211,43 @@ fi
 	}
 	if !result.Valid {
 		t.Fatalf("validation result = invalid: %s", result.Error)
+	}
+}
+
+func TestBackupServiceValidateRewindsFileBeforePgRestore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell helper")
+	}
+
+	backupPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(backupPath, testBackupFilename), []byte("backup-data"), 0o600); err != nil {
+		t.Fatalf("write backup file: %v", err)
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	t.Cleanup(svc.Close)
+	svc.pgRestorePath = writePgRestoreStub(t)
+
+	file, _, err := svc.OpenFile(testBackupFilename)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Fatalf("close opened backup: %v", err)
+		}
+	}()
+
+	buf := make([]byte, len("backup-"))
+	if _, err := io.ReadFull(file, buf); err != nil {
+		t.Fatalf("read prefix from backup: %v", err)
+	}
+	if string(buf) != "backup-" {
+		t.Fatalf("backup prefix = %q, want backup-", buf)
+	}
+
+	if err := svc.validateBackupFile(context.Background(), file); err != nil {
+		t.Fatalf("validateBackupFile after partial read: %v", err)
 	}
 }
 

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/async"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/types"
 )
 
 const testBackupFilename = "aeron-backup-2026-01-02-030405.dump"
@@ -47,7 +48,11 @@ func TestBackupServiceOpenFileReadsManagedBackup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Fatalf("close opened backup: %v", err)
+		}
+	}()
 
 	if info.Size() != int64(len("backup-data")) {
 		t.Fatalf("file size = %d, want %d", info.Size(), len("backup-data"))
@@ -123,8 +128,11 @@ if [ "$input" != "backup-data" ]; then
   exit 4
 fi
 `
-	if err := os.WriteFile(pgRestorePath, []byte(script), 0o700); err != nil {
+	if err := os.WriteFile(pgRestorePath, []byte(script), 0o600); err != nil {
 		t.Fatalf("write pg_restore helper: %v", err)
+	}
+	if err := os.Chmod(pgRestorePath, 0o700); err != nil { //nolint:gosec // test helper script must be executable.
+		t.Fatalf("chmod pg_restore helper: %v", err)
 	}
 
 	svc := newBackupTestService(t, backupPath)
@@ -137,6 +145,23 @@ fi
 	}
 	if !result.Valid {
 		t.Fatalf("validation result = invalid: %s", result.Error)
+	}
+}
+
+func TestBackupServiceValidateMissingFileReturnsError(t *testing.T) {
+	svc := newBackupTestService(t, t.TempDir())
+	t.Cleanup(svc.Close)
+
+	result, err := svc.Validate(testBackupFilename)
+	if err == nil {
+		t.Fatal("Validate returned nil error for missing backup")
+	}
+	if result != nil {
+		t.Fatalf("Validate result = %#v, want nil on missing backup", result)
+	}
+	var notFound *types.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Validate error = %T %[1]v, want *types.NotFoundError", err)
 	}
 }
 

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -80,6 +80,62 @@ func TestBackupServiceOpenFileRejectsInvalidFilename(t *testing.T) {
 	}
 }
 
+func TestBackupServiceOpenFileRejectsNonBackupNames(t *testing.T) {
+	backupPath := t.TempDir()
+	for _, filename := range []string{
+		"notaprefix.dump",
+		"aeron-backup-2026-01-02-030405.txt",
+	} {
+		if err := os.WriteFile(filepath.Join(backupPath, filename), []byte("backup-data"), 0o600); err != nil {
+			t.Fatalf("write backup file %q: %v", filename, err)
+		}
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	t.Cleanup(svc.Close)
+
+	for _, filename := range []string{
+		"notaprefix.dump",
+		"aeron-backup-2026-01-02-030405.txt",
+	} {
+		t.Run(filename, func(t *testing.T) {
+			file, _, err := svc.OpenFile(filename)
+			if file != nil {
+				_ = file.Close()
+			}
+			if err == nil {
+				t.Fatal("OpenFile accepted non-backup filename")
+			}
+			var validationErr *types.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("OpenFile error = %T %[1]v, want *types.ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestBackupServiceOpenFileRejectsDirectory(t *testing.T) {
+	backupPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(backupPath, testBackupFilename), 0o700); err != nil {
+		t.Fatalf("create backup directory: %v", err)
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	t.Cleanup(svc.Close)
+
+	file, _, err := svc.OpenFile(testBackupFilename)
+	if file != nil {
+		_ = file.Close()
+	}
+	if err == nil {
+		t.Fatal("OpenFile accepted directory named like a backup")
+	}
+	var validationErr *types.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("OpenFile error = %T %[1]v, want *types.ValidationError", err)
+	}
+}
+
 func TestBackupServiceOpenFileRejectsSymlinkEscape(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevated privileges on many Windows systems")

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -1,0 +1,157 @@
+package service
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/async"
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
+)
+
+const testBackupFilename = "aeron-backup-2026-01-02-030405.dump"
+
+func newBackupTestService(t *testing.T, backupPath string) *BackupService {
+	t.Helper()
+
+	root, err := os.OpenRoot(backupPath)
+	if err != nil {
+		t.Fatalf("open backup root: %v", err)
+	}
+
+	return &BackupService{
+		config: &config.Config{
+			Backup: config.BackupConfig{
+				Enabled: true,
+				Path:    backupPath,
+			},
+		},
+		backupRoot: root,
+		runner:     async.New(),
+	}
+}
+
+func TestBackupServiceOpenFileReadsManagedBackup(t *testing.T) {
+	backupPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(backupPath, testBackupFilename), []byte("backup-data"), 0o600); err != nil {
+		t.Fatalf("write backup file: %v", err)
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	t.Cleanup(svc.Close)
+
+	file, info, err := svc.OpenFile(testBackupFilename)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer file.Close()
+
+	if info.Size() != int64(len("backup-data")) {
+		t.Fatalf("file size = %d, want %d", info.Size(), len("backup-data"))
+	}
+
+	got, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read opened backup: %v", err)
+	}
+	if string(got) != "backup-data" {
+		t.Fatalf("opened backup data = %q, want backup-data", got)
+	}
+}
+
+func TestBackupServiceOpenFileRejectsInvalidFilename(t *testing.T) {
+	svc := newBackupTestService(t, t.TempDir())
+	t.Cleanup(svc.Close)
+
+	file, _, err := svc.OpenFile("../" + testBackupFilename)
+	if file != nil {
+		_ = file.Close()
+	}
+	if err == nil {
+		t.Fatal("OpenFile accepted path traversal filename")
+	}
+}
+
+func TestBackupServiceOpenFileRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on many Windows systems")
+	}
+
+	backupPath := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside.dump")
+	if err := os.WriteFile(outsidePath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(backupPath, testBackupFilename)); err != nil {
+		t.Fatalf("create symlink escape: %v", err)
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	t.Cleanup(svc.Close)
+
+	file, _, err := svc.OpenFile(testBackupFilename)
+	if file != nil {
+		_ = file.Close()
+	}
+	if err == nil {
+		t.Fatal("OpenFile followed symlink outside backup root")
+	}
+}
+
+func TestBackupServiceValidateStreamsRootedFileToPgRestore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell helper")
+	}
+
+	backupPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(backupPath, testBackupFilename), []byte("backup-data"), 0o600); err != nil {
+		t.Fatalf("write backup file: %v", err)
+	}
+
+	pgRestorePath := filepath.Join(t.TempDir(), "pg_restore")
+	script := `#!/bin/sh
+if [ "$#" -ne 1 ] || [ "$1" != "--list" ]; then
+  echo "unexpected args: $*" >&2
+  exit 3
+fi
+input=$(cat)
+if [ "$input" != "backup-data" ]; then
+  echo "unexpected stdin: $input" >&2
+  exit 4
+fi
+`
+	if err := os.WriteFile(pgRestorePath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write pg_restore helper: %v", err)
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	t.Cleanup(svc.Close)
+	svc.pgRestorePath = pgRestorePath
+
+	result, err := svc.Validate(testBackupFilename)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("validation result = invalid: %s", result.Error)
+	}
+}
+
+func TestBackupServiceCloseClosesBackupRoot(t *testing.T) {
+	backupPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(backupPath, testBackupFilename), []byte("backup-data"), 0o600); err != nil {
+		t.Fatalf("write backup file: %v", err)
+	}
+
+	svc := newBackupTestService(t, backupPath)
+	root := svc.backupRoot
+
+	svc.Close()
+
+	if _, err := root.Stat(testBackupFilename); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("root.Stat after Close error = %v, want %v", err, os.ErrClosed)
+	}
+}

--- a/internal/service/s3.go
+++ b/internal/service/s3.go
@@ -2,9 +2,8 @@ package service
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -63,24 +62,14 @@ func ptrOrNil(s string) *string {
 }
 
 // upload streams one local backup file to remote storage.
-func (s *s3Service) upload(ctx context.Context, filename, localPath string) (err error) {
-	file, err := os.Open(localPath) //nolint:gosec // G304: localPath is built from a validated managed backup filename
-	if err != nil {
-		return types.NewOperationError("S3 upload", fmt.Errorf("open file: %w", err))
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = types.NewOperationError("S3 upload", fmt.Errorf("close file: %w", closeErr))
-		}
-	}()
-
+func (s *s3Service) upload(ctx context.Context, filename string, body io.Reader) error {
 	key := s.prefix + filename
 	start := time.Now()
 
-	_, err = s.tm.UploadObject(ctx, &transfermanager.UploadObjectInput{
+	_, err := s.tm.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
-		Body:   file,
+		Body:   body,
 	})
 	if err != nil {
 		return types.NewOperationError("S3 upload", err)

--- a/internal/service/s3.go
+++ b/internal/service/s3.go
@@ -61,7 +61,7 @@ func ptrOrNil(s string) *string {
 	return aws.String(s)
 }
 
-// upload streams one local backup file to remote storage.
+// upload streams one backup file to remote storage.
 func (s *s3Service) upload(ctx context.Context, filename string, body io.Reader) error {
 	key := s.prefix + filename
 	start := time.Now()


### PR DESCRIPTION
## Fact check
- Confirmed download used `Backup.GetFilePath` followed by `http.ServeFile` on a joined path.
- Confirmed on-demand validation passed that joined path to `pg_restore --list`.
- Confirmed S3 upload reopened the joined path with `os.Open`.
- Confirmed `BackupService.Close` did not close `backupRoot`.

## Fix
- Added `BackupService.OpenFile` to validate and open managed backup files through `os.Root`.
- Switched downloads to `http.ServeContent` over the opened rooted file handle.
- Switched `pg_restore --list` validation to read the rooted file via stdin instead of a filesystem path.
- Switched S3 upload to receive a reader from `BackupService` instead of opening a path itself.
- Listed backups through `backupRoot.FS()` and closed `backupRoot` during service shutdown.
- Removed the path-returning `GetFilePath` API to avoid future TOCTOU reuse.

## Verification
- `go test ./internal/service ./internal/api`
- `go test ./...`

Closes #152