### PR TITLE
build(deps): bump Go to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine3.24 AS builder
+FROM golang:1.26.6-alpine3.24 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oszuidwest/zwfm-aerontoolbox
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/doyensec/safeurl v0.2.5


### PR DESCRIPTION
## Summary

- bump the Go baseline and Docker builder from 1.26.5 to 1.26.6
- let the existing CI and release workflows inherit Go 1.26.6 from go.mod
- resolve standard-library vulnerabilities fixed by Go 1.26.6

## Validation

- go mod tidy -diff
- go mod verify
- go test -race -shuffle=on ./...
- go vet ./...
- go fmt ./... with a clean diff
- golangci-lint run --timeout=5m
- deadcode -test ./...
- govulncheck ./... (0 reachable vulnerabilities)
- staticcheck ./...