### PR TITLE
feat: add optional api rate limiting

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,7 +31,7 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 | Endpoint | Methode | Beschrijving | Auth |
 |----------|---------|--------------|------|
 | **Algemeen** |
-| `/api/health` | GET | API-status controleren | Nee |
+| `/health` (`/api/health`) | GET | API-status controleren | Nee |
 | **Artiesten** |
 | `/api/artists` | GET | Statistieken over artiesten | Ja |
 | `/api/artists/{id}` | GET | Specifieke artiest ophalen | Ja |
@@ -69,13 +69,13 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 
 ## Authenticatie
 
-Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `GET /api/health`) een API-sleutel.
+Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `GET /health` en `GET /api/health`) een API-sleutel.
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
 Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropie (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
 
-Optionele rate limiting kan worden ingeschakeld met `api.rate_limit_enabled`. De limiter telt per API-sleutel, of per remote adres wanneer geen sleutel is meegestuurd.
+Optionele rate limiting kan worden ingeschakeld met `api.rate_limit_enabled`. De limiter telt per API-sleutel, of per direct peer-adres (`RemoteAddr`) wanneer geen geldige sleutel is meegestuurd. Achter een reverse proxy die client-IP's verbergt, delen alle unauthenticated requests achter die proxy dus één budget.
 
 **Response bij ontbrekende autorisatie:**
 ```json
@@ -138,8 +138,10 @@ Alle fouten volgen dit formaat:
 
 Controleer de status van de API.
 
-**Endpoint:** `GET /api/health`
+**Endpoint:** `GET /health` (ook beschikbaar als `GET /api/health` voor compatibiliteit)
 **Authenticatie:** Niet vereist
+
+Deze publieke health-route wordt niet rate-limited.
 
 **Response:** `200 OK`
 ```json
@@ -1256,7 +1258,7 @@ Strikte gelijkheid (`completed_run_id == myRunID`) bevestigt dat de zichtbare `c
 
 ### Integratie met het health-endpoint (bestandsbewaking)
 
-Als de bestandsbewaking is ingeschakeld, geeft het health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
+Als de bestandsbewaking is ingeschakeld, geeft het health-endpoint (`GET /health`, ook beschikbaar als `GET /api/health`) een extra `file_monitor`-blok terug:
 
 ```json
 {
@@ -1428,7 +1430,7 @@ Met `media_file_check.scheduler` draait de controle automatisch op een cron-sche
 
 ### Integratie met het health-endpoint (aanwezigheidscontrole)
 
-Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
+Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /health` (ook beschikbaar als `GET /api/health`) een extra `media_file_check`-blok terug:
 
 ```json
 {
@@ -1771,6 +1773,9 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
 - `api.idle_timeout_seconds`: Maximale idle tijd voor keep-alive verbindingen (standaard 120).
 - `api.max_upload_body_bytes`: Maximale JSON request-body voor image upload endpoints
   (standaard 73400320, ongeveer 70 MiB).
+- `api.rate_limit_enabled`: Schakel fixed-window rate limiting in voor API-endpoints behalve de publieke health-route.
+- `api.rate_limit_requests`: Aantal toegestane requests per bucket per window (standaard 120).
+- `api.rate_limit_window_seconds`: Lengte van het rate-limitwindow in seconden (standaard 60).
 
 Voor deze API-instellingen betekent `0` of weglaten: gebruik de applicatiestandaard. Het betekent dus niet "onbeperkt".
 
@@ -1782,7 +1787,7 @@ Voor deze API-instellingen betekent `0` of weglaten: gebruik de applicatiestanda
   - `path`: Absoluut pad naar het bestand.
   - `max_age_minutes`: Maximaal toegestane leeftijd in minuten (minimaal 1).
   - `stat_timeout_seconds`: Maximale tijd in seconden voor `os.Stat` (standaard 5; `0` of weglaten = standaard). Beschermt tegen vastgelopen NFS- of SMB-mounts.
-  - `active_window`: Optioneel tijdvenster `"HH:MM-HH:MM"` waarin alerts en `GET /api/health`-degradatie actief zijn. Buiten dit venster blijft `is_stale` zichtbaar in `GET /api/file-monitor/status`, maar wordt er geen alert- of herstelmail verstuurd en blijft `GET /api/health` gezond. Een eindtijd vóór de starttijd betekent dat het venster over middernacht heen loopt, bijvoorbeeld `"22:00-06:00"`. Gelijke start- en eindtijd zijn ongeldig; laat het veld weg voor altijd actief.
+  - `active_window`: Optioneel tijdvenster `"HH:MM-HH:MM"` waarin alerts en health-degradatie actief zijn. Buiten dit venster blijft `is_stale` zichtbaar in `GET /api/file-monitor/status`, maar wordt er geen alert- of herstelmail verstuurd en blijft `GET /health` (`GET /api/health`) gezond. Een eindtijd vóór de starttijd betekent dat het venster over middernacht heen loopt, bijvoorbeeld `"22:00-06:00"`. Gelijke start- en eindtijd zijn ongeldig; laat het veld weg voor altijd actief.
 
 Het controle-interval staat los van `max_age_minutes` en wordt geconfigureerd via `interval_seconds` (standaard 60 s).
 

--- a/API.md
+++ b/API.md
@@ -73,6 +73,8 @@ Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoint
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
+Optionele rate limiting kan worden ingeschakeld met `api.rate_limit_enabled`. De limiter telt per API-sleutel, of per remote adres wanneer geen sleutel is meegestuurd.
+
 **Response bij ontbrekende autorisatie:**
 ```json
 {
@@ -1673,7 +1675,10 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
   "api": {
     "enabled": true,
     "keys": ["jouw-veilige-api-sleutel-hier"],
-    "request_timeout_seconds": 30
+    "request_timeout_seconds": 30,
+    "rate_limit_enabled": false,
+    "rate_limit_requests": 120,
+    "rate_limit_window_seconds": 60
   },
   "maintenance": {
     "bloat_threshold": 10.0,

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/api/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Start API server by default
 ENTRYPOINT ["/app/zwfm-aerontoolbox"]

--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 |--------|---------------------|
 | `database` | PostgreSQL-verbinding (host, poort, inloggegevens, schema) |
 | `image` | Doelafmetingen en JPEG-kwaliteit voor geüploade afbeeldingen |
-| `api` | API-sleutels voor authenticatie |
+| `api` | API-sleutels voor authenticatie en optionele rate limiting |
 | `maintenance` | Drempelwaarden en automatische scheduler voor database health checks |
 | `backup` | Pad naar backups, retentie, scheduler en optionele S3-sync |
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
 | `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
+
+Voor rate limiting kun je `api.rate_limit_enabled` aanzetten. `rate_limit_requests` requests per `rate_limit_window_seconds` worden dan toegestaan per API-sleutel, of per remote adres wanneer geen sleutel is meegestuurd.
 
 ### Backupfunctionaliteit
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 
 Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropie, bijvoorbeeld via `openssl rand -base64 32`.
 
-Voor rate limiting kun je `api.rate_limit_enabled` aanzetten. `rate_limit_requests` requests per `rate_limit_window_seconds` worden dan toegestaan per API-sleutel, of per remote adres wanneer geen sleutel is meegestuurd.
+Voor rate limiting kun je `api.rate_limit_enabled` aanzetten. `rate_limit_requests` requests per `rate_limit_window_seconds` worden dan toegestaan per API-sleutel, of per direct peer-adres (`RemoteAddr`) wanneer geen geldige sleutel is meegestuurd. Achter een reverse proxy die client-IP's verbergt, delen alle unauthenticated requests achter die proxy dus één budget.
 
 ### Backupfunctionaliteit
 
@@ -138,7 +138,7 @@ Test de configuratie via `POST /api/notifications/test-email`.
 
 ```bash
 # Health check
-curl http://localhost:8080/api/health
+curl http://localhost:8080/health
 
 # Artiestafbeelding uploaden (via URL)
 curl -X POST http://localhost:8080/api/artists/{id}/image \

--- a/config.example.json
+++ b/config.example.json
@@ -21,7 +21,10 @@
   "api": {
     "enabled": false,
     "keys": [],
-    "request_timeout_seconds": 30
+    "request_timeout_seconds": 30,
+    "rate_limit_enabled": false,
+    "rate_limit_requests": 120,
+    "rate_limit_window_seconds": 60
   },
   "maintenance": {
     "bloat_threshold": 10.0,

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,7 +13,7 @@ services:
       # Override log level via environment variable (optional)
       # - LOG_LEVEL=debug
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/oszuidwest/zwfm-aerontoolbox/internal/config"
+)
+
+type rateLimitState struct {
+	windowStart time.Time
+	lastSeen    time.Time
+	count       int
+}
+
+type apiRateLimiter struct {
+	mu      sync.Mutex
+	limit   int
+	window  time.Duration
+	clients map[string]rateLimitState
+	now     func() time.Time
+}
+
+func newAPIRateLimiter(cfg *config.APIConfig) *apiRateLimiter {
+	if !cfg.RateLimitEnabled {
+		return nil
+	}
+	return &apiRateLimiter{
+		limit:   cfg.GetRateLimitRequests(),
+		window:  cfg.GetRateLimitWindow(),
+		clients: make(map[string]rateLimitState),
+		now:     time.Now,
+	}
+}
+
+func (l *apiRateLimiter) allow(key string) (bool, time.Duration) {
+	now := l.now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	st := l.clients[key]
+	if st.windowStart.IsZero() || now.Sub(st.windowStart) >= l.window {
+		st = rateLimitState{windowStart: now}
+	}
+	st.lastSeen = now
+
+	if st.count >= l.limit {
+		l.clients[key] = st
+		return false, st.windowStart.Add(l.window).Sub(now)
+	}
+
+	st.count++
+	l.clients[key] = st
+	l.cleanupLocked(now)
+	return true, 0
+}
+
+func (l *apiRateLimiter) cleanupLocked(now time.Time) {
+	if len(l.clients) < 1024 {
+		return
+	}
+	maxIdle := 2 * l.window
+	for key, st := range l.clients {
+		if now.Sub(st.lastSeen) > maxIdle {
+			delete(l.clients, key)
+		}
+	}
+}
+
+func (s *Server) rateLimitMiddleware(limiter *apiRateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ok, retryAfter := limiter.allow(s.rateLimitKey(r))
+			if !ok {
+				w.Header().Set("Retry-After", retryAfterSeconds(retryAfter))
+				respondError(w, http.StatusTooManyRequests, "Rate limit exceeded")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func (s *Server) rateLimitKey(r *http.Request) string {
+	if apiKey := r.Header.Get("X-API-Key"); apiKey != "" && s.isValidAPIKey(apiKey) {
+		sum := sha256.Sum256([]byte(apiKey))
+		return "api-key:" + hex.EncodeToString(sum[:])
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil || host == "" {
+		host = r.RemoteAddr
+	}
+	return "remote:" + host
+}
+
+func retryAfterSeconds(d time.Duration) string {
+	seconds := int(math.Ceil(d.Seconds()))
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.Itoa(seconds)
+}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"log/slog"
 	"math"
 	"net"
 	"net/http"
@@ -15,8 +16,8 @@ import (
 
 type rateLimitState struct {
 	windowStart time.Time
-	lastSeen    time.Time
 	count       int
+	denyLogged  bool
 }
 
 type apiRateLimiter struct {
@@ -39,7 +40,7 @@ func newAPIRateLimiter(cfg *config.APIConfig) *apiRateLimiter {
 	}
 }
 
-func (l *apiRateLimiter) allow(key string) (bool, time.Duration) {
+func (l *apiRateLimiter) allow(key string) (bool, time.Duration, bool) {
 	now := l.now()
 
 	l.mu.Lock()
@@ -49,17 +50,25 @@ func (l *apiRateLimiter) allow(key string) (bool, time.Duration) {
 	if st.windowStart.IsZero() || now.Sub(st.windowStart) >= l.window {
 		st = rateLimitState{windowStart: now}
 	}
-	st.lastSeen = now
 
-	if st.count >= l.limit {
-		l.clients[key] = st
-		return false, st.windowStart.Add(l.window).Sub(now)
+	allowed := st.count < l.limit
+	var retryAfter time.Duration
+	var logDenied bool
+	if allowed {
+		st.count++
+	} else {
+		logDenied = !st.denyLogged
+		st.denyLogged = true
+		retryAfter = st.windowStart.Add(l.window).Sub(now)
 	}
 
-	st.count++
 	l.clients[key] = st
+	if !allowed {
+		return false, retryAfter, logDenied
+	}
+
 	l.cleanupLocked(now)
-	return true, 0
+	return true, 0, false
 }
 
 func (l *apiRateLimiter) cleanupLocked(now time.Time) {
@@ -68,7 +77,7 @@ func (l *apiRateLimiter) cleanupLocked(now time.Time) {
 	}
 	maxIdle := 2 * l.window
 	for key, st := range l.clients {
-		if now.Sub(st.lastSeen) > maxIdle {
+		if now.Sub(st.windowStart) > maxIdle {
 			delete(l.clients, key)
 		}
 	}
@@ -77,8 +86,20 @@ func (l *apiRateLimiter) cleanupLocked(now time.Time) {
 func (s *Server) rateLimitMiddleware(limiter *apiRateLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ok, retryAfter := limiter.allow(s.rateLimitKey(r))
+			if isPublicHealthPath(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			key := s.rateLimitKey(r)
+			ok, retryAfter, logDenied := limiter.allow(key)
 			if !ok {
+				if logDenied {
+					slog.Warn("Rate limit exceeded",
+						"bucket", key,
+						"path", r.URL.Path,
+						"method", r.Method)
+				}
 				w.Header().Set("Retry-After", retryAfterSeconds(retryAfter))
 				respondError(w, http.StatusTooManyRequests, "Rate limit exceeded")
 				return

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -173,7 +173,7 @@ func TestAPIRateLimiterAllowConcurrent(t *testing.T) {
 	}
 }
 
-func TestRateLimitMiddlewareSkipsPublicHealthPaths(t *testing.T) {
+func TestRateLimitMiddlewareSkipsAPIHealthPath(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
@@ -185,21 +185,15 @@ func TestRateLimitMiddlewareSkipsPublicHealthPaths(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	for _, path := range []string{"/health", "/api/health"} {
-		t.Run(path, func(t *testing.T) {
-			t.Parallel()
+	for range 2 {
+		req := httptest.NewRequest(http.MethodGet, "/api/health", http.NoBody)
+		rec := httptest.NewRecorder()
 
-			for range 2 {
-				req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
-				rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
 
-				handler.ServeHTTP(rec, req)
-
-				if rec.Code != http.StatusNoContent {
-					t.Fatalf("status code = %d, want %d; body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
-				}
-			}
-		})
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status code = %d, want %d; body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+		}
 	}
 }
 

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAPIRateLimiterAllowResetsAfterWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+		return now
+	})
+
+	allowed, retryAfter, logDenied := limiter.allow("client-a")
+	if !allowed {
+		t.Fatal("first request allowed = false, want true")
+	}
+	if retryAfter != 0 {
+		t.Fatalf("first retryAfter = %s, want 0", retryAfter)
+	}
+	if logDenied {
+		t.Fatal("first logDenied = true, want false")
+	}
+
+	allowed, retryAfter, logDenied = limiter.allow("client-a")
+	if allowed {
+		t.Fatal("second request allowed = true, want false")
+	}
+	if retryAfter != time.Minute {
+		t.Fatalf("second retryAfter = %s, want 1m0s", retryAfter)
+	}
+	if !logDenied {
+		t.Fatal("second logDenied = false, want true")
+	}
+
+	now = now.Add(time.Minute)
+	allowed, retryAfter, logDenied = limiter.allow("client-a")
+	if !allowed {
+		t.Fatal("request after window reset allowed = false, want true")
+	}
+	if retryAfter != 0 {
+		t.Fatalf("request after window reset retryAfter = %s, want 0", retryAfter)
+	}
+	if logDenied {
+		t.Fatal("request after window reset logDenied = true, want false")
+	}
+}
+
+func TestAPIRateLimiterRetryAfterSeconds(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+		return now
+	})
+
+	allowed, _, _ := limiter.allow("client-a")
+	if !allowed {
+		t.Fatal("first request allowed = false, want true")
+	}
+
+	now = now.Add(12*time.Second + 100*time.Millisecond)
+	allowed, retryAfter, _ := limiter.allow("client-a")
+	if allowed {
+		t.Fatal("second request allowed = true, want false")
+	}
+	if got, want := retryAfterSeconds(retryAfter), "48"; got != want {
+		t.Fatalf("Retry-After = %q, want %q", got, want)
+	}
+}
+
+func TestAPIRateLimiterBucketsAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+		return now
+	})
+
+	allowed, _, _ := limiter.allow("client-a")
+	if !allowed {
+		t.Fatal("first client-a request allowed = false, want true")
+	}
+
+	allowed, _, _ = limiter.allow("client-a")
+	if allowed {
+		t.Fatal("second client-a request allowed = true, want false")
+	}
+
+	allowed, _, _ = limiter.allow("client-b")
+	if !allowed {
+		t.Fatal("first client-b request allowed = false, want true")
+	}
+}
+
+func TestAPIRateLimiterDenialLogSignalIsOncePerWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+		return now
+	})
+
+	allowed, _, logDenied := limiter.allow("client-a")
+	if !allowed || logDenied {
+		t.Fatalf("first request = allowed %v logDenied %v, want allowed true logDenied false", allowed, logDenied)
+	}
+
+	allowed, _, logDenied = limiter.allow("client-a")
+	if allowed || !logDenied {
+		t.Fatalf("first denial = allowed %v logDenied %v, want allowed false logDenied true", allowed, logDenied)
+	}
+
+	allowed, _, logDenied = limiter.allow("client-a")
+	if allowed || logDenied {
+		t.Fatalf("second denial = allowed %v logDenied %v, want allowed false logDenied false", allowed, logDenied)
+	}
+
+	now = now.Add(time.Minute)
+	allowed, _, logDenied = limiter.allow("client-a")
+	if !allowed || logDenied {
+		t.Fatalf("new window request = allowed %v logDenied %v, want allowed true logDenied false", allowed, logDenied)
+	}
+
+	allowed, _, logDenied = limiter.allow("client-a")
+	if allowed || !logDenied {
+		t.Fatalf("new window denial = allowed %v logDenied %v, want allowed false logDenied true", allowed, logDenied)
+	}
+}
+
+func TestAPIRateLimiterAllowConcurrent(t *testing.T) {
+	const goroutines = 64
+
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newTestRateLimiter(goroutines, time.Minute, func() time.Time {
+		return now
+	})
+
+	var wg sync.WaitGroup
+	results := make(chan bool, goroutines)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			allowed, _, _ := limiter.allow("client-a")
+			results <- allowed
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var allowedCount int
+	for allowed := range results {
+		if !allowed {
+			t.Fatal("concurrent request allowed = false, want true")
+		}
+		allowedCount++
+	}
+	if allowedCount != goroutines {
+		t.Fatalf("allowed count = %d, want %d", allowedCount, goroutines)
+	}
+
+	limiter.mu.Lock()
+	count := limiter.clients["client-a"].count
+	limiter.mu.Unlock()
+	if count != goroutines {
+		t.Fatalf("stored count = %d, want %d", count, goroutines)
+	}
+}
+
+func TestRateLimitMiddlewareSkipsPublicHealthPaths(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newTestRateLimiter(0, time.Minute, func() time.Time {
+		return now
+	})
+	server := &Server{}
+	handler := server.rateLimitMiddleware(limiter)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for _, path := range []string{"/health", "/api/health"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			for range 2 {
+				req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+				rec := httptest.NewRecorder()
+
+				handler.ServeHTTP(rec, req)
+
+				if rec.Code != http.StatusNoContent {
+					t.Fatalf("status code = %d, want %d; body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func newTestRateLimiter(limit int, window time.Duration, now func() time.Time) *apiRateLimiter {
+	return &apiRateLimiter{
+		limit:   limit,
+		window:  window,
+		clients: make(map[string]rateLimitState),
+		now:     now,
+	}
+}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -12,7 +12,7 @@ func TestAPIRateLimiterAllowResetsAfterWindow(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
-	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+	limiter := newTestRateLimiter(1, func() time.Time {
 		return now
 	})
 
@@ -55,7 +55,7 @@ func TestAPIRateLimiterRetryAfterSeconds(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
-	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+	limiter := newTestRateLimiter(1, func() time.Time {
 		return now
 	})
 
@@ -78,7 +78,7 @@ func TestAPIRateLimiterBucketsAreIsolated(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
-	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+	limiter := newTestRateLimiter(1, func() time.Time {
 		return now
 	})
 
@@ -102,7 +102,7 @@ func TestAPIRateLimiterDenialLogSignalIsOncePerWindow(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
-	limiter := newTestRateLimiter(1, time.Minute, func() time.Time {
+	limiter := newTestRateLimiter(1, func() time.Time {
 		return now
 	})
 
@@ -137,7 +137,7 @@ func TestAPIRateLimiterAllowConcurrent(t *testing.T) {
 	const goroutines = 64
 
 	now := time.Unix(1_700_000_000, 0)
-	limiter := newTestRateLimiter(goroutines, time.Minute, func() time.Time {
+	limiter := newTestRateLimiter(goroutines, func() time.Time {
 		return now
 	})
 
@@ -177,7 +177,7 @@ func TestRateLimitMiddlewareSkipsAPIHealthPath(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
-	limiter := newTestRateLimiter(0, time.Minute, func() time.Time {
+	limiter := newTestRateLimiter(0, func() time.Time {
 		return now
 	})
 	server := &Server{}
@@ -197,10 +197,10 @@ func TestRateLimitMiddlewareSkipsAPIHealthPath(t *testing.T) {
 	}
 }
 
-func newTestRateLimiter(limit int, window time.Duration, now func() time.Time) *apiRateLimiter {
+func newTestRateLimiter(limit int, now func() time.Time) *apiRateLimiter {
 	return &apiRateLimiter{
 		limit:   limit,
-		window:  window,
+		window:  time.Minute,
 		clients: make(map[string]rateLimitState),
 		now:     now,
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -62,6 +62,9 @@ func (s *Server) router() http.Handler {
 
 	router.Route("/api", func(r chi.Router) {
 		r.Use(middleware.SetHeader("Content-Type", "application/json; charset=utf-8"))
+		if limiter := newAPIRateLimiter(&s.service.Config().API); limiter != nil {
+			r.Use(s.rateLimitMiddleware(limiter))
+		}
 
 		r.NotFound(func(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusNotFound, "Endpoint not found")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -139,7 +139,7 @@ func (s *Server) router() http.Handler {
 }
 
 func isPublicHealthPath(path string) bool {
-	return path == "/health" || path == "/api/health"
+	return path == "/api/health"
 }
 
 // Shutdown gracefully stops the active HTTP server. It is a no-op before Start.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -68,8 +68,11 @@ func (s *Server) router() http.Handler {
 		respondError(w, http.StatusNotFound, "Endpoint not found")
 	})
 
+	jsonHeader := middleware.SetHeader("Content-Type", "application/json; charset=utf-8")
+	router.With(jsonHeader).Get("/health", s.handleHealth)
+
 	router.Route("/api", func(r chi.Router) {
-		r.Use(middleware.SetHeader("Content-Type", "application/json; charset=utf-8"))
+		r.Use(jsonHeader)
 		if limiter := newAPIRateLimiter(&s.service.Config().API); limiter != nil {
 			r.Use(s.rateLimitMiddleware(limiter))
 		}
@@ -133,6 +136,10 @@ func (s *Server) router() http.Handler {
 	})
 
 	return router
+}
+
+func isPublicHealthPath(path string) bool {
+	return path == "/health" || path == "/api/health"
 }
 
 // Shutdown gracefully stops the active HTTP server. It is a no-op before Start.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -100,8 +100,8 @@ func TestRateLimiterLimitsAuthenticatedProtectedRequests(t *testing.T) {
 	if rec.Code != http.StatusTooManyRequests {
 		t.Fatalf("second status code = %d, want %d; body: %s", rec.Code, http.StatusTooManyRequests, rec.Body.String())
 	}
-	if rec.Header().Get("Retry-After") == "" {
-		t.Fatal("Retry-After header is empty")
+	if got, want := rec.Header().Get("Retry-After"), "60"; got != want {
+		t.Fatalf("Retry-After = %q, want %q", got, want)
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -63,6 +63,76 @@ func TestFileMonitorRoutesDisabledReturnNotFound(t *testing.T) {
 	}
 }
 
+func TestRateLimiterLimitsAuthenticatedProtectedRequests(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.API.Enabled = true
+	cfg.API.Keys = []string{"test-api-key"}
+	cfg.API.RateLimitEnabled = true
+	cfg.API.RateLimitRequests = 1
+	cfg.API.RateLimitWindowSeconds = 60
+	cfg.FileMonitor.Enabled = true
+
+	svc, err := service.New(nil, cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	t.Cleanup(svc.Close)
+
+	handler := New(svc, "test").router()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/file-monitor/check", http.NoBody)
+	req.Header.Set("X-API-Key", "test-api-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("first status code = %d, want %d; body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/file-monitor/check", http.NoBody)
+	req.Header.Set("X-API-Key", "test-api-key")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status code = %d, want %d; body: %s", rec.Code, http.StatusTooManyRequests, rec.Body.String())
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Fatal("Retry-After header is empty")
+	}
+}
+
+func TestRateLimiterLimitsInvalidAPIKeyProbesByRemoteAddress(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.API.Enabled = true
+	cfg.API.Keys = []string{"test-api-key"}
+	cfg.API.RateLimitEnabled = true
+	cfg.API.RateLimitRequests = 1
+	cfg.API.RateLimitWindowSeconds = 60
+
+	svc, err := service.New(nil, cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	t.Cleanup(svc.Close)
+
+	handler := New(svc, "test").router()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/playlist", http.NoBody)
+	req.Header.Set("X-API-Key", "wrong-key-1")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("first status code = %d, want %d; body: %s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/playlist", http.NoBody)
+	req.Header.Set("X-API-Key", "wrong-key-2")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status code = %d, want %d; body: %s", rec.Code, http.StatusTooManyRequests, rec.Body.String())
+	}
+}
+
 func TestFileMonitorRoutesEnabledPassThrough(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.FileMonitor.Enabled = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,8 +54,8 @@ type APIConfig struct {
 	IdleTimeoutSeconds       int      `json:"idle_timeout_seconds" validate:"gte=0"`
 	MaxUploadBodyBytes       int64    `json:"max_upload_body_bytes" validate:"gte=0"`
 	RateLimitEnabled         bool     `json:"rate_limit_enabled"`
-	RateLimitRequests        int      `json:"rate_limit_requests" validate:"gte=0"`
-	RateLimitWindowSeconds   int      `json:"rate_limit_window_seconds" validate:"gte=0"`
+	RateLimitRequests        int      `json:"rate_limit_requests" validate:"omitempty,gte=1"`
+	RateLimitWindowSeconds   int      `json:"rate_limit_window_seconds" validate:"omitempty,gte=1"`
 }
 
 // MaintenanceConfig holds thresholds used by database health checks.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,9 +44,12 @@ type ImageConfig struct {
 
 // APIConfig controls API authentication and request timeouts.
 type APIConfig struct {
-	Enabled               bool     `json:"enabled"`
-	Keys                  []string `json:"keys" validate:"required_if=Enabled true,dive,required"`
-	RequestTimeoutSeconds int      `json:"request_timeout_seconds" validate:"gte=0"`
+	Enabled                bool     `json:"enabled"`
+	Keys                   []string `json:"keys" validate:"required_if=Enabled true,dive,required"`
+	RequestTimeoutSeconds  int      `json:"request_timeout_seconds" validate:"gte=0"`
+	RateLimitEnabled       bool     `json:"rate_limit_enabled"`
+	RateLimitRequests      int      `json:"rate_limit_requests" validate:"gte=0"`
+	RateLimitWindowSeconds int      `json:"rate_limit_window_seconds" validate:"gte=0"`
 }
 
 // MaintenanceConfig holds thresholds used by database health checks.
@@ -243,6 +246,8 @@ const (
 	DefaultConnMaxLifetimeMinutes      = 5
 	DefaultMaxImageDownloadSizeBytes   = 50 * 1024 * 1024
 	DefaultRequestTimeoutSeconds       = 30
+	DefaultRateLimitRequests           = 120
+	DefaultRateLimitWindowSeconds      = 60
 	DefaultBloatThreshold              = 10.0
 	DefaultDeadTupleThreshold          = 10000
 	DefaultVacuumStalenessDays         = 7
@@ -267,6 +272,16 @@ func (c *ImageConfig) GetMaxDownloadBytes() int64 {
 // GetRequestTimeout returns the configured HTTP timeout or its default.
 func (c *APIConfig) GetRequestTimeout() time.Duration {
 	return time.Duration(cmp.Or(c.RequestTimeoutSeconds, DefaultRequestTimeoutSeconds)) * time.Second
+}
+
+// GetRateLimitRequests returns the configured request cap or its default.
+func (c *APIConfig) GetRateLimitRequests() int {
+	return cmp.Or(c.RateLimitRequests, DefaultRateLimitRequests)
+}
+
+// GetRateLimitWindow returns the configured rate-limit window or its default.
+func (c *APIConfig) GetRateLimitWindow() time.Duration {
+	return time.Duration(cmp.Or(c.RateLimitWindowSeconds, DefaultRateLimitWindowSeconds)) * time.Second
 }
 
 // GetMaxOpenConns returns the configured open-connection cap or its default.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -191,6 +191,18 @@ func TestAPIConfigValidationRejectsNegativeValues(t *testing.T) {
 				cfg.API.MaxUploadBodyBytes = -1
 			},
 		},
+		{
+			name: "negative rate limit requests",
+			mutate: func(cfg *Config) {
+				cfg.API.RateLimitRequests = -1
+			},
+		},
+		{
+			name: "negative rate limit window",
+			mutate: func(cfg *Config) {
+				cfg.API.RateLimitWindowSeconds = -1
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,25 @@ func TestInterval_ZeroFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestAPIRateLimitDefaults(t *testing.T) {
+	cfg := &APIConfig{}
+	if got := cfg.GetRateLimitRequests(); got != DefaultRateLimitRequests {
+		t.Fatalf("GetRateLimitRequests() = %d, want %d", got, DefaultRateLimitRequests)
+	}
+	if got := cfg.GetRateLimitWindow(); got != time.Duration(DefaultRateLimitWindowSeconds)*time.Second {
+		t.Fatalf("GetRateLimitWindow() = %s, want %ds", got, DefaultRateLimitWindowSeconds)
+	}
+
+	cfg.RateLimitRequests = 10
+	cfg.RateLimitWindowSeconds = 5
+	if got := cfg.GetRateLimitRequests(); got != 10 {
+		t.Fatalf("configured GetRateLimitRequests() = %d, want 10", got)
+	}
+	if got := cfg.GetRateLimitWindow(); got != 5*time.Second {
+		t.Fatalf("configured GetRateLimitWindow() = %s, want 5s", got)
+	}
+}
+
 func TestFileMonitorValidation_DuplicatePaths(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.FileMonitor.Enabled = true


### PR DESCRIPTION
## Fact check
- Confirmed the API middleware stack had request ID/recovery/compression/auth/timeout, but no rate limiter.
- Confirmed invalid API key attempts were only rejected, not throttled.
- Confirmed the requested behavior should be opt-in/backward compatible.

## Fix
- Added optional fixed-window API rate limiting via `api.rate_limit_enabled`.
- Added configurable `rate_limit_requests` and `rate_limit_window_seconds` defaults.
- Applied the limiter to the `/api` router so it covers health, auth probes, and protected endpoints when enabled.
- Keys valid authenticated traffic by hashed API key; missing or invalid keys are keyed by remote address to avoid brute-force bypass with rotating invalid keys.
- Added `Retry-After` on 429 responses and documented config fields.

## Verification
- `go test ./internal/api ./internal/config`
- `go test ./...`

Closes #166