### PR TITLE
ci: clean up orphaned GHCR manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,19 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+  cleanup:
+    needs: docker
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Every push of a rebuilt image orphans the previous manifest set
+      # (manifest list + per-arch children) as untagged versions. This
+      # deletes only truly unreferenced manifests; arch children of tagged
+      # manifest lists are preserved.
+      - name: Delete orphaned untagged images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: zwfm-aerontoolbox
+          validate: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.4-alpine3.24 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oszuidwest/zwfm-aerontoolbox
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/doyensec/safeurl v0.2.5


### PR DESCRIPTION
## Summary
- add a cleanup job after the Docker publish job
- clean up orphaned untagged GHCR manifests for package `zwfm-aerontoolbox`
- validate multi-arch manifests afterwards with `validate: true`
- bump the Go toolchain and Docker builder image to `1.26.5` to clear the govulncheck standard-library finding

## Checks
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `go mod tidy`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`