### PR TITLE
feat: add optional api metrics endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -1441,7 +1441,7 @@ Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra 
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de gezondheidsstatus niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope die status niet beïnvloeden.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@
 ## Inhoudsopgave
 
 - [Overzicht](#overzicht)
-- [Snel overzicht endpoints](#snel-overzicht-endpoints)
+- [Snel overzicht van de endpoints](#snel-overzicht-van-de-endpoints)
 - [Authenticatie](#authenticatie)
 - [Response-formaat](#response-formaat)
 - [Foutmeldingen](#foutmeldingen)
@@ -15,18 +15,18 @@
   - [Database onderhoud](#database-onderhoud)
   - [Backup-endpoints](#backup-endpoints)
   - [Bestandscontrole](#bestandscontrole)
-  - [Mediabestandcontrole](#mediabestandcontrole)
+  - [Aanwezigheidscontrole](#aanwezigheidscontrole)
   - [Notificaties](#notificaties)
 - [Codevoorbeelden](#codevoorbeelden)
 - [Configuratie](#configuratie)
 
 ## Overzicht
 
-De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem. De API biedt directe databasetoegang voor afbeeldingenbeheer, mediabrowser, database-onderhoud en backup-management.
+De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem en geeft directe databasetoegang voor afbeeldingenbeheer, het doorzoeken van media, database-onderhoud en backupbeheer.
 
 **Basis-URL:** `http://localhost:8080/api`
 
-## Snel overzicht endpoints
+## Snel overzicht van de endpoints
 
 | Endpoint | Methode | Beschrijving | Auth |
 |----------|---------|--------------|------|
@@ -54,9 +54,9 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 | **Bestandscontrole** |
 | `/api/file-monitor/status` | GET | Status bestandscontrole | Ja |
 | `/api/file-monitor/check` | POST | Handmatige bestandscontrole starten | Ja |
-| **Mediabestandcontrole** |
+| **Aanwezigheidscontrole** |
 | `/api/media/files/check` | POST | Controle op ontbrekende audiobestanden starten | Ja |
-| `/api/media/files/check/status` | GET | Resultaat van de mediabestandcontrole | Ja |
+| `/api/media/files/check/status` | GET | Resultaat van de aanwezigheidscontrole | Ja |
 | **Backups** |
 | `/api/db/backup` | POST | Nieuwe backup aanmaken | Ja |
 | `/api/db/backup/status` | GET | Backup status opvragen | Ja |
@@ -73,7 +73,7 @@ Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoint
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
-Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropy (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
+Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropie (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
 
 **Response bij ontbrekende autorisatie:**
 ```json
@@ -190,7 +190,7 @@ De `status`-waarden hebben een vaste prioriteitsvolgorde: `"unhealthy"` > `"degr
 | `checks_alerting` groter dan `0` | `"degraded"` |
 | Geen van bovenstaande | `"healthy"` |
 
-Een database-uitval overschrijft altijd een eventuele `"degraded"`-signaal van notificaties of de bestandscontrole.
+Een database-uitval overschrijft altijd een eventueel `"degraded"`-signaal van notificaties of de bestandscontrole.
 
 ---
 
@@ -687,7 +687,7 @@ De health check kan automatisch worden uitgevoerd via de ingebouwde scheduler. B
 - `scheduler.enabled`: Schakel automatische health checks in/uit
 - `scheduler.schedule`: Cron-expressie (zie backup-sectie voor voorbeelden)
 
-Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via `TZ` environment variable).
+Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via de `TZ`-omgevingsvariabele).
 
 ---
 
@@ -711,7 +711,7 @@ Backups worden asynchroon uitgevoerd:
 Na het aanmaken van een backup wordt deze automatisch gevalideerd via `pg_restore --list` (controleert TOC en checksums). Alleen gevalideerde backups worden als succesvol gemarkeerd en naar S3 gesynchroniseerd.
 
 Deze aanpak biedt voordelen:
-- Request retourneert direct (geen timeout issues)
+- Request retourneert direct (geen problemen met time-outs)
 - Fouten zijn zichtbaar via het status endpoint
 - Er kan slechts één backup tegelijk draaien
 - Bij connectieverlies loopt backup door op de server
@@ -738,7 +738,7 @@ Backups kunnen automatisch worden uitgevoerd via de ingebouwde scheduler. Config
 - `enabled`: Schakel automatische backups in/uit
 - `schedule`: Cron-expressie voor het backup-schema
 
-De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als environment variable.
+De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als omgevingsvariabele.
 
 **Cron-expressieformaat:** `minuut uur dag maand weekdag`
 
@@ -794,7 +794,7 @@ Backups kunnen automatisch worden gesynchroniseerd naar S3-compatibele storage (
 
 **Gedrag:**
 - Na elke succesvolle backup wordt het bestand asynchroon naar S3 geüpload
-- Bij het verwijderen van lokale backups (handmatig of door retention) wordt ook de S3-kopie verwijderd
+- Bij het verwijderen van lokale backups (handmatig of door retentie) wordt ook de S3-kopie verwijderd
 - S3-fouten blokkeren de backup niet; de status is zichtbaar via `GET /api/db/backup/status`
 - Uploads gebruiken multipart voor grote bestanden
 
@@ -1202,8 +1202,8 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 - `path`: Bestandspad op schijf.
 - `max_age_minutes`: Maximaal toegestane leeftijd.
 - `file_exists`: Of het bestand bestaat (`true`, `false`, of `null` bij fouten).
-- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
-- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
+- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
+- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
 - `is_stale`: Of het bestand te oud is of niet bereikbaar is.
 - `in_alert`: Of voor dit bestand momenteel een alert actief is. Buiten de geconfigureerde `active_window` is dit altijd `false`, ook als `is_stale` `true` is.
 - `error`: Leesbare foutmelding bij toegangsproblemen (ontbreekt bij normaal gebruik).
@@ -1214,7 +1214,7 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 
 ### Handmatig een bestandscontrole starten
 
-Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande tick.
+Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande controle.
 
 **Endpoint:** `POST /api/file-monitor/check`
 **Authenticatie:** Vereist
@@ -1252,9 +1252,9 @@ De handmatige trigger en de cronjob gebruiken dezelfde single-flight gate. Daard
 
 Strikte gelijkheid (`completed_run_id == myRunID`) bevestigt dat de zichtbare `checks` exact door jouw run zijn geproduceerd. Een hogere waarde betekent dat een latere run, bijvoorbeeld via cron, jouw run heeft ingehaald. Dat is prima voor de vraag "is het systeem nu gezond?", maar verliest de exacte correlatie. Gebruik voor nauwkeurige troubleshooting daarom de strikte vergelijking en houd rekening met een mogelijke race.
 
-### Integratie met de health-endpoint (bestandscontrole)
+### Integratie met het health-endpoint (bestandscontrole)
 
-Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
+Als de bestandscontrole is ingeschakeld, geeft het health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
 
 ```json
 {
@@ -1276,9 +1276,9 @@ Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/hea
 
 ---
 
-## Mediabestandcontrole
+## Aanwezigheidscontrole
 
-Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, is de mediabestandcontrole **database-gestuurd**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks vóórdat ze in de uitzending vallen.
+Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, werkt de aanwezigheidscontrole **op basis van de database**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks voordat ze worden uitgezonden.
 
 De controle draait asynchroon: een `POST` start een run op de achtergrond en geeft direct een `run_id` terug; het resultaat lees je op met `GET .../status`.
 
@@ -1300,7 +1300,7 @@ Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de 
 - `no_reference` — het playlistitem heeft geen bruikbare referentie (bijv. de track bestaat niet meer in de database).
 - `stat_error` — het bestand kon niet gecontroleerd worden (time-out, geen rechten, mount onbereikbaar).
 
-### Mediabestandcontrole starten
+### Aanwezigheidscontrole starten
 
 Start een controle op de achtergrond voor de opgegeven scope.
 
@@ -1346,7 +1346,7 @@ Start een controle op de achtergrond voor de opgegeven scope.
 
 De handmatige trigger en de geplande cronrun delen dezelfde single-flight gate; ze kunnen elkaar dus niet overlappen.
 
-### Resultaat van de mediabestandcontrole
+### Resultaat van de aanwezigheidscontrole
 
 Toont de runstatus plus het resultaat van de meest recente run.
 
@@ -1416,17 +1416,17 @@ Toont de runstatus plus het resultaat van de meest recente run.
 - `checked_paths`: De concrete paden en zoekacties die zijn geprobeerd.
 - `matches`: De gevonden bestanden op schijf (één bij `present`, meerdere bij `ambiguous`).
 - `match_type`: Hoe gematcht is: `exact_path`, `filename` of `filename_noext` (ontbreekt bij geen match).
-- `error`: Foutmelding bij `stat_error` (ontbreekt verder).
+- `error`: Foutmelding bij `stat_error` (ontbreekt in andere gevallen).
 
 **Pollingrecept:** lees `run_id` uit de `POST`-response (`myRunID`), poll daarna `GET .../status` tot `completed_run_id >= myRunID && running == false`.
 
 ### Geplande controle en e-mailnotificaties
 
-Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` checkt de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
+Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` controleert de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
 
-### Integratie met de health-endpoint (mediabestandcontrole)
+### Integratie met het health-endpoint (aanwezigheidscontrole)
 
-Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
+Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
 
 ```json
 {
@@ -1441,7 +1441,7 @@ Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de gezondheidsstatus niet beïnvloeden.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -9,6 +9,7 @@
 - [Foutmeldingen](#foutmeldingen)
 - [Endpoints](#endpoints)
   - [Statuscontrole](#statuscontrole)
+  - [Metrics](#metrics)
   - [Artiestendpoints](#artiestendpoints)
   - [Trackendpoints](#trackendpoints)
   - [Playlist-endpoints](#playlist-endpoints)
@@ -32,6 +33,7 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 |----------|---------|--------------|------|
 | **Algemeen** |
 | `/api/health` | GET | API-status controleren | Nee |
+| `/metrics` | GET | Prometheus-compatible metrics ophalen wanneer ingeschakeld | Nee |
 | **Artiesten** |
 | `/api/artists` | GET | Statistieken over artiesten | Ja |
 | `/api/artists/{id}` | GET | Specifieke artiest ophalen | Ja |
@@ -69,7 +71,7 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 
 ## Authenticatie
 
-Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `GET /api/health`) een API-sleutel.
+Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoints (behalve `GET /api/health` en de optionele metrics-endpoint) een API-sleutel.
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
@@ -189,6 +191,61 @@ De `status`-waarden hebben een vaste prioriteitsvolgorde: `"unhealthy"` > `"degr
 | Geen van bovenstaande | `"healthy"` |
 
 Een database-uitval overschrijft altijd een eventuele `"degraded"`-signaal van notificaties of de bestandscontrole.
+
+---
+
+### Metrics
+
+Haal Prometheus-compatible metrics op. Deze endpoint staat standaard uit en is
+alleen beschikbaar wanneer `metrics.enabled: true` is geconfigureerd. De
+metrics-route staat buiten de `/api` prefix en gebruikt geen JSON-wrapper.
+
+**Endpoint:** `GET /metrics` (of de waarde van `metrics.path`)
+**Authenticatie:** Niet vereist
+
+**Response:** `200 OK`
+```text
+# HELP aeron_toolbox_up Whether the Aeron Toolbox process is running.
+# TYPE aeron_toolbox_up gauge
+aeron_toolbox_up 1
+# HELP aeron_toolbox_health_status Current health status as one sample per status label.
+# TYPE aeron_toolbox_health_status gauge
+aeron_toolbox_health_status{status="healthy"} 1
+aeron_toolbox_health_status{status="degraded"} 0
+aeron_toolbox_health_status{status="unhealthy"} 0
+# HELP aeron_toolbox_database_connected Whether the configured database answered the last metrics health probe.
+# TYPE aeron_toolbox_database_connected gauge
+aeron_toolbox_database_connected 1
+```
+
+De output bevat onder andere:
+- HTTP request counters en latency-histograms met `method`, chi-routepatroon en HTTP-status als labels.
+- Database-connectiviteit en dezelfde algemene health-status als `GET /api/health`.
+- Backup job-status, laatste succesvolle backup en laatste backupduur.
+- Bestandscontrole en mediabestandcontrole: running/completed-status en probleem- of alerttellingen.
+- Notificatieconfiguratie en of er sinds processtart een verzendfout is geregistreerd.
+
+De metrics bevatten geen API-sleutels, databasewachtwoorden, bestandsnamen,
+database-namen of ruwe foutmeldingen. Gebruik de endpoint alleen vanaf een
+vertrouwd monitoring-netwerk of plaats hem achter je reverse-proxy access
+controls.
+
+Voorbeeld Prometheus scrape-configuratie:
+
+```yaml
+scrape_configs:
+  - job_name: "aeron-toolbox"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+Voorbeeld alerts:
+- `aeron_toolbox_database_connected == 0`
+- `aeron_toolbox_backup_enabled == 1 and aeron_toolbox_backup_last_completed == 1 and aeron_toolbox_backup_last_success == 0`
+- `aeron_toolbox_file_monitor_checks_alerting > 0`
+- `aeron_toolbox_media_file_check_problems > 0`
+- `rate(aeron_toolbox_http_requests_total{status=~"5.."}[5m]) > 0`
 
 ---
 
@@ -1735,12 +1792,20 @@ Het gedrag van de API kan worden geconfigureerd via `config.json`:
       "recipients": ""
     }
   },
+  "metrics": {
+    "enabled": false,
+    "path": "/metrics"
+  },
   "log": {
     "level": "info",
     "format": "text"
   }
 }
 ```
+
+**Instellingen voor metrics:**
+- `metrics.enabled`: Schakel de Prometheus-compatible metrics-endpoint in of uit. Standaard `false`.
+- `metrics.path`: Scrape-pad. Standaard `/metrics`; een ontbrekende eerste slash wordt automatisch toegevoegd.
 
 **Instellingen voor bestandscontrole:**
 - `file_monitor.enabled`: Schakel de bestandscontrole in.

--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@
 ## Inhoudsopgave
 
 - [Overzicht](#overzicht)
-- [Snel overzicht endpoints](#snel-overzicht-endpoints)
+- [Snel overzicht van de endpoints](#snel-overzicht-van-de-endpoints)
 - [Authenticatie](#authenticatie)
 - [Response-formaat](#response-formaat)
 - [Foutmeldingen](#foutmeldingen)
@@ -15,18 +15,18 @@
   - [Database onderhoud](#database-onderhoud)
   - [Backup-endpoints](#backup-endpoints)
   - [Bestandscontrole](#bestandscontrole)
-  - [Mediabestandcontrole](#mediabestandcontrole)
+  - [Aanwezigheidscontrole](#aanwezigheidscontrole)
   - [Notificaties](#notificaties)
 - [Codevoorbeelden](#codevoorbeelden)
 - [Configuratie](#configuratie)
 
 ## Overzicht
 
-De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem. De API biedt directe databasetoegang voor afbeeldingenbeheer, mediabrowser, database-onderhoud en backup-management.
+De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiseringssysteem en geeft directe databasetoegang voor afbeeldingenbeheer, het doorzoeken van media, database-onderhoud en backupbeheer.
 
 **Basis-URL:** `http://localhost:8080/api`
 
-## Snel overzicht endpoints
+## Snel overzicht van de endpoints
 
 | Endpoint | Methode | Beschrijving | Auth |
 |----------|---------|--------------|------|
@@ -54,9 +54,9 @@ De Aeron Toolbox API biedt RESTful-endpoints voor het Aeron-radioautomatiserings
 | **Bestandscontrole** |
 | `/api/file-monitor/status` | GET | Status bestandscontrole | Ja |
 | `/api/file-monitor/check` | POST | Handmatige bestandscontrole starten | Ja |
-| **Mediabestandcontrole** |
+| **Aanwezigheidscontrole** |
 | `/api/media/files/check` | POST | Controle op ontbrekende audiobestanden starten | Ja |
-| `/api/media/files/check/status` | GET | Resultaat van de mediabestandcontrole | Ja |
+| `/api/media/files/check/status` | GET | Resultaat van de aanwezigheidscontrole | Ja |
 | **Backups** |
 | `/api/db/backup` | POST | Nieuwe backup aanmaken | Ja |
 | `/api/db/backup/status` | GET | Backup status opvragen | Ja |
@@ -73,7 +73,7 @@ Wanneer authenticatie is ingeschakeld in de configuratie, vereisen alle endpoint
 
 **Header:** `X-API-Key: jouw-api-sleutel`
 
-Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropy (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
+Gebruik per omgeving unieke, willekeurig gegenereerde API-sleutels van minimaal 32 bytes entropie (bijvoorbeeld `openssl rand -base64 32`). Hergebruik geen wachtwoorden, woordenboekwoorden of korte gedeelde secrets.
 
 **Response bij ontbrekende autorisatie:**
 ```json
@@ -190,7 +190,7 @@ De `status`-waarden hebben een vaste prioriteitsvolgorde: `"unhealthy"` > `"degr
 | `checks_alerting` groter dan `0` | `"degraded"` |
 | Geen van bovenstaande | `"healthy"` |
 
-Een database-uitval overschrijft altijd een eventuele `"degraded"`-signaal van notificaties of de bestandscontrole.
+Een database-uitval overschrijft altijd een eventueel `"degraded"`-signaal van notificaties of de bestandscontrole.
 
 ---
 
@@ -687,7 +687,7 @@ De health check kan automatisch worden uitgevoerd via de ingebouwde scheduler. B
 - `scheduler.enabled`: Schakel automatische health checks in/uit
 - `scheduler.schedule`: Cron-expressie (zie backup-sectie voor voorbeelden)
 
-Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via `TZ` environment variable).
+Bij detectie van problemen (hoge bloat, veel connecties, langlopende queries) wordt een e-mailmelding verstuurd. Wanneer alle problemen zijn opgelost, volgt een herstelmelding. De tijdzone wordt bepaald door de systeemtijdzone (instelbaar via de `TZ`-omgevingsvariabele).
 
 ---
 
@@ -711,7 +711,7 @@ Backups worden asynchroon uitgevoerd:
 Na het aanmaken van een backup wordt deze automatisch gevalideerd via `pg_restore --list` (controleert TOC en checksums). Alleen gevalideerde backups worden als succesvol gemarkeerd en naar S3 gesynchroniseerd.
 
 Deze aanpak biedt voordelen:
-- Request retourneert direct (geen timeout issues)
+- Request retourneert direct (geen problemen met time-outs)
 - Fouten zijn zichtbaar via het status endpoint
 - Er kan slechts één backup tegelijk draaien
 - Bij connectieverlies loopt backup door op de server
@@ -738,7 +738,7 @@ Backups kunnen automatisch worden uitgevoerd via de ingebouwde scheduler. Config
 - `enabled`: Schakel automatische backups in/uit
 - `schedule`: Cron-expressie voor het backup-schema
 
-De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als environment variable.
+De tijdzone voor alle geplande taken (backup én onderhoud) wordt bepaald door de systeemtijdzone. In Docker: stel `TZ=Europe/Amsterdam` in als omgevingsvariabele.
 
 **Cron-expressieformaat:** `minuut uur dag maand weekdag`
 
@@ -794,7 +794,7 @@ Backups kunnen automatisch worden gesynchroniseerd naar S3-compatibele storage (
 
 **Gedrag:**
 - Na elke succesvolle backup wordt het bestand asynchroon naar S3 geüpload
-- Bij het verwijderen van lokale backups (handmatig of door retention) wordt ook de S3-kopie verwijderd
+- Bij het verwijderen van lokale backups (handmatig of door retentie) wordt ook de S3-kopie verwijderd
 - S3-fouten blokkeren de backup niet; de status is zichtbaar via `GET /api/db/backup/status`
 - Uploads gebruiken multipart voor grote bestanden
 
@@ -1202,8 +1202,8 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 - `path`: Bestandspad op schijf.
 - `max_age_minutes`: Maximaal toegestane leeftijd.
 - `file_exists`: Of het bestand bestaat (`true`, `false`, of `null` bij fouten).
-- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
-- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand ontbreekt of niet bereikbaar is).
+- `file_age_minutes`: Leeftijd in minuten (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
+- `last_modified`: Laatste wijzigingstijd (ontbreekt als het bestand niet bestaat of niet bereikbaar is).
 - `is_stale`: Of het bestand te oud is of niet bereikbaar is.
 - `in_alert`: Of voor dit bestand momenteel een alert actief is. Buiten de geconfigureerde `active_window` is dit altijd `false`, ook als `is_stale` `true` is.
 - `error`: Leesbare foutmelding bij toegangsproblemen (ontbreekt bij normaal gebruik).
@@ -1214,7 +1214,7 @@ De volgende voorbeelden tonen losse items uit de `checks`-array voor specifieke 
 
 ### Handmatig een bestandscontrole starten
 
-Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande tick.
+Start een bestandscontrole op de achtergrond. Handig tijdens configuratie of storingsonderzoek, zodat operators niet hoeven te wachten op de volgende geplande controle.
 
 **Endpoint:** `POST /api/file-monitor/check`
 **Authenticatie:** Vereist
@@ -1252,9 +1252,9 @@ De handmatige trigger en de cronjob gebruiken dezelfde single-flight gate. Daard
 
 Strikte gelijkheid (`completed_run_id == myRunID`) bevestigt dat de zichtbare `checks` exact door jouw run zijn geproduceerd. Een hogere waarde betekent dat een latere run, bijvoorbeeld via cron, jouw run heeft ingehaald. Dat is prima voor de vraag "is het systeem nu gezond?", maar verliest de exacte correlatie. Gebruik voor nauwkeurige troubleshooting daarom de strikte vergelijking en houd rekening met een mogelijke race.
 
-### Integratie met de health-endpoint (bestandscontrole)
+### Integratie met het health-endpoint (bestandscontrole)
 
-Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
+Als de bestandscontrole is ingeschakeld, geeft het health-endpoint (`GET /api/health`) een extra `file_monitor`-blok terug:
 
 ```json
 {
@@ -1276,9 +1276,9 @@ Als de bestandscontrole is ingeschakeld, geeft de health-endpoint (`GET /api/hea
 
 ---
 
-## Mediabestandcontrole
+## Aanwezigheidscontrole
 
-Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, is de mediabestandcontrole **database-gestuurd**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks vóórdat ze in de uitzending vallen.
+Waar de [bestandscontrole](#bestandscontrole) een vaste lijst configuratiebestanden bewaakt, werkt de aanwezigheidscontrole **op basis van de database**: hij leest de playlist uit de Aeron-database en controleert of de bijbehorende audiobestanden daadwerkelijk op schijf staan. Zo signaleer je ontbrekende of verplaatste tracks voordat ze worden uitgezonden.
 
 De controle draait asynchroon: een `POST` start een run op de achtergrond en geeft direct een `run_id` terug; het resultaat lees je op met `GET .../status`.
 
@@ -1300,7 +1300,7 @@ Matchen gebeurt standaard hoofdletter-ongevoelig (`case_insensitive`), omdat de 
 - `no_reference` — het playlistitem heeft geen bruikbare referentie (bijv. de track bestaat niet meer in de database).
 - `stat_error` — het bestand kon niet gecontroleerd worden (time-out, geen rechten, mount onbereikbaar).
 
-### Mediabestandcontrole starten
+### Aanwezigheidscontrole starten
 
 Start een controle op de achtergrond voor de opgegeven scope.
 
@@ -1346,7 +1346,7 @@ Start een controle op de achtergrond voor de opgegeven scope.
 
 De handmatige trigger en de geplande cronrun delen dezelfde single-flight gate; ze kunnen elkaar dus niet overlappen.
 
-### Resultaat van de mediabestandcontrole
+### Resultaat van de aanwezigheidscontrole
 
 Toont de runstatus plus het resultaat van de meest recente run.
 
@@ -1416,17 +1416,17 @@ Toont de runstatus plus het resultaat van de meest recente run.
 - `checked_paths`: De concrete paden en zoekacties die zijn geprobeerd.
 - `matches`: De gevonden bestanden op schijf (één bij `present`, meerdere bij `ambiguous`).
 - `match_type`: Hoe gematcht is: `exact_path`, `filename` of `filename_noext` (ontbreekt bij geen match).
-- `error`: Foutmelding bij `stat_error` (ontbreekt verder).
+- `error`: Foutmelding bij `stat_error` (ontbreekt in andere gevallen).
 
 **Pollingrecept:** lees `run_id` uit de `POST`-response (`myRunID`), poll daarna `GET .../status` tot `completed_run_id >= myRunID && running == false`.
 
 ### Geplande controle en e-mailnotificaties
 
-Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` checkt de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
+Met `media_file_check.scheduler` draait de controle automatisch op een cron-schema. De geplande run controleert standaard **vandaag**; met `media_file_check.lookahead_days` kun je vooruitkijken — bij `lookahead_days: 2` controleert de run vandaag t/m overmorgen (inclusief), zodat ontbrekende bestanden opvallen vóórdat ze worden uitgezonden. `0` (standaard) is alleen vandaag. Handmatige API-runs gebruiken hun eigen `from`/`to`-bereik en negeren deze instelling. Als e-mailnotificaties zijn geconfigureerd, stuurt een geplande run een alert wanneer er problemen (`missing`, `ambiguous` of `stat_error`) worden gevonden, en een herstelmelding zodra een volgende run weer schoon is. Handmatige API-runs versturen geen e-mail, zodat ad-hoc scopes de alert-status niet verstoren.
 
-### Integratie met de health-endpoint (mediabestandcontrole)
+### Integratie met het health-endpoint (aanwezigheidscontrole)
 
-Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
+Als de aanwezigheidscontrole is ingeschakeld, geeft `GET /api/health` een extra `media_file_check`-blok terug:
 
 ```json
 {
@@ -1441,7 +1441,7 @@ Als de mediabestandcontrole is ingeschakeld, geeft `GET /api/health` een extra `
 }
 ```
 
-- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope de health niet beïnvloeden.
+- `problems`: aantal `missing`-, `ambiguous`- en `stat_error`-items in de meest recente **geplande** run. Dit telt alleen mee voor de algemene status `"degraded"` wanneer de geplande controle (`scheduler.enabled`) aanstaat, zodat ad-hoc API-runs met een afwijkende scope die status niet beïnvloeden.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
 | `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
+| `metrics` | Optionele Prometheus-compatible metrics-endpoint |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
 
 ### Backupfunctionaliteit
@@ -130,11 +131,44 @@ De applicatie stuurt:
 
 Test de configuratie via `POST /api/notifications/test-email`.
 
+### Metrics
+
+Prometheus-compatible metrics staan standaard uit. Zet ze expliciet aan wanneer
+de endpoint bereikbaar mag zijn voor je monitoring-netwerk:
+
+```json
+"metrics": {
+  "enabled": true,
+  "path": "/metrics"
+}
+```
+
+Voorbeeld scrape-configuratie:
+
+```yaml
+scrape_configs:
+  - job_name: "aeron-toolbox"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+De endpoint bevat geen secrets, bestandsnamen of ruwe foutmeldingen. Bruikbare
+alerts zijn bijvoorbeeld:
+- `aeron_toolbox_database_connected == 0`
+- `aeron_toolbox_backup_enabled == 1 and aeron_toolbox_backup_last_completed == 1 and aeron_toolbox_backup_last_success == 0`
+- `aeron_toolbox_file_monitor_checks_alerting > 0`
+- `aeron_toolbox_media_file_check_problems > 0`
+- `aeron_toolbox_notifications_last_error == 1`
+
 ## Voorbeelden
 
 ```bash
 # Health check
 curl http://localhost:8080/api/health
+
+# Metrics ophalen wanneer metrics.enabled=true
+curl http://localhost:8080/metrics
 
 # Artiestafbeelding uploaden (via URL)
 curl -X POST http://localhost:8080/api/artists/{id}/image \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 
 - **Afbeeldingen:** upload en optimaliseer albumhoezen en artiestfoto's
 - **Media:** doorzoek artiesten, tracks en playlists met metadata
-- **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
+- **Onderhoud:** bewaak de conditie van de database en ontvang automatisch een melding bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
 - **Mediabestanden:** controleer op basis van de database of de audio uit de playlist daadwerkelijk op schijf staat

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 
 - **Afbeeldingen:** upload en optimaliseer albumhoezen en artiestfoto's
 - **Media:** doorzoek artiesten, tracks en playlists met metadata
-- **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
+- **Onderhoud:** bewaak de conditie van de database en ontvang automatisch een melding bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
-- **Mediabestanden:** controleer database-gestuurd of de audio uit de playlist daadwerkelijk op schijf staat
+- **Mediabestanden:** controleer op basis van de database of de audio uit de playlist daadwerkelijk op schijf staat
 
 ## Snel starten
 
@@ -23,7 +23,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/config.example.json -O config.json
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-compose.example.yml -O docker-compose.yml
 
-# Pas config.json aan naar jouw situatie, dan:
+# Stem config.json af op jouw situatie, dan:
 docker compose up -d
 ```
 
@@ -40,7 +40,7 @@ docker run -d -p 8080:8080 \
 ```
 
 > [!NOTE]
-> De `TZ` omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
+> De `TZ`-omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
 
 ### Binary
 
@@ -70,11 +70,11 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `maintenance` | Drempelwaarden en automatische scheduler voor database health checks |
 | `backup` | Pad naar backups, retentie, scheduler en optionele S3-sync |
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
-| `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
+| `media_file_check` | Controleert op basis van de database of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
 
-Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropy, bijvoorbeeld via `openssl rand -base64 32`.
+Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropie, bijvoorbeeld via `openssl rand -base64 32`.
 
 ### Backupfunctionaliteit
 
@@ -112,7 +112,7 @@ Dit controleert elke zondag om 04:00 de database en stuurt een melding bij probl
 
 ### E-mailnotificaties
 
-Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send` permissie.
+Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send`-machtiging.
 
 ```json
 "notifications": {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 - **Onderhoud:** bewaak de gezondheid van de database met automatische meldingen bij problemen
 - **Backups:** maak, valideer en download databasebackups (optioneel naar S3)
 - **Bestandscontrole:** controleer of bestanden actueel zijn, met meldingen bij verouderde of ontbrekende bestanden
-- **Mediabestanden:** controleer database-gestuurd of de audio uit de playlist daadwerkelijk op schijf staat
+- **Mediabestanden:** controleer op basis van de database of de audio uit de playlist daadwerkelijk op schijf staat
 
 ## Snel starten
 
@@ -23,7 +23,7 @@ Het radioautomatiseringssysteem Aeron mist tooling voor beheer en onderhoud. Aer
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/config.example.json -O config.json
 wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-compose.example.yml -O docker-compose.yml
 
-# Pas config.json aan naar jouw situatie, dan:
+# Stem config.json af op jouw situatie, dan:
 docker compose up -d
 ```
 
@@ -40,7 +40,7 @@ docker run -d -p 8080:8080 \
 ```
 
 > [!NOTE]
-> De `TZ` omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
+> De `TZ`-omgevingsvariabele bepaalt de tijdzone voor geplande taken (backups en health checks).
 
 ### Binary
 
@@ -70,11 +70,11 @@ Kopieer [`config.example.json`](config.example.json) naar `config.json`. De bela
 | `maintenance` | Drempelwaarden en automatische scheduler voor database health checks |
 | `backup` | Pad naar backups, retentie, scheduler en optionele S3-sync |
 | `file_monitor` | Signaleert verouderde of ontbrekende bestanden op schijf |
-| `media_file_check` | Controleert database-gestuurd of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
+| `media_file_check` | Controleert op basis van de database of playlist-audio op schijf staat (exacte `drive_mounts` + `search_dirs` als fallback) |
 | `notifications` | E-mailmeldingen via Microsoft Graph API |
 | `log` | Logniveau (`debug`, `info`, `warn`, `error`) en formaat (`text`, `json`) |
 
-Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropy, bijvoorbeeld via `openssl rand -base64 32`.
+Gebruik voor `api.keys` per omgeving unieke, willekeurig gegenereerde API-sleutels met minimaal 32 bytes entropie, bijvoorbeeld via `openssl rand -base64 32`.
 
 ### Backupfunctionaliteit
 
@@ -112,7 +112,7 @@ Dit controleert elke zondag om 04:00 de database en stuurt een melding bij probl
 
 ### E-mailnotificaties
 
-Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send` permissie.
+Ontvang e-mailmeldingen bij mislukte backups, S3-synchronisatie, database health checks en verouderde of ontbrekende bestanden. Vereist een Azure AD app-registratie met `Mail.Send`-machtiging.
 
 ```json
 "notifications": {

--- a/config.example.json
+++ b/config.example.json
@@ -109,6 +109,10 @@
       "recipients": ""
     }
   },
+  "metrics": {
+    "enabled": false,
+    "path": "/metrics"
+  },
   "log": {
     "level": "info",
     "format": "text"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -106,9 +107,13 @@ func (s *Server) validateAndGetEntityID(w http.ResponseWriter, r *http.Request, 
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, s.collectHealth(r.Context()))
+}
+
+func (s *Server) collectHealth(ctx context.Context) HealthResponse {
 	dbStatus := "connected"
 	dbConnected := true
-	if err := s.service.Repository().Ping(r.Context()); err != nil {
+	if err := s.service.Repository().Ping(ctx); err != nil {
 		dbStatus = "disconnected"
 		dbConnected = false
 		slog.Warn("Database health check failed", "error", err)
@@ -160,7 +165,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp.Status = overallHealthStatus(dbConnected, notifyExpiresSoon || fmAlerting > 0 || mediaProblems > 0)
-	respondJSON(w, http.StatusOK, resp)
+	return resp
 }
 
 // overallHealthStatus returns the highest-severity status given the database

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,479 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+var httpDurationBuckets = []float64{
+	0.005,
+	0.01,
+	0.025,
+	0.05,
+	0.1,
+	0.25,
+	0.5,
+	1,
+	2.5,
+	5,
+	10,
+}
+
+type httpMetricKey struct {
+	Method string
+	Route  string
+	Status string
+}
+
+type httpMetricSeries struct {
+	Count   uint64
+	Sum     float64
+	Buckets []uint64
+}
+
+type httpMetricSample struct {
+	Key     httpMetricKey
+	Count   uint64
+	Sum     float64
+	Buckets []uint64
+}
+
+type httpMetrics struct {
+	mu     sync.Mutex
+	series map[httpMetricKey]*httpMetricSeries
+}
+
+func newHTTPMetrics() *httpMetrics {
+	return &httpMetrics{
+		series: map[httpMetricKey]*httpMetricSeries{},
+	}
+}
+
+func (m *httpMetrics) middleware(next http.Handler) http.Handler {
+	if m == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &metricsResponseWriter{
+			ResponseWriter: w,
+			status:         http.StatusOK,
+		}
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				m.record(r, http.StatusInternalServerError, time.Since(start))
+				panic(recovered)
+			}
+			m.record(r, rw.status, time.Since(start))
+		}()
+
+		next.ServeHTTP(rw, r)
+	})
+}
+
+func (m *httpMetrics) record(r *http.Request, status int, duration time.Duration) {
+	route := chi.RouteContext(r.Context()).RoutePattern()
+	if route == "" {
+		route = "unmatched"
+	}
+
+	key := httpMetricKey{
+		Method: r.Method,
+		Route:  route,
+		Status: strconv.Itoa(status),
+	}
+
+	seconds := duration.Seconds()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	series := m.series[key]
+	if series == nil {
+		series = &httpMetricSeries{
+			Buckets: make([]uint64, len(httpDurationBuckets)),
+		}
+		m.series[key] = series
+	}
+
+	series.Count++
+	series.Sum += seconds
+	for i, bucket := range httpDurationBuckets {
+		if seconds <= bucket {
+			series.Buckets[i]++
+		}
+	}
+}
+
+func (m *httpMetrics) snapshot() []httpMetricSample {
+	if m == nil {
+		return []httpMetricSample{}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	samples := make([]httpMetricSample, 0, len(m.series))
+	for key, series := range m.series {
+		samples = append(samples, httpMetricSample{
+			Key:     key,
+			Count:   series.Count,
+			Sum:     series.Sum,
+			Buckets: slices.Clone(series.Buckets),
+		})
+	}
+
+	sort.Slice(samples, func(i, j int) bool {
+		if samples[i].Key.Route != samples[j].Key.Route {
+			return samples[i].Key.Route < samples[j].Key.Route
+		}
+		if samples[i].Key.Method != samples[j].Key.Method {
+			return samples[i].Key.Method < samples[j].Key.Method
+		}
+		return samples[i].Key.Status < samples[j].Key.Status
+	})
+
+	return samples
+}
+
+type metricsResponseWriter struct {
+	http.ResponseWriter
+	status int
+	wrote  bool
+}
+
+func (w *metricsResponseWriter) WriteHeader(status int) {
+	if w.wrote {
+		return
+	}
+	w.status = status
+	w.wrote = true
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *metricsResponseWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *metricsResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+type metricsSnapshot struct {
+	HealthStatus        string
+	DatabaseConnected   bool
+	BackupEnabled       bool
+	BackupRunning       bool
+	BackupCompleted     bool
+	BackupLastSuccess   bool
+	BackupLastDuration  float64
+	FileMonitorEnabled  bool
+	FileMonitorRunning  bool
+	FileMonitorDone     bool
+	FileMonitorAlerting int
+	MediaCheckEnabled   bool
+	MediaCheckRunning   bool
+	MediaCheckDone      bool
+	MediaCheckSuccess   bool
+	MediaCheckProblems  int
+	NotifyConfigured    bool
+	NotifyLastError     bool
+	HTTPSamples         []httpMetricSample
+}
+
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = w.Write([]byte(formatPrometheusMetrics(s.collectMetrics(r.Context()))))
+}
+
+func (s *Server) collectMetrics(ctx context.Context) metricsSnapshot {
+	health := s.collectHealth(ctx)
+	cfg := s.service.Config()
+	snapshot := metricsSnapshot{
+		HealthStatus:      health.Status,
+		DatabaseConnected: health.DatabaseStatus == "connected",
+		NotifyConfigured:  health.Notifications != nil && health.Notifications.Configured,
+		NotifyLastError:   health.Notifications != nil && health.Notifications.LastError != "",
+		HTTPSamples:       s.httpMetrics.snapshot(),
+	}
+
+	if cfg.Backup.Enabled {
+		status := s.service.Backup.Status()
+		snapshot.BackupEnabled = true
+		snapshot.BackupRunning = status.Running
+		snapshot.BackupCompleted = status.EndedAt != nil
+		snapshot.BackupLastSuccess = status.EndedAt != nil && status.Success
+		if status.StartedAt != nil && status.EndedAt != nil {
+			snapshot.BackupLastDuration = status.EndedAt.Sub(*status.StartedAt).Seconds()
+		}
+	}
+
+	if cfg.FileMonitor.Enabled {
+		status := s.service.FileMonitor.Status()
+		snapshot.FileMonitorEnabled = true
+		snapshot.FileMonitorRunning = status.Running
+		snapshot.FileMonitorDone = status.CompletedRunID > 0
+		if health.FileMonitor != nil {
+			snapshot.FileMonitorAlerting = health.FileMonitor.ChecksAlerting
+		}
+	}
+
+	if cfg.MediaFileCheck.Enabled {
+		status := s.service.MediaFileCheck.Status()
+		snapshot.MediaCheckEnabled = true
+		snapshot.MediaCheckRunning = status.Running
+		snapshot.MediaCheckDone = status.CompletedRunID > 0
+		snapshot.MediaCheckSuccess = status.CompletedRunID > 0 && status.Result != nil && status.Result.Error == ""
+		if health.MediaFileCheck != nil {
+			snapshot.MediaCheckProblems = health.MediaFileCheck.Problems
+		}
+	}
+
+	return snapshot
+}
+
+func formatPrometheusMetrics(snapshot metricsSnapshot) string {
+	var b strings.Builder
+
+	writeGauge(&b, "aeron_toolbox_up", "Whether the Aeron Toolbox process is running.", 1)
+	writeHealthStatus(&b, snapshot.HealthStatus)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_database_connected",
+		"Whether the configured database answered the last metrics health probe.",
+		snapshot.DatabaseConnected,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_backup_enabled",
+		"Whether backup support is enabled.",
+		snapshot.BackupEnabled,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_backup_running",
+		"Whether a backup job is currently running.",
+		snapshot.BackupRunning,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_backup_last_completed",
+		"Whether at least one backup job has completed since process start.",
+		snapshot.BackupCompleted,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_backup_last_success",
+		"Whether the last completed backup job succeeded.",
+		snapshot.BackupLastSuccess,
+	)
+	writeGauge(
+		&b,
+		"aeron_toolbox_backup_last_duration_seconds",
+		"Duration of the last completed backup job in seconds.",
+		nonNegative(snapshot.BackupLastDuration),
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_file_monitor_enabled",
+		"Whether file monitoring is enabled.",
+		snapshot.FileMonitorEnabled,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_file_monitor_running",
+		"Whether a file-monitor job is currently running.",
+		snapshot.FileMonitorRunning,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_file_monitor_last_completed",
+		"Whether at least one file-monitor job has completed since process start.",
+		snapshot.FileMonitorDone,
+	)
+	writeGauge(
+		&b,
+		"aeron_toolbox_file_monitor_checks_alerting",
+		"Number of monitored files currently alerting in their active window.",
+		float64(snapshot.FileMonitorAlerting),
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_media_file_check_enabled",
+		"Whether media-file checking is enabled.",
+		snapshot.MediaCheckEnabled,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_media_file_check_running",
+		"Whether a media-file check job is currently running.",
+		snapshot.MediaCheckRunning,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_media_file_check_last_completed",
+		"Whether at least one media-file check has completed since process start.",
+		snapshot.MediaCheckDone,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_media_file_check_last_success",
+		"Whether the last completed media-file check succeeded.",
+		snapshot.MediaCheckSuccess,
+	)
+	writeGauge(
+		&b,
+		"aeron_toolbox_media_file_check_problems",
+		"Number of missing, ambiguous, or errored files in the latest scheduled media-file check.",
+		float64(snapshot.MediaCheckProblems),
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_notifications_configured",
+		"Whether email notifications are configured.",
+		snapshot.NotifyConfigured,
+	)
+	writeGaugeBool(
+		&b,
+		"aeron_toolbox_notifications_last_error",
+		"Whether the notification service has recorded a send error since process start.",
+		snapshot.NotifyLastError,
+	)
+	writeHTTPMetrics(&b, snapshot.HTTPSamples)
+
+	return b.String()
+}
+
+func writeGaugeBool(b *strings.Builder, name, help string, value bool) {
+	if value {
+		writeGauge(b, name, help, 1)
+		return
+	}
+	writeGauge(b, name, help, 0)
+}
+
+func writeGauge(b *strings.Builder, name, help string, value float64) {
+	fmt.Fprintf(b, "# HELP %s %s\n", name, help)
+	fmt.Fprintf(b, "# TYPE %s gauge\n", name)
+	fmt.Fprintf(b, "%s %s\n", name, prometheusFloat(value))
+}
+
+func writeHealthStatus(b *strings.Builder, active string) {
+	const name = "aeron_toolbox_health_status"
+	fmt.Fprintf(b, "# HELP %s Current health status as one sample per status label.\n", name)
+	fmt.Fprintf(b, "# TYPE %s gauge\n", name)
+	for _, status := range []string{"healthy", "degraded", "unhealthy"} {
+		value := 0.0
+		if active == status {
+			value = 1
+		}
+		fmt.Fprintf(
+			b,
+			"%s{status=%q} %s\n",
+			name,
+			status,
+			prometheusFloat(value),
+		)
+	}
+}
+
+func writeHTTPMetrics(b *strings.Builder, samples []httpMetricSample) {
+	const requestsName = "aeron_toolbox_http_requests_total"
+	fmt.Fprintf(b, "# HELP %s Total HTTP requests by method, route pattern, and status.\n", requestsName)
+	fmt.Fprintf(b, "# TYPE %s counter\n", requestsName)
+	for _, sample := range samples {
+		fmt.Fprintf(
+			b,
+			"%s%s %d\n",
+			requestsName,
+			httpMetricLabels(sample.Key, ""),
+			sample.Count,
+		)
+	}
+
+	const durationName = "aeron_toolbox_http_request_duration_seconds"
+	fmt.Fprintf(b, "# HELP %s HTTP request duration by method, route pattern, and status.\n", durationName)
+	fmt.Fprintf(b, "# TYPE %s histogram\n", durationName)
+	for _, sample := range samples {
+		for i, bucket := range httpDurationBuckets {
+			fmt.Fprintf(
+				b,
+				"%s_bucket%s %d\n",
+				durationName,
+				httpMetricLabels(sample.Key, prometheusFloat(bucket)),
+				sample.Buckets[i],
+			)
+		}
+		fmt.Fprintf(
+			b,
+			"%s_bucket%s %d\n",
+			durationName,
+			httpMetricLabels(sample.Key, "+Inf"),
+			sample.Count,
+		)
+		fmt.Fprintf(
+			b,
+			"%s_sum%s %s\n",
+			durationName,
+			httpMetricLabels(sample.Key, ""),
+			prometheusFloat(sample.Sum),
+		)
+		fmt.Fprintf(
+			b,
+			"%s_count%s %d\n",
+			durationName,
+			httpMetricLabels(sample.Key, ""),
+			sample.Count,
+		)
+	}
+}
+
+func httpMetricLabels(key httpMetricKey, le string) string {
+	labels := []string{
+		`method="` + prometheusLabelValue(key.Method) + `"`,
+		`route="` + prometheusLabelValue(key.Route) + `"`,
+		`status="` + prometheusLabelValue(key.Status) + `"`,
+	}
+	if le != "" {
+		labels = append(labels, `le="`+prometheusLabelValue(le)+`"`)
+	}
+	return "{" + strings.Join(labels, ",") + "}"
+}
+
+func prometheusLabelValue(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		"\n", `\n`,
+		`"`, `\"`,
+	)
+	return replacer.Replace(value)
+}
+
+func prometheusFloat(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "0"
+	}
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+func nonNegative(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -198,7 +198,8 @@ type metricsSnapshot struct {
 
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = w.Write([]byte(formatPrometheusMetrics(s.collectMetrics(r.Context()))))
+	snapshot := s.collectMetrics(r.Context())
+	_, _ = w.Write([]byte(formatPrometheusMetrics(&snapshot)))
 }
 
 func (s *Server) collectMetrics(ctx context.Context) metricsSnapshot {
@@ -247,7 +248,7 @@ func (s *Server) collectMetrics(ctx context.Context) metricsSnapshot {
 	return snapshot
 }
 
-func formatPrometheusMetrics(snapshot metricsSnapshot) string {
+func formatPrometheusMetrics(snapshot *metricsSnapshot) string {
 	var b strings.Builder
 
 	writeGauge(&b, "aeron_toolbox_up", "Whether the Aeron Toolbox process is running.", 1)

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -15,7 +15,7 @@ func TestFormatPrometheusMetrics(t *testing.T) {
 		buckets[i] = 3
 	}
 
-	got := formatPrometheusMetrics(metricsSnapshot{
+	got := formatPrometheusMetrics(&metricsSnapshot{
 		HealthStatus:        "degraded",
 		DatabaseConnected:   true,
 		BackupEnabled:       true,

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestFormatPrometheusMetrics(t *testing.T) {
+	buckets := make([]uint64, len(httpDurationBuckets))
+	for i := range buckets {
+		buckets[i] = 3
+	}
+
+	got := formatPrometheusMetrics(metricsSnapshot{
+		HealthStatus:        "degraded",
+		DatabaseConnected:   true,
+		BackupEnabled:       true,
+		BackupCompleted:     true,
+		BackupLastDuration:  2.5,
+		FileMonitorEnabled:  true,
+		FileMonitorDone:     true,
+		FileMonitorAlerting: 2,
+		MediaCheckEnabled:   true,
+		MediaCheckDone:      true,
+		MediaCheckProblems:  1,
+		NotifyConfigured:    true,
+		NotifyLastError:     true,
+		HTTPSamples: []httpMetricSample{
+			{
+				Key: httpMetricKey{
+					Method: http.MethodGet,
+					Route:  "/api/health",
+					Status: "200",
+				},
+				Count:   3,
+				Sum:     0.12,
+				Buckets: buckets,
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"aeron_toolbox_up 1\n",
+		`aeron_toolbox_health_status{status="degraded"} 1`,
+		"aeron_toolbox_database_connected 1\n",
+		"aeron_toolbox_backup_last_success 0\n",
+		"aeron_toolbox_file_monitor_checks_alerting 2\n",
+		"aeron_toolbox_media_file_check_problems 1\n",
+		"aeron_toolbox_notifications_last_error 1\n",
+		`aeron_toolbox_http_requests_total{method="GET",route="/api/health",status="200"} 3`,
+		`aeron_toolbox_http_request_duration_seconds_bucket{method="GET",route="/api/health",status="200",le="+Inf"} 3`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("metrics output missing %q:\n%s", want, got)
+		}
+	}
+
+	for _, forbidden := range []string{"super-secret", "raw database error", "aeron_prod"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("metrics output leaked %q:\n%s", forbidden, got)
+		}
+	}
+}
+
+func TestHTTPMetricsUsesRoutePattern(t *testing.T) {
+	metrics := newHTTPMetrics()
+	router := chi.NewRouter()
+	router.Use(metrics.middleware)
+	router.Get("/api/items/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/sensitive-id", http.NoBody)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status code = %d, want %d", rec.Code, http.StatusCreated)
+	}
+
+	samples := metrics.snapshot()
+	if len(samples) != 1 {
+		t.Fatalf("sample count = %d, want 1: %#v", len(samples), samples)
+	}
+	got := samples[0].Key
+	if got.Route != "/api/items/{id}" {
+		t.Fatalf("route = %q, want route pattern", got.Route)
+	}
+	if strings.Contains(got.Route, "sensitive-id") {
+		t.Fatalf("route label contains concrete URL value: %q", got.Route)
+	}
+	if got.Status != "201" {
+		t.Fatalf("status = %q, want 201", got.Status)
+	}
+}
+
+func TestPrometheusLabelValueEscapesSpecialCharacters(t *testing.T) {
+	got := prometheusLabelValue("line\nquote\"slash\\")
+	want := `line\nquote\"slash\\`
+	if got != want {
+		t.Fatalf("prometheusLabelValue() = %q, want %q", got, want)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,16 +16,18 @@ import (
 
 // Server owns the HTTP routing, middleware, and listener lifecycle.
 type Server struct {
-	service *service.AeronService
-	version string
-	server  *http.Server
+	service     *service.AeronService
+	version     string
+	server      *http.Server
+	httpMetrics *httpMetrics
 }
 
 // New returns a Server bound to the service layer and build version.
 func New(svc *service.AeronService, version string) *Server {
 	return &Server{
-		service: svc,
-		version: version,
+		service:     svc,
+		version:     version,
+		httpMetrics: newHTTPMetrics(),
 	}
 }
 
@@ -45,6 +47,9 @@ func (s *Server) Start(port string) error {
 // router builds the public health route and authenticated API surface.
 func (s *Server) router() http.Handler {
 	router := chi.NewRouter()
+	if s.httpMetrics == nil {
+		s.httpMetrics = newHTTPMetrics()
+	}
 
 	cop := http.NewCrossOriginProtection()
 	router.Use(func(next http.Handler) http.Handler {
@@ -53,12 +58,17 @@ func (s *Server) router() http.Handler {
 
 	router.Use(middleware.RequestID)
 	router.Use(middleware.Recoverer)
+	router.Use(s.httpMetrics.middleware)
 	router.Use(middleware.Compress(5))
 
 	router.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		respondError(w, http.StatusNotFound, "Endpoint not found")
 	})
+
+	if cfg := s.service.Config().Metrics; cfg.Enabled {
+		router.Get(cfg.GetPath(), s.handleMetrics)
+	}
 
 	router.Route("/api", func(r chi.Router) {
 		r.Use(middleware.SetHeader("Content-Type", "application/json; charset=utf-8"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,12 @@ type NotificationsConfig struct {
 	Email GraphConfig `json:"email"`
 }
 
+// MetricsConfig controls the optional Prometheus-compatible metrics endpoint.
+type MetricsConfig struct {
+	Enabled bool   `json:"enabled"`
+	Path    string `json:"path"`
+}
+
 // GraphConfig configures Microsoft Graph email delivery.
 type GraphConfig struct {
 	TenantID     string `json:"tenant_id" validate:"omitempty,guid"`
@@ -234,6 +240,7 @@ type Config struct {
 	FileMonitor    FileMonitorConfig    `json:"file_monitor"`
 	MediaFileCheck MediaFileCheckConfig `json:"media_file_check"`
 	Notifications  NotificationsConfig  `json:"notifications"`
+	Metrics        MetricsConfig        `json:"metrics"`
 	Log            LogConfig            `json:"log"`
 }
 
@@ -257,6 +264,7 @@ const (
 	DefaultBackupCompression           = 9
 	DefaultBackupPath                  = "./backups"
 	DefaultBackupTimeoutMinutes        = 30
+	DefaultMetricsPath                 = "/metrics"
 )
 
 // GetMaxDownloadBytes returns the configured image download cap or its default.
@@ -366,6 +374,17 @@ func (c *S3Config) GetPathPrefix() string {
 		prefix += "/"
 	}
 	return prefix
+}
+
+// GetPath returns the scrape path for the metrics endpoint.
+func (c *MetricsConfig) GetPath() string {
+	if c.Path == "" {
+		return DefaultMetricsPath
+	}
+	if strings.HasPrefix(c.Path, "/") {
+		return c.Path
+	}
+	return "/" + c.Path
 }
 
 // GetLevel returns the configured log level as an slog.Level.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,37 @@ func TestInterval_ZeroFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestMetricsPath(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  MetricsConfig
+		want string
+	}{
+		{
+			name: "default",
+			cfg:  MetricsConfig{},
+			want: "/metrics",
+		},
+		{
+			name: "leading slash",
+			cfg:  MetricsConfig{Path: "/internal/metrics"},
+			want: "/internal/metrics",
+		},
+		{
+			name: "missing leading slash",
+			cfg:  MetricsConfig{Path: "internal/metrics"},
+			want: "/internal/metrics",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.GetPath(); got != tt.want {
+				t.Fatalf("GetPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFileMonitorValidation_DuplicatePaths(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.FileMonitor.Enabled = true


### PR DESCRIPTION
## Fact check
- Issue #159 klopt: de service had structured logs en een JSON health endpoint, maar geen scrapebare metrics of operator-alertvoorbeelden.
- Dit is de moeite waard omdat backup-, health-, file-monitor-, media-check- en notificatiesignalen nu in monitoring kunnen landen zonder JSON polling of log scraping.

## Fix
- Voeg opt-in `metrics.enabled` en `metrics.path` configuratie toe, standaard uit.
- Voeg een Prometheus-compatible text endpoint toe buiten `/api`, met dezelfde health-status als `/api/health`.
- Voeg dependency-vrije HTTP request counters en latency histograms toe met bounded labels: method, chi-routepatroon en status.
- Exporteer job/status gauges voor database, backups, file monitor, media file check en notificaties zonder secrets, bestandsnamen, database-namen of raw errors.
- Documenteer enable/scrape/alert voorbeelden in README en API.md.

## Verification
- `go test ./internal/api ./internal/config`
- `go test ./...`
- `go vet ./...`
- `go tool staticcheck ./...`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go tool govulncheck ./...`

Closes #159