### PR TITLE
fix: bound media file checks on frozen mounts

### DIFF
--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -102,9 +103,6 @@ type MediaFileCheckService struct {
 	statInflightMu sync.Mutex
 	statInflight   map[string]*statInFlight
 
-	indexInflightMu sync.Mutex
-	indexInflight   map[string]*indexInFlight
-
 	publishedMu    sync.RWMutex
 	lastResult     *MediaCheckResult
 	lastScheduled  *MediaCheckResult
@@ -118,12 +116,11 @@ func newMediaFileCheckService(
 	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
 ) *MediaFileCheckService {
 	return &MediaFileCheckService{
-		repo:          repo,
-		config:        cfg,
-		notify:        notifySvc,
-		runner:        async.New(),
-		statInflight:  make(map[string]*statInFlight),
-		indexInflight: make(map[string]*indexInFlight),
+		repo:         repo,
+		config:       cfg,
+		notify:       notifySvc,
+		runner:       async.New(),
+		statInflight: make(map[string]*statInFlight),
 	}
 }
 
@@ -204,13 +201,18 @@ func (s *MediaFileCheckService) executeRun(ctx context.Context, opts *database.M
 	}
 	// Workers embed their verdict in results and never return an error, so Wait
 	// only blocks for completion. A run-level failure surfaces as a context error
-	// (timeout/cancel) or an index-build error, in that precedence.
+	// (timeout/cancel), an index-build error, or both when the timeout caused the
+	// index build to be incomplete.
 	_ = g.Wait()
-	if err := ctx.Err(); err != nil {
-		result.Error = err.Error()
-	}
-	if err := matcher.indexErr(); err != nil && result.Error == "" {
-		result.Error = err.Error()
+	ctxErr := ctx.Err()
+	indexErr := matcher.indexErr()
+	switch {
+	case indexErr != nil && ctxErr != nil:
+		result.Error = errors.Join(indexErr, ctxErr).Error()
+	case indexErr != nil:
+		result.Error = indexErr.Error()
+	case ctxErr != nil:
+		result.Error = ctxErr.Error()
 	}
 
 	result.Items = results
@@ -250,19 +252,20 @@ func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *medi
 	}
 
 	matcher = &mediaMatcher{
-		driveRoots:       driveRoots,
-		searchDirs:       mfc.SearchDirs,
-		caseInsensitive:  mfc.IsCaseInsensitive(),
-		statTimeout:      mfc.StatTimeout(),
-		indexTimeout:     mediaCheckRunTimeout,
-		ctx:              ctx,
-		startStatFlight:  s.startOrJoinMediaStatFlight,
-		startIndexFlight: s.startOrJoinMediaIndexFlight,
+		driveRoots:      driveRoots,
+		searchDirs:      mfc.SearchDirs,
+		caseInsensitive: mfc.IsCaseInsensitive(),
+		statTimeout:     mfc.StatTimeout(),
+		indexTimeout:    mediaCheckRunTimeout,
+		ctx:             ctx,
+		startStatFlight: s.startOrJoinMediaStatFlight,
 	}
 
 	cleanup = func() {
 		for _, rd := range driveRoots {
 			if rd.root != nil {
+				// Timed-out stat goroutines may still be unwinding; ErrClosed from
+				// a post-cleanup os.Root.Stat is expected and safe.
 				if err := rd.root.Close(); err != nil {
 					slog.Debug("Media file check: failed to close drive root", "dir", rd.dir, "error", err)
 				}
@@ -302,40 +305,6 @@ func (s *MediaFileCheckService) startOrJoinMediaStatFlight(
 			delete(s.statInflight, key)
 		}
 		s.statInflightMu.Unlock()
-	}()
-
-	return flight, true
-}
-
-func (s *MediaFileCheckService) startOrJoinMediaIndexFlight(
-	key string,
-	now time.Time,
-	buildFn func() *fileIndex,
-) (*indexInFlight, bool) {
-	s.indexInflightMu.Lock()
-	defer s.indexInflightMu.Unlock()
-
-	if s.indexInflight == nil {
-		s.indexInflight = make(map[string]*indexInFlight)
-	}
-	if existing, ok := s.indexInflight[key]; ok {
-		return existing, false
-	}
-
-	flight := &indexInFlight{done: make(chan struct{})}
-	flight.startedNano.Store(now.UnixNano())
-	s.indexInflight[key] = flight
-
-	go func() {
-		flight.startedNano.Store(time.Now().UnixNano())
-		flight.index = buildFn()
-		close(flight.done)
-
-		s.indexInflightMu.Lock()
-		if s.indexInflight[key] == flight {
-			delete(s.indexInflight, key)
-		}
-		s.indexInflightMu.Unlock()
 	}()
 
 	return flight, true

--- a/internal/service/mediacheck.go
+++ b/internal/service/mediacheck.go
@@ -99,6 +99,12 @@ type MediaFileCheckService struct {
 
 	runner *async.Runner
 
+	statInflightMu sync.Mutex
+	statInflight   map[string]*statInFlight
+
+	indexInflightMu sync.Mutex
+	indexInflight   map[string]*indexInFlight
+
 	publishedMu    sync.RWMutex
 	lastResult     *MediaCheckResult
 	lastScheduled  *MediaCheckResult
@@ -112,10 +118,12 @@ func newMediaFileCheckService(
 	repo *database.Repository, cfg *config.Config, notifySvc *notify.NotificationService,
 ) *MediaFileCheckService {
 	return &MediaFileCheckService{
-		repo:   repo,
-		config: cfg,
-		notify: notifySvc,
-		runner: async.New(),
+		repo:          repo,
+		config:        cfg,
+		notify:        notifySvc,
+		runner:        async.New(),
+		statInflight:  make(map[string]*statInFlight),
+		indexInflight: make(map[string]*indexInFlight),
 	}
 }
 
@@ -242,11 +250,14 @@ func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *medi
 	}
 
 	matcher = &mediaMatcher{
-		driveRoots:      driveRoots,
-		searchDirs:      mfc.SearchDirs,
-		caseInsensitive: mfc.IsCaseInsensitive(),
-		statTimeout:     mfc.StatTimeout(),
-		ctx:             ctx,
+		driveRoots:       driveRoots,
+		searchDirs:       mfc.SearchDirs,
+		caseInsensitive:  mfc.IsCaseInsensitive(),
+		statTimeout:      mfc.StatTimeout(),
+		indexTimeout:     mediaCheckRunTimeout,
+		ctx:              ctx,
+		startStatFlight:  s.startOrJoinMediaStatFlight,
+		startIndexFlight: s.startOrJoinMediaIndexFlight,
 	}
 
 	cleanup = func() {
@@ -259,6 +270,75 @@ func (s *MediaFileCheckService) buildMatcher(ctx context.Context) (matcher *medi
 		}
 	}
 	return matcher, cleanup
+}
+
+func (s *MediaFileCheckService) startOrJoinMediaStatFlight(
+	key string,
+	now time.Time,
+	statFn func() (os.FileInfo, error),
+) (*statInFlight, bool) {
+	s.statInflightMu.Lock()
+	defer s.statInflightMu.Unlock()
+
+	if s.statInflight == nil {
+		s.statInflight = make(map[string]*statInFlight)
+	}
+	if existing, ok := s.statInflight[key]; ok {
+		return existing, false
+	}
+
+	flight := &statInFlight{done: make(chan struct{})}
+	flight.startedNano.Store(now.UnixNano())
+	s.statInflight[key] = flight
+
+	go func() {
+		flight.startedNano.Store(time.Now().UnixNano())
+		info, err := statFn()
+		flight.result = statResult{info: info, err: err}
+		close(flight.done)
+
+		s.statInflightMu.Lock()
+		if s.statInflight[key] == flight {
+			delete(s.statInflight, key)
+		}
+		s.statInflightMu.Unlock()
+	}()
+
+	return flight, true
+}
+
+func (s *MediaFileCheckService) startOrJoinMediaIndexFlight(
+	key string,
+	now time.Time,
+	buildFn func() *fileIndex,
+) (*indexInFlight, bool) {
+	s.indexInflightMu.Lock()
+	defer s.indexInflightMu.Unlock()
+
+	if s.indexInflight == nil {
+		s.indexInflight = make(map[string]*indexInFlight)
+	}
+	if existing, ok := s.indexInflight[key]; ok {
+		return existing, false
+	}
+
+	flight := &indexInFlight{done: make(chan struct{})}
+	flight.startedNano.Store(now.UnixNano())
+	s.indexInflight[key] = flight
+
+	go func() {
+		flight.startedNano.Store(time.Now().UnixNano())
+		flight.index = buildFn()
+		close(flight.done)
+
+		s.indexInflightMu.Lock()
+		if s.indexInflight[key] == flight {
+			delete(s.indexInflight, key)
+		}
+		s.indexInflightMu.Unlock()
+	}()
+
+	return flight, true
 }
 
 // Status returns a consistent snapshot of run-state plus the most recent result.

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -11,9 +11,9 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
 )
 
@@ -128,9 +128,15 @@ type fileIndex struct {
 	errors []string
 }
 
-// buildFileIndex indexes regular files by full filename and stem.
+// buildFileIndexWithWalkDir indexes regular files by full filename and stem.
 // Per-file walk errors are logged and skipped; ctx cancellation aborts the walk.
-func buildFileIndex(ctx context.Context, dirs []string, caseInsensitive bool) *fileIndex {
+// walkDir is injected so callers can snapshot mediaWalkDir before spawning.
+func buildFileIndexWithWalkDir(
+	ctx context.Context,
+	dirs []string,
+	caseInsensitive bool,
+	walkDir func(string, fs.WalkDirFunc) error,
+) *fileIndex {
 	idx := &fileIndex{
 		byName: make(map[string][]string),
 		byStem: make(map[string][]string),
@@ -150,7 +156,7 @@ func buildFileIndex(ctx context.Context, dirs []string, caseInsensitive bool) *f
 			idx.addError(fmt.Sprintf("index build canceled before %s: %v", dir, ctx.Err()))
 			break
 		}
-		err := mediaWalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		err := walkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if ctx != nil && ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -213,29 +219,16 @@ type statFlightStarter func(
 	statFn func() (os.FileInfo, error),
 ) (*statInFlight, bool)
 
-type indexInFlight struct {
-	startedNano atomic.Int64
-	done        chan struct{}
-	index       *fileIndex
-}
-
-type indexFlightStarter func(
-	key string,
-	now time.Time,
-	buildFn func() *fileIndex,
-) (*indexInFlight, bool)
-
 // mediaMatcher resolves database references to files on disk using two
 // strategies: exact path translation via drive mounts, then a filename index
 // over the configured search dirs (built lazily on first fallback).
 type mediaMatcher struct {
-	driveRoots       map[string]*rootDir
-	searchDirs       []string
-	caseInsensitive  bool
-	statTimeout      time.Duration
-	indexTimeout     time.Duration
-	startStatFlight  statFlightStarter
-	startIndexFlight indexFlightStarter
+	driveRoots      map[string]*rootDir
+	searchDirs      []string
+	caseInsensitive bool
+	statTimeout     time.Duration
+	indexTimeout    time.Duration
+	startStatFlight statFlightStarter
 
 	ctx        context.Context
 	indexMu    sync.Mutex
@@ -354,6 +347,11 @@ func (m *mediaMatcher) match(in *matchInput) matchOutcome {
 			return out
 		}
 		out.CheckedPaths = append(out.CheckedPaths, describeSearch("by name", names))
+		if err := idx.err(); err != nil {
+			out.Status = MediaStatusStatError
+			out.Error = err.Error()
+			return out
+		}
 	}
 	out.Status = MediaStatusMissing
 	return out
@@ -400,7 +398,7 @@ func (m *mediaMatcher) statDriveMapped(ref string) (candidate string, exists boo
 
 // getIndex returns the lazily-built filename index, or nil when no search dirs
 // are configured. The index is built at most once per matcher; concurrent callers
-// that fall through to the index strategy share the same bounded build attempt.
+// that fall through to the index strategy wait for that bounded build attempt.
 func (m *mediaMatcher) getIndex() *fileIndex {
 	m.indexMu.Lock()
 	defer m.indexMu.Unlock()
@@ -430,15 +428,39 @@ func (m *mediaMatcher) getIndex() *fileIndex {
 }
 
 func (m *mediaMatcher) buildIndex() *fileIndex {
-	buildFn := func() *fileIndex {
-		return buildFileIndex(m.ctx, m.searchDirs, m.caseInsensitive)
-	}
-	if m.startIndexFlight == nil {
-		return buildFn()
+	ch := make(chan *fileIndex, 1)
+	walkDir := mediaWalkDir
+	go func() {
+		ch <- buildFileIndexWithWalkDir(m.ctx, m.searchDirs, m.caseInsensitive, walkDir)
+	}()
+
+	timeout := m.indexTimeout
+	if timeout <= 0 {
+		timeout = mediaCheckRunTimeout
 	}
 
-	flight, isNew := m.startIndexFlight(fileIndexFlightKey(m.searchDirs, m.caseInsensitive), time.Now(), buildFn)
-	return m.waitIndexFlight(flight, isNew)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	var ctxDone <-chan struct{}
+	if m.ctx != nil {
+		ctxDone = m.ctx.Done()
+	}
+
+	select {
+	case idx := <-ch:
+		if idx == nil {
+			idx = emptyFileIndex()
+			idx.addError("media file index failed without result")
+		}
+		return idx
+	case <-timer.C:
+		return indexTimeoutResult(timeout)
+	case <-ctxDone:
+		idx := emptyFileIndex()
+		idx.addError(fmt.Sprintf("media file index canceled: %v", m.ctx.Err()))
+		return idx
+	}
 }
 
 func (m *mediaMatcher) indexErr() error {
@@ -446,10 +468,6 @@ func (m *mediaMatcher) indexErr() error {
 		return nil
 	}
 	return m.index.err()
-}
-
-func fileIndexFlightKey(dirs []string, caseInsensitive bool) string {
-	return fmt.Sprintf("%t\x00%s", caseInsensitive, strings.Join(dirs, "\x00"))
 }
 
 // lookup collects the distinct on-disk paths matching any of the given keys.
@@ -471,10 +489,10 @@ func (m *mediaMatcher) statRootWithTimeout(key string, root *os.Root, name strin
 		return statRootWithTimeout(root, name, m.statTimeout)
 	}
 
-	statFn := func() (os.FileInfo, error) {
-		return mediaRootStat(root, name)
-	}
-	flight, isNew := m.startStatFlight(key, time.Now(), statFn)
+	statFn := mediaRootStat
+	flight, isNew := m.startStatFlight(key, time.Now(), func() (os.FileInfo, error) {
+		return statFn(root, name)
+	})
 	info, err := m.waitStatFlight(flight, isNew)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -488,7 +506,7 @@ func (m *mediaMatcher) statRootWithTimeout(key string, root *os.Root, name strin
 func (m *mediaMatcher) waitStatFlight(flight *statInFlight, isNew bool) (os.FileInfo, error) {
 	timeout := m.statTimeout
 	if timeout <= 0 {
-		timeout = 5 * time.Second
+		timeout = config.DefaultMediaFileCheckStatTimeoutSeconds * time.Second
 	}
 
 	remaining := timeout
@@ -523,10 +541,11 @@ func (m *mediaMatcher) waitStatFlight(flight *statInFlight, isNew bool) (os.File
 func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (bool, error) {
 	type result struct{ err error }
 	ch := make(chan result, 1)
+	statFn := mediaRootStat
 	go func() {
 		// A frozen mount can leave this goroutine stuck in Stat after the caller
 		// times out; the buffered channel prevents an additional blocked send.
-		_, err := mediaRootStat(root, name)
+		_, err := statFn(root, name)
 		ch <- result{err: err}
 	}()
 
@@ -546,45 +565,6 @@ func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (boo
 		return false, r.err
 	case <-timer.C:
 		return false, fmt.Errorf("stat timeout after %s", timeout)
-	}
-}
-
-func (m *mediaMatcher) waitIndexFlight(flight *indexInFlight, isNew bool) *fileIndex {
-	timeout := m.indexTimeout
-	if timeout <= 0 {
-		timeout = mediaCheckRunTimeout
-	}
-
-	remaining := timeout
-	if !isNew {
-		remaining = timeout - time.Since(time.Unix(0, flight.startedNano.Load()))
-		if remaining <= 0 {
-			return indexTimeoutResult(timeout)
-		}
-	}
-
-	timer := time.NewTimer(remaining)
-	defer timer.Stop()
-
-	var ctxDone <-chan struct{}
-	if m.ctx != nil {
-		ctxDone = m.ctx.Done()
-	}
-
-	select {
-	case <-flight.done:
-		if flight.index == nil {
-			idx := emptyFileIndex()
-			idx.addError("media file index failed without result")
-			return idx
-		}
-		return flight.index
-	case <-timer.C:
-		return indexTimeoutResult(timeout)
-	case <-ctxDone:
-		idx := emptyFileIndex()
-		idx.addError(fmt.Sprintf("media file index canceled: %v", m.ctx.Err()))
-		return idx
 	}
 }
 

--- a/internal/service/mediamatch.go
+++ b/internal/service/mediamatch.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oszuidwest/zwfm-aerontoolbox/internal/util"
@@ -40,6 +41,12 @@ const (
 )
 
 const maxFileIndexErrors = 5
+
+var mediaRootStat = func(root *os.Root, name string) (os.FileInfo, error) {
+	return root.Stat(name)
+}
+
+var mediaWalkDir = filepath.WalkDir
 
 // normalizeDriveKey converts a Windows drive prefix to canonical "O:" form.
 // It returns "" when s is not a single-letter drive.
@@ -143,7 +150,7 @@ func buildFileIndex(ctx context.Context, dirs []string, caseInsensitive bool) *f
 			idx.addError(fmt.Sprintf("index build canceled before %s: %v", dir, ctx.Err()))
 			break
 		}
-		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		err := mediaWalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if ctx != nil && ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -200,18 +207,40 @@ type rootDir struct {
 	openErr error
 }
 
+type statFlightStarter func(
+	key string,
+	now time.Time,
+	statFn func() (os.FileInfo, error),
+) (*statInFlight, bool)
+
+type indexInFlight struct {
+	startedNano atomic.Int64
+	done        chan struct{}
+	index       *fileIndex
+}
+
+type indexFlightStarter func(
+	key string,
+	now time.Time,
+	buildFn func() *fileIndex,
+) (*indexInFlight, bool)
+
 // mediaMatcher resolves database references to files on disk using two
 // strategies: exact path translation via drive mounts, then a filename index
 // over the configured search dirs (built lazily on first fallback).
 type mediaMatcher struct {
-	driveRoots      map[string]*rootDir
-	searchDirs      []string
-	caseInsensitive bool
-	statTimeout     time.Duration
+	driveRoots       map[string]*rootDir
+	searchDirs       []string
+	caseInsensitive  bool
+	statTimeout      time.Duration
+	indexTimeout     time.Duration
+	startStatFlight  statFlightStarter
+	startIndexFlight indexFlightStarter
 
-	ctx       context.Context
-	index     *fileIndex
-	indexOnce sync.Once
+	ctx        context.Context
+	indexMu    sync.Mutex
+	indexReady bool
+	index      *fileIndex
 }
 
 // matchInput is the database-free item data classified by mediaMatcher.
@@ -364,32 +393,52 @@ func (m *mediaMatcher) statDriveMapped(ref string) (candidate string, exists boo
 		return candidate, false, fmt.Errorf("drive %s root unavailable: %w", drive, rd.openErr)
 	}
 
-	exists, err = statRootWithTimeout(rd.root, rel, m.statTimeout)
+	key := rd.dir + "\x00" + rel
+	exists, err = m.statRootWithTimeout(key, rd.root, rel)
 	return candidate, exists, err
 }
 
 // getIndex returns the lazily-built filename index, or nil when no search dirs
-// are configured. The index is built at most once per matcher; concurrent
-// callers that fall through to the index strategy block on the same build via Once.
+// are configured. The index is built at most once per matcher; concurrent callers
+// that fall through to the index strategy share the same bounded build attempt.
 func (m *mediaMatcher) getIndex() *fileIndex {
-	m.indexOnce.Do(func() {
-		if len(m.searchDirs) == 0 {
-			return
-		}
-		start := time.Now()
-		m.index = buildFileIndex(m.ctx, m.searchDirs, m.caseInsensitive)
-		if err := m.index.err(); err != nil {
-			slog.Warn("Media file check: index built with errors",
-				"files", m.index.count, "search_dirs", len(m.searchDirs),
-				"duration", time.Since(start).Round(time.Millisecond).String(),
-				"error", err)
-			return
-		}
-		slog.Info("Media file check: index built",
+	m.indexMu.Lock()
+	defer m.indexMu.Unlock()
+
+	if m.indexReady {
+		return m.index
+	}
+	m.indexReady = true
+	if len(m.searchDirs) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+	m.index = m.buildIndex()
+	if err := m.index.err(); err != nil {
+		slog.Warn("Media file check: index built with errors",
 			"files", m.index.count, "search_dirs", len(m.searchDirs),
-			"duration", time.Since(start).Round(time.Millisecond).String())
-	})
+			"duration", time.Since(start).Round(time.Millisecond).String(),
+			"error", err)
+		return m.index
+	}
+	slog.Info("Media file check: index built",
+		"files", m.index.count, "search_dirs", len(m.searchDirs),
+		"duration", time.Since(start).Round(time.Millisecond).String())
+
 	return m.index
+}
+
+func (m *mediaMatcher) buildIndex() *fileIndex {
+	buildFn := func() *fileIndex {
+		return buildFileIndex(m.ctx, m.searchDirs, m.caseInsensitive)
+	}
+	if m.startIndexFlight == nil {
+		return buildFn()
+	}
+
+	flight, isNew := m.startIndexFlight(fileIndexFlightKey(m.searchDirs, m.caseInsensitive), time.Now(), buildFn)
+	return m.waitIndexFlight(flight, isNew)
 }
 
 func (m *mediaMatcher) indexErr() error {
@@ -397,6 +446,10 @@ func (m *mediaMatcher) indexErr() error {
 		return nil
 	}
 	return m.index.err()
+}
+
+func fileIndexFlightKey(dirs []string, caseInsensitive bool) string {
+	return fmt.Sprintf("%t\x00%s", caseInsensitive, strings.Join(dirs, "\x00"))
 }
 
 // lookup collects the distinct on-disk paths matching any of the given keys.
@@ -413,6 +466,57 @@ func (idx *fileIndex) lookup(table map[string][]string, keys []string, caseInsen
 	return matches
 }
 
+func (m *mediaMatcher) statRootWithTimeout(key string, root *os.Root, name string) (bool, error) {
+	if m.startStatFlight == nil {
+		return statRootWithTimeout(root, name, m.statTimeout)
+	}
+
+	statFn := func() (os.FileInfo, error) {
+		return mediaRootStat(root, name)
+	}
+	flight, isNew := m.startStatFlight(key, time.Now(), statFn)
+	info, err := m.waitStatFlight(flight, isNew)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info != nil, nil
+}
+
+func (m *mediaMatcher) waitStatFlight(flight *statInFlight, isNew bool) (os.FileInfo, error) {
+	timeout := m.statTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	remaining := timeout
+	if !isNew {
+		remaining = timeout - time.Since(time.Unix(0, flight.startedNano.Load()))
+		if remaining <= 0 {
+			return nil, fmt.Errorf("stat timeout after %s", timeout)
+		}
+	}
+
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+
+	var ctxDone <-chan struct{}
+	if m.ctx != nil {
+		ctxDone = m.ctx.Done()
+	}
+
+	select {
+	case <-flight.done:
+		return flight.result.info, flight.result.err
+	case <-timer.C:
+		return nil, fmt.Errorf("stat timeout after %s", timeout)
+	case <-ctxDone:
+		return nil, m.ctx.Err()
+	}
+}
+
 // statRootWithTimeout stats name within root, bounding the call with timeout so
 // a frozen mount cannot stall the worker. A timeout is reported as an error
 // (the file's existence is unknown), a genuine absence as (false, nil).
@@ -422,7 +526,7 @@ func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (boo
 	go func() {
 		// A frozen mount can leave this goroutine stuck in Stat after the caller
 		// times out; the buffered channel prevents an additional blocked send.
-		_, err := root.Stat(name)
+		_, err := mediaRootStat(root, name)
 		ch <- result{err: err}
 	}()
 
@@ -443,6 +547,58 @@ func statRootWithTimeout(root *os.Root, name string, timeout time.Duration) (boo
 	case <-timer.C:
 		return false, fmt.Errorf("stat timeout after %s", timeout)
 	}
+}
+
+func (m *mediaMatcher) waitIndexFlight(flight *indexInFlight, isNew bool) *fileIndex {
+	timeout := m.indexTimeout
+	if timeout <= 0 {
+		timeout = mediaCheckRunTimeout
+	}
+
+	remaining := timeout
+	if !isNew {
+		remaining = timeout - time.Since(time.Unix(0, flight.startedNano.Load()))
+		if remaining <= 0 {
+			return indexTimeoutResult(timeout)
+		}
+	}
+
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+
+	var ctxDone <-chan struct{}
+	if m.ctx != nil {
+		ctxDone = m.ctx.Done()
+	}
+
+	select {
+	case <-flight.done:
+		if flight.index == nil {
+			idx := emptyFileIndex()
+			idx.addError("media file index failed without result")
+			return idx
+		}
+		return flight.index
+	case <-timer.C:
+		return indexTimeoutResult(timeout)
+	case <-ctxDone:
+		idx := emptyFileIndex()
+		idx.addError(fmt.Sprintf("media file index canceled: %v", m.ctx.Err()))
+		return idx
+	}
+}
+
+func emptyFileIndex() *fileIndex {
+	return &fileIndex{
+		byName: make(map[string][]string),
+		byStem: make(map[string][]string),
+	}
+}
+
+func indexTimeoutResult(timeout time.Duration) *fileIndex {
+	idx := emptyFileIndex()
+	idx.addError(fmt.Sprintf("media file index timeout after %s", timeout))
+	return idx
 }
 
 // describeSearch renders an operator-facing note about an index lookup.

--- a/internal/service/mediamatch_test.go
+++ b/internal/service/mediamatch_test.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
 )
 
 func TestNormalizeDriveKey(t *testing.T) {
@@ -95,7 +98,7 @@ func buildTestMatcher(t *testing.T, driveDirs map[string]string, searchDirs []st
 		driveRoots:      driveRoots,
 		searchDirs:      searchDirs,
 		caseInsensitive: caseInsensitive,
-		statTimeout:     5 * time.Second,
+		statTimeout:     config.DefaultMediaFileCheckStatTimeoutSeconds * time.Second,
 	}
 }
 
@@ -107,6 +110,52 @@ func writeFile(t *testing.T, path string) {
 	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func waitForTestSignal(t *testing.T, ch <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+func receiveMatchOutcome(t *testing.T, ch <-chan matchOutcome) matchOutcome {
+	t.Helper()
+	var out matchOutcome
+	select {
+	case out = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for match outcome")
+	}
+	return out
+}
+
+func receiveFileIndex(t *testing.T, ch <-chan *fileIndex) *fileIndex {
+	t.Helper()
+	var idx *fileIndex
+	select {
+	case idx = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for file index")
+	}
+	return idx
+}
+
+func waitForStatInflightEmpty(t *testing.T, svc *MediaFileCheckService) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		svc.statInflightMu.Lock()
+		n := len(svc.statInflight)
+		svc.statInflightMu.Unlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for stat in-flight cleanup")
 }
 
 func TestMatch_DriveMappingExactPath(t *testing.T) {
@@ -293,12 +342,152 @@ func TestMatch_StatTimeoutUsesSingleFlight(t *testing.T) {
 		t.Fatalf("first status=%q error=%q, want stat timeout", out.Status, out.Error)
 	}
 
+	start := time.Now()
 	out = m.match(&matchInput{FilePath: `O:\Audio\frozen.wav`})
+	elapsed := time.Since(start)
 	if out.Status != MediaStatusStatError || !strings.Contains(out.Error, "stat timeout") {
 		t.Fatalf("second status=%q error=%q, want stat timeout", out.Status, out.Error)
 	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("second match took %v, want near-immediate return on already-budgeted stat flight", elapsed)
+	}
 	if got := starts.Load(); got != 1 {
 		t.Fatalf("mediaRootStat starts = %d, want 1 shared in-flight stat", got)
+	}
+}
+
+func TestMatch_StatSingleFlightSuccessPath(t *testing.T) {
+	prev := mediaRootStat
+	t.Cleanup(func() { mediaRootStat = prev })
+
+	dir := t.TempDir()
+	full := filepath.Join(dir, "Audio", "hit.wav")
+	writeFile(t, full)
+	info, err := os.Stat(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	closeRelease := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(closeRelease)
+
+	var starts atomic.Int32
+	mediaRootStat = func(_ *os.Root, _ string) (os.FileInfo, error) {
+		if starts.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return info, nil
+	}
+
+	svc := &MediaFileCheckService{
+		statInflight: make(map[string]*statInFlight),
+	}
+	m := buildTestMatcher(t, map[string]string{"O:": dir}, nil, true)
+	m.ctx = context.Background()
+	m.statTimeout = time.Second
+	m.startStatFlight = svc.startOrJoinMediaStatFlight
+
+	input := &matchInput{FilePath: `O:\Audio\hit.wav`}
+	first := make(chan matchOutcome, 1)
+	go func() { first <- m.match(input) }()
+	waitForTestSignal(t, started, "first stat start")
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		closeRelease()
+	}()
+	second := m.match(input)
+	firstOut := receiveMatchOutcome(t, first)
+
+	for _, out := range []matchOutcome{firstOut, second} {
+		if out.Status != MediaStatusPresent || out.MatchType != matchTypeExactPath {
+			t.Fatalf("status=%q matchType=%q, want present/exact_path", out.Status, out.MatchType)
+		}
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("mediaRootStat starts = %d, want 1 shared successful stat", got)
+	}
+	waitForStatInflightEmpty(t, svc)
+}
+
+func TestMatch_StatFlightContextCancel(t *testing.T) {
+	prev := mediaRootStat
+	block := make(chan struct{})
+	t.Cleanup(func() { mediaRootStat = prev })
+	t.Cleanup(func() { close(block) })
+
+	started := make(chan struct{})
+	var starts atomic.Int32
+	mediaRootStat = func(_ *os.Root, _ string) (os.FileInfo, error) {
+		if starts.Add(1) == 1 {
+			close(started)
+		}
+		<-block
+		return nil, os.ErrNotExist
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	svc := &MediaFileCheckService{
+		statInflight: make(map[string]*statInFlight),
+	}
+	m := buildTestMatcher(t, map[string]string{"O:": t.TempDir()}, nil, true)
+	m.ctx = ctx
+	m.statTimeout = time.Second
+	m.startStatFlight = svc.startOrJoinMediaStatFlight
+
+	outCh := make(chan matchOutcome, 1)
+	go func() { outCh <- m.match(&matchInput{FilePath: `O:\Audio\frozen.wav`}) }()
+	waitForTestSignal(t, started, "stat start")
+	cancel()
+
+	out := receiveMatchOutcome(t, outCh)
+	if out.Status != MediaStatusStatError || !strings.Contains(out.Error, context.Canceled.Error()) {
+		t.Fatalf("status=%q error=%q, want context-canceled stat_error", out.Status, out.Error)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("mediaRootStat starts = %d, want 1", got)
+	}
+}
+
+func TestMatch_CompletedStatFlightIsRemoved(t *testing.T) {
+	prev := mediaRootStat
+	t.Cleanup(func() { mediaRootStat = prev })
+
+	dir := t.TempDir()
+	full := filepath.Join(dir, "Audio", "hit.wav")
+	writeFile(t, full)
+	info, err := os.Stat(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var starts atomic.Int32
+	mediaRootStat = func(_ *os.Root, _ string) (os.FileInfo, error) {
+		starts.Add(1)
+		return info, nil
+	}
+
+	svc := &MediaFileCheckService{
+		statInflight: make(map[string]*statInFlight),
+	}
+	m := buildTestMatcher(t, map[string]string{"O:": dir}, nil, true)
+	m.ctx = context.Background()
+	m.statTimeout = time.Second
+	m.startStatFlight = svc.startOrJoinMediaStatFlight
+
+	for range 2 {
+		out := m.match(&matchInput{FilePath: `O:\Audio\hit.wav`})
+		if out.Status != MediaStatusPresent {
+			t.Fatalf("status = %q, want present", out.Status)
+		}
+		waitForStatInflightEmpty(t, svc)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("mediaRootStat starts = %d, want a fresh stat after completed flight cleanup", got)
 	}
 }
 
@@ -318,14 +507,14 @@ func TestMatch_DriveMappingPrefersExactOverIndex(t *testing.T) {
 }
 
 func TestBuildFileIndexRecordsWalkError(t *testing.T) {
-	idx := buildFileIndex(context.Background(), []string{filepath.Join(t.TempDir(), "missing")}, true)
+	idx := buildFileIndexWithWalkDir(context.Background(), []string{filepath.Join(t.TempDir(), "missing")}, true, mediaWalkDir)
 
 	if err := idx.err(); err == nil {
 		t.Fatal("expected index error for missing root, got nil")
 	}
 }
 
-func TestGetIndexTimeoutUsesSingleFlight(t *testing.T) {
+func TestMatch_IndexTimeoutReportsStatError(t *testing.T) {
 	prev := mediaWalkDir
 	block := make(chan struct{})
 	t.Cleanup(func() { mediaWalkDir = prev })
@@ -338,30 +527,62 @@ func TestGetIndexTimeoutUsesSingleFlight(t *testing.T) {
 		return nil
 	}
 
-	svc := &MediaFileCheckService{
-		indexInflight: make(map[string]*indexInFlight),
-	}
-	newMatcher := func() *mediaMatcher {
-		return &mediaMatcher{
-			searchDirs:       []string{"/frozen-share"},
-			caseInsensitive:  true,
-			indexTimeout:     10 * time.Millisecond,
-			ctx:              context.Background(),
-			startIndexFlight: svc.startOrJoinMediaIndexFlight,
-		}
-	}
+	m := buildTestMatcher(t, nil, []string{"/frozen-share"}, true)
+	m.ctx = context.Background()
+	m.indexTimeout = 10 * time.Millisecond
 
-	idx := newMatcher().getIndex()
-	if err := idx.err(); err == nil || !strings.Contains(err.Error(), "media file index timeout") {
-		t.Fatalf("first index error = %v, want timeout", err)
-	}
-
-	idx = newMatcher().getIndex()
-	if err := idx.err(); err == nil || !strings.Contains(err.Error(), "media file index timeout") {
-		t.Fatalf("second index error = %v, want timeout", err)
+	out := m.match(&matchInput{FileName: `O:\Audio\frozen.wav`})
+	if out.Status != MediaStatusStatError || !strings.Contains(out.Error, "media file index timeout") {
+		t.Fatalf("status=%q error=%q, want index timeout stat_error", out.Status, out.Error)
 	}
 	if got := starts.Load(); got != 1 {
-		t.Fatalf("mediaWalkDir starts = %d, want 1 shared in-flight index build", got)
+		t.Fatalf("mediaWalkDir starts = %d, want 1 bounded index build", got)
+	}
+}
+
+func TestGetIndexContextCancel(t *testing.T) {
+	prev := mediaWalkDir
+	block := make(chan struct{})
+	t.Cleanup(func() { mediaWalkDir = prev })
+	t.Cleanup(func() { close(block) })
+
+	started := make(chan struct{})
+	var starts atomic.Int32
+	mediaWalkDir = func(_ string, _ fs.WalkDirFunc) error {
+		if starts.Add(1) == 1 {
+			close(started)
+		}
+		<-block
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := buildTestMatcher(t, nil, []string{"/frozen-share"}, true)
+	m.ctx = ctx
+	m.indexTimeout = time.Hour
+
+	idxCh := make(chan *fileIndex, 1)
+	go func() { idxCh <- m.getIndex() }()
+	waitForTestSignal(t, started, "index walk start")
+	cancel()
+
+	idx := receiveFileIndex(t, idxCh)
+	if err := idx.err(); err == nil || !strings.Contains(err.Error(), "media file index canceled: context canceled") {
+		t.Fatalf("index error = %v, want context-canceled index error", err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("mediaWalkDir starts = %d, want 1", got)
+	}
+}
+
+func TestIndexErrReportsBuiltIndexError(t *testing.T) {
+	m := buildTestMatcher(t, nil, nil, true)
+	idx := emptyFileIndex()
+	idx.addError("boom")
+	m.index = idx
+
+	if err := m.indexErr(); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("indexErr = %v, want stored index error", err)
 	}
 }
 

--- a/internal/service/mediamatch_test.go
+++ b/internal/service/mediamatch_test.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -265,6 +268,40 @@ func TestMatch_StatErrorWinsOverIndexFallback(t *testing.T) {
 	}
 }
 
+func TestMatch_StatTimeoutUsesSingleFlight(t *testing.T) {
+	prev := mediaRootStat
+	block := make(chan struct{})
+	t.Cleanup(func() { mediaRootStat = prev })
+	t.Cleanup(func() { close(block) })
+
+	var starts atomic.Int32
+	mediaRootStat = func(_ *os.Root, _ string) (os.FileInfo, error) {
+		starts.Add(1)
+		<-block
+		return nil, os.ErrNotExist
+	}
+
+	svc := &MediaFileCheckService{
+		statInflight: make(map[string]*statInFlight),
+	}
+	m := buildTestMatcher(t, map[string]string{"O:": t.TempDir()}, nil, true)
+	m.statTimeout = 10 * time.Millisecond
+	m.startStatFlight = svc.startOrJoinMediaStatFlight
+
+	out := m.match(&matchInput{FilePath: `O:\Audio\frozen.wav`})
+	if out.Status != MediaStatusStatError || !strings.Contains(out.Error, "stat timeout") {
+		t.Fatalf("first status=%q error=%q, want stat timeout", out.Status, out.Error)
+	}
+
+	out = m.match(&matchInput{FilePath: `O:\Audio\frozen.wav`})
+	if out.Status != MediaStatusStatError || !strings.Contains(out.Error, "stat timeout") {
+		t.Fatalf("second status=%q error=%q, want stat timeout", out.Status, out.Error)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("mediaRootStat starts = %d, want 1 shared in-flight stat", got)
+	}
+}
+
 func TestMatch_DriveMappingPrefersExactOverIndex(t *testing.T) {
 	// A correct exact path must win even when an index also has the basename.
 	driveDir := t.TempDir()
@@ -285,6 +322,46 @@ func TestBuildFileIndexRecordsWalkError(t *testing.T) {
 
 	if err := idx.err(); err == nil {
 		t.Fatal("expected index error for missing root, got nil")
+	}
+}
+
+func TestGetIndexTimeoutUsesSingleFlight(t *testing.T) {
+	prev := mediaWalkDir
+	block := make(chan struct{})
+	t.Cleanup(func() { mediaWalkDir = prev })
+	t.Cleanup(func() { close(block) })
+
+	var starts atomic.Int32
+	mediaWalkDir = func(_ string, _ fs.WalkDirFunc) error {
+		starts.Add(1)
+		<-block
+		return nil
+	}
+
+	svc := &MediaFileCheckService{
+		indexInflight: make(map[string]*indexInFlight),
+	}
+	newMatcher := func() *mediaMatcher {
+		return &mediaMatcher{
+			searchDirs:       []string{"/frozen-share"},
+			caseInsensitive:  true,
+			indexTimeout:     10 * time.Millisecond,
+			ctx:              context.Background(),
+			startIndexFlight: svc.startOrJoinMediaIndexFlight,
+		}
+	}
+
+	idx := newMatcher().getIndex()
+	if err := idx.err(); err == nil || !strings.Contains(err.Error(), "media file index timeout") {
+		t.Fatalf("first index error = %v, want timeout", err)
+	}
+
+	idx = newMatcher().getIndex()
+	if err := idx.err(); err == nil || !strings.Contains(err.Error(), "media file index timeout") {
+		t.Fatalf("second index error = %v, want timeout", err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("mediaWalkDir starts = %d, want 1 shared in-flight index build", got)
 	}
 }
 


### PR DESCRIPTION
## Fact check
- Confirmed media exact-path checks used `statRootWithTimeout`, which spawned a fresh goroutine per stat and could leave one stuck goroutine per run/path on a frozen mount.
- Confirmed `search_dirs` indexing used `filepath.WalkDir` directly inside lazy matcher indexing, so a frozen recursive walk could block check workers and prevent the run from completing.
- Confirmed file monitor already uses single-flight stat tracking to bound repeated hangs; media file check did not.

## Fix
- Added service-level single-flight tracking for media exact-path stats, keyed by drive mount target and relative path.
- Added service-level single-flight tracking for search-dir index builds, keyed by search dirs and case-sensitivity.
- Reworked matcher index building so workers share one bounded build attempt instead of blocking indefinitely in `sync.Once`.
- Preserved existing exact-path root checks through `os.Root`.
- Surfaced index timeout/cancel failures through `matcher.indexErr()` so the run result reports a clear error.

## Verification
- `go test ./internal/service -run 'TestMatch|TestGetIndex|TestBuildFileIndex|TestMediaFileCheck|TestProblemCount'`
- `go test ./internal/service ./internal/config`
- `go test ./...`

Closes #151