### PR TITLE
fix: require safe auth defaults

### DIFF
--- a/API.md
+++ b/API.md
@@ -1674,7 +1674,7 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   },
   "api": {
     "enabled": true,
-    "keys": ["jouw-lange-willekeurige-api-sleutel-hier"],
+    "keys": ["vervang-dit-door-een-lange-willekeurige-api-sleutel"],
     "request_timeout_seconds": 30
   },
   "maintenance": {

--- a/API.md
+++ b/API.md
@@ -69,9 +69,11 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 
 ## Authenticatie
 
-Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `GET /api/health`) een API-sleutel.
+De voorbeeldconfiguratie schakelt authenticatie standaard in. Alle endpoints behalve `GET /api/health` vereisen dan een API-sleutel.
 
 **Header:** `X-API-Key: jouw-api-sleutel`
+
+Gebruik in productie een lange willekeurige sleutel in `api.keys`. Zet `api.enabled` alleen op `false` voor lokale tests of volledig afgeschermde netwerken; zonder authenticatie zijn muterende endpoints, backupdownloads en operationele statusinformatie bereikbaar voor iedereen die de HTTP-poort kan benaderen.
 
 **Response bij ontbrekende autorisatie:**
 ```json
@@ -1672,7 +1674,7 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   },
   "api": {
     "enabled": true,
-    "keys": ["jouw-veilige-api-sleutel-hier"],
+    "keys": ["jouw-lange-willekeurige-api-sleutel-hier"],
     "request_timeout_seconds": 30
   },
   "maintenance": {

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/config.example.json -O config.json
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-compose.example.yml -O docker-compose.yml
 
-# Zet in config.json een lange willekeurige api.keys waarde, pas daarna de rest aan:
+# Genereer een sleutel en plak de uitvoer in config.json bij api.keys:
 openssl rand -base64 32
 
 docker compose up -d
@@ -54,7 +54,7 @@ Download een kant-en-klare Linux- of macOS-binary via de [releases-pagina](https
 git clone https://github.com/oszuidwest/zwfm-aerontoolbox.git
 cd zwfm-aerontoolbox
 cp config.example.json config.json
-# Zet in config.json een lange willekeurige api.keys waarde:
+# Genereer een sleutel en plak de uitvoer in config.json bij api.keys:
 openssl rand -base64 32
 go build -o zwfm-aerontoolbox .
 ./zwfm-aerontoolbox -config=config.json -port=8080

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/config.example.json -O config.json
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-compose.example.yml -O docker-compose.yml
 
-# Pas config.json aan naar jouw situatie, dan:
+# Zet in config.json een lange willekeurige api.keys waarde, pas daarna de rest aan:
+openssl rand -base64 32
+
 docker compose up -d
 ```
 
@@ -52,6 +54,8 @@ Download een kant-en-klare Linux- of macOS-binary via de [releases-pagina](https
 git clone https://github.com/oszuidwest/zwfm-aerontoolbox.git
 cd zwfm-aerontoolbox
 cp config.example.json config.json
+# Zet in config.json een lange willekeurige api.keys waarde:
+openssl rand -base64 32
 go build -o zwfm-aerontoolbox .
 ./zwfm-aerontoolbox -config=config.json -port=8080
 ```
@@ -73,6 +77,10 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
+
+### Authenticatie
+
+De voorbeeldconfiguratie zet API-authenticatie standaard aan. Vervang de placeholder in `api.keys` door een lange willekeurige sleutel en stuur die mee als `X-API-Key`. Zet `api.enabled` alleen op `false` voor lokale tests of volledig afgeschermde netwerken; zonder authenticatie zijn muterende endpoints, backupdownloads en beheerstatussen bereikbaar voor iedereen die de HTTP-poort kan benaderen.
 
 ### Backupfunctionaliteit
 

--- a/config.example.json
+++ b/config.example.json
@@ -19,8 +19,8 @@
     "max_image_download_size_bytes": 52428800
   },
   "api": {
-    "enabled": false,
-    "keys": [],
+    "enabled": true,
+    "keys": ["vervang-dit-door-een-lange-willekeurige-api-sleutel"],
     "request_timeout_seconds": 30
   },
   "maintenance": {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -63,6 +63,39 @@ func TestFileMonitorRoutesDisabledReturnNotFound(t *testing.T) {
 	}
 }
 
+func TestProtectedRoutesRequireAPIKeyWhenAuthEnabled(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.API.Enabled = true
+	cfg.API.Keys = []string{"test-api-key"}
+
+	svc, err := service.New(nil, cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	t.Cleanup(svc.Close)
+
+	handler := New(svc, "test").router()
+	req := httptest.NewRequest(http.MethodGet, "/api/playlist", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status code = %d, want %d; body: %s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+
+	var got Response
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Success {
+		t.Fatal("success = true, want false")
+	}
+	if got.Error != "Unauthorized: invalid or missing API key" {
+		t.Fatalf("error = %q, want unauthorized API key message", got.Error)
+	}
+}
+
 func TestFileMonitorRoutesEnabledPassThrough(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.FileMonitor.Enabled = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,8 @@ type APIConfig struct {
 	RequestTimeoutSeconds int      `json:"request_timeout_seconds" validate:"gte=0"`
 }
 
+const apiKeyPlaceholder = "vervang-dit-door-een-lange-willekeurige-api-sleutel" //nolint:gosec // Public example value, explicitly rejected by validation.
+
 // MaintenanceConfig holds thresholds used by database health checks.
 type MaintenanceConfig struct {
 	BloatThreshold              float64         `json:"bloat_threshold" validate:"gte=0,lte=100"`
@@ -441,10 +443,29 @@ func newConfigValidator() *validator.Validate {
 	})
 
 	v.RegisterStructValidation(validateS3Config, S3Config{})
+	v.RegisterStructValidation(validateAPIConfig, APIConfig{})
 	v.RegisterStructValidation(validateFileMonitorConfig, FileMonitorConfig{})
 	v.RegisterStructValidation(validateMediaFileCheckConfig, MediaFileCheckConfig{})
 
 	return v
+}
+
+// validateAPIConfig rejects the documented placeholder as a live credential.
+func validateAPIConfig(sl validator.StructLevel) {
+	api := sl.Current().Interface().(APIConfig)
+	if !api.Enabled {
+		return
+	}
+	if len(api.Keys) == 0 {
+		sl.ReportError(api.Keys, "keys", "Keys", "required_when_enabled", "")
+		return
+	}
+	for _, key := range api.Keys {
+		if key == apiKeyPlaceholder {
+			sl.ReportError(api.Keys, "keys", "Keys", "api_key_placeholder", "")
+			return
+		}
+	}
 }
 
 // validateS3Config checks that S3 has either a region or custom endpoint when enabled.
@@ -575,6 +596,8 @@ func tagMessage(tag, param string) string {
 		return "is required when no endpoint is specified"
 	case "required_when_enabled":
 		return "must have at least one entry when enabled"
+	case "api_key_placeholder":
+		return "must replace the example placeholder with a random key"
 	case "media_check_no_source":
 		return "requires at least one search dir or drive mount when enabled"
 	case "media_check_drive_key":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,68 @@ func TestInterval_ZeroFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestAPIValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		keys    []string
+		wantErr bool
+	}{
+		{
+			name:    "disabled with no keys",
+			enabled: false,
+			keys:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "enabled with key",
+			enabled: true,
+			keys:    []string{"long-random-test-key"},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with empty slice",
+			enabled: true,
+			keys:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "enabled with nil keys",
+			enabled: true,
+			keys:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "enabled with empty string key",
+			enabled: true,
+			keys:    []string{""},
+			wantErr: true,
+		},
+		{
+			name:    "enabled with placeholder key",
+			enabled: true,
+			keys:    []string{apiKeyPlaceholder},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.API.Enabled = tt.enabled
+			cfg.API.Keys = tt.keys
+
+			err := validate(cfg)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
 func TestFileMonitorValidation_DuplicatePaths(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.FileMonitor.Enabled = true


### PR DESCRIPTION
## Fact check
- Confirmed `config.example.json` disabled API auth and used an empty key list.
- Confirmed README quick start tells users to copy/download that example before running Docker or the binary.
- Confirmed `authMiddleware` intentionally passes protected routes through when `api.enabled=false`.

## Fix
- Changed the example config to enable API authentication by default with a placeholder key that must be replaced.
- Documented generating a long random key before deployment.
- Documented unauthenticated mode as suitable only for local tests or fully isolated networks.
- Added a router unit test proving protected routes return 401 without `X-API-Key` when auth is enabled.

## Verification
- `go test ./internal/api ./internal/config`
- `go test ./...`

Closes #149