### PR TITLE
chore: upgrade to Go 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build stage
-FROM golang:1.26.6-alpine3.24 AS builder
+FROM golang:1.27.0-alpine3.24 AS builder
 
-# Install dependencies
-RUN apk add --no-cache git ca-certificates tzdata
+# Install the CA bundle needed for module downloads.
+RUN apk add --no-cache ca-certificates
 
 # Set working directory
 WORKDIR /app
@@ -21,12 +21,12 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
 ARG COMMIT=unknown
-ARG BUILD_TIME
+ARG BUILD_TIME=unknown
 
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags="-w -s -extldflags '-static' -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildTime=${BUILD_TIME}" \
-    -a -installsuffix cgo \
+    -trimpath \
+    -ldflags="-s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildTime=${BUILD_TIME}" \
     -o zwfm-aerontoolbox .
 
 # Runtime stage
@@ -42,21 +42,18 @@ RUN apk --no-cache upgrade && \
 
 # Create non-root user
 RUN addgroup -g 1000 aeron && \
-    adduser -u 1000 -G aeron -s /bin/sh -D aeron
+    adduser -u 1000 -G aeron -s /sbin/nologin -D -H aeron
 
 # Set working directory
 WORKDIR /app
 
 # Create backup directory
-RUN mkdir -p /backups && chown aeron:aeron /backups
+RUN install -d -o aeron -g aeron -m 0755 /backups
 
 # Copy binary from builder
-COPY --from=builder /app/zwfm-aerontoolbox /app/zwfm-aerontoolbox
+COPY --from=builder --chown=0:0 --chmod=0555 /app/zwfm-aerontoolbox /app/zwfm-aerontoolbox
 
 # Runtime config is mounted at /app/config.json; never bake local config into the image.
-
-# Change ownership
-RUN chown -R aeron:aeron /app
 
 # Switch to non-root user
 USER 1000:1000
@@ -66,7 +63,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD ["wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+    CMD ["wget", "-q", "-T", "3", "--spider", "http://127.0.0.1:8080/health"]
 
 # Start API server by default
 ENTRYPOINT ["/app/zwfm-aerontoolbox"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ wget https://raw.githubusercontent.com/oszuidwest/zwfm-aerontoolbox/main/docker-
 openssl rand -base64 32
 
 # Stem de overige instellingen af op jouw situatie, dan:
+mkdir -p backups
+# De container draait als UID/GID 1000 en moet naar deze bind mount kunnen schrijven:
+sudo chown 1000:1000 backups
 docker compose up -d
 ```
 
@@ -34,7 +37,7 @@ De meegeleverde Docker-configuratie gebruikt `Europe/Amsterdam` voor geplande ta
 ### Andere installatiemethoden
 
 - Download een Linux- of macOS-binary via [GitHub Releases](https://github.com/oszuidwest/zwfm-aerontoolbox/releases).
-- Zelf bouwen vereist Go 1.26 of nieuwer:
+- Zelf bouwen vereist Go 1.27 of nieuwer:
 
 ```bash
 git clone https://github.com/oszuidwest/zwfm-aerontoolbox.git

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,7 +13,7 @@ services:
       # Override log level via environment variable (optional)
       # - LOG_LEVEL=debug
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-q", "-T", "3", "--spider", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,19 @@
 module github.com/oszuidwest/zwfm-aerontoolbox
 
-go 1.26.6
-
-require (
-	github.com/doyensec/safeurl v0.2.5
-	github.com/go-chi/chi/v5 v5.3.1
-	github.com/jmoiron/sqlx v1.4.0
-	github.com/lib/pq v1.12.3
-	golang.org/x/image v0.45.0
-)
+go 1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.35
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.1
+	github.com/doyensec/safeurl v0.2.5
+	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/jmoiron/sqlx v1.4.0
+	github.com/lib/pq v1.12.3
 	github.com/netresearch/go-cron v0.15.1
+	golang.org/x/image v0.45.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 )

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -142,12 +142,10 @@ func TestAPIRateLimiterAllowConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	results := make(chan bool, goroutines)
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			allowed, _, _ := limiter.allow("client-a")
 			results <- allowed
-		}()
+		})
 	}
 	wg.Wait()
 	close(results)

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -178,8 +178,7 @@ func TestResolveToolPathRejectsInvalidCustomPaths(t *testing.T) {
 				t.Fatal("resolveToolPath returned nil error")
 			}
 
-			var configErr *types.ConfigError
-			if !errors.As(err, &configErr) {
+			if _, ok := errors.AsType[*types.ConfigError](err); !ok {
 				t.Fatalf("resolveToolPath error = %T, want *types.ConfigError", err)
 			}
 		})
@@ -530,8 +529,7 @@ func TestBackupServiceOpenFileRejectsInvalidFilename(t *testing.T) {
 	if err == nil {
 		t.Fatal("OpenFile accepted path traversal filename")
 	}
-	var validationErr *types.ValidationError
-	if !errors.As(err, &validationErr) {
+	if _, ok := errors.AsType[*types.ValidationError](err); !ok {
 		t.Fatalf("OpenFile error = %T %[1]v, want *types.ValidationError", err)
 	}
 }
@@ -562,8 +560,7 @@ func TestBackupServiceOpenFileRejectsNonBackupNames(t *testing.T) {
 			if err == nil {
 				t.Fatal("OpenFile accepted non-backup filename")
 			}
-			var validationErr *types.ValidationError
-			if !errors.As(err, &validationErr) {
+			if _, ok := errors.AsType[*types.ValidationError](err); !ok {
 				t.Fatalf("OpenFile error = %T %[1]v, want *types.ValidationError", err)
 			}
 		})
@@ -586,8 +583,7 @@ func TestBackupServiceOpenFileRejectsDirectory(t *testing.T) {
 	if err == nil {
 		t.Fatal("OpenFile accepted directory named like a backup")
 	}
-	var validationErr *types.ValidationError
-	if !errors.As(err, &validationErr) {
+	if _, ok := errors.AsType[*types.ValidationError](err); !ok {
 		t.Fatalf("OpenFile error = %T %[1]v, want *types.ValidationError", err)
 	}
 }
@@ -689,8 +685,7 @@ func TestBackupServiceValidateMissingFileReturnsError(t *testing.T) {
 	if result != nil {
 		t.Fatalf("Validate result = %#v, want nil on missing backup", result)
 	}
-	var notFound *types.NotFoundError
-	if !errors.As(err, &notFound) {
+	if _, ok := errors.AsType[*types.NotFoundError](err); !ok {
 		t.Fatalf("Validate error = %T %[1]v, want *types.NotFoundError", err)
 	}
 }

--- a/internal/service/filemonitor_test.go
+++ b/internal/service/filemonitor_test.go
@@ -655,8 +655,7 @@ func TestTriggerCheck_ReturnsConflictWhenAlreadyRunning(t *testing.T) {
 	if runID2 != 0 {
 		t.Errorf("conflict runID = %d, want 0", runID2)
 	}
-	var conflict *types.ConflictError
-	if !errors.As(err, &conflict) {
+	if _, ok := errors.AsType[*types.ConflictError](err); !ok {
 		t.Errorf("expected *types.ConflictError, got %T: %v", err, err)
 	}
 

--- a/tests/Dockerfile.testdb
+++ b/tests/Dockerfile.testdb
@@ -1,13 +1,8 @@
 # Dockerfile for test database with pre-loaded data
-FROM postgres:17-alpine
+FROM postgres:17.11-alpine3.24
 
 # Copy mock data
-COPY fixtures/mock_data.sql /docker-entrypoint-initdb.d/01-mock-data.sql
-
-# Set environment variables
-ENV POSTGRES_USER=aeron
-ENV POSTGRES_PASSWORD=aeron123
-ENV POSTGRES_DB=aeron_db
+COPY --chmod=0444 fixtures/mock_data.sql /docker-entrypoint-initdb.d/01-mock-data.sql
 
 # The postgres image will automatically run SQL files in /docker-entrypoint-initdb.d/
 # This happens only once when the container is first created

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,6 +1,9 @@
 services:
   postgres-test:
-    image: postgres:17-alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.testdb
+    image: zwfm-aerontoolbox-testdb:postgres17
     container_name: aeron-test-db
     environment:
       POSTGRES_USER: aeron
@@ -8,10 +11,8 @@ services:
       POSTGRES_DB: aeron_db
     ports:
       - "5433:5432"  # Different port to avoid conflicts with local dev
-    volumes:
-      - ./fixtures/mock_data.sql:/docker-entrypoint-initdb.d/01-mock-data.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aeron -d aeron_db"]
+      test: ["CMD", "pg_isready", "-U", "aeron", "-d", "aeron_db"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- target Go 1.27.0 in go.mod, the Docker builder, and build documentation
- apply the standalone modernize analyzer and Go 1.27 go fix modernizers to adopt WaitGroup.Go and errors.AsType where safe
- let Go 1.27 go mod tidy consolidate direct requirements without changing dependency versions
- review Go 1.27 release-note impacts for JSON v2-backed v1 behavior, HTTP response-body draining, synchronous timer channels, stdversion, and new standard-library APIs; no opt-outs or risky API migrations are needed
- harden the runtime image with a non-login user, root-owned read-only binary, writable backup directory, portable health check, trimpath build, and deterministic local build metadata fallback
- pin the PostgreSQL fixture image to 17.11/Alpine 3.24, keep test credentials out of image metadata, and make the integration Compose stack build and validate that fixture image directly

## Tests

- `GOTOOLCHAIN=go1.27.0 go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest ./...`
- `GOTOOLCHAIN=go1.27.0 go test ./...`
- `GOTOOLCHAIN=go1.27.0 go test -race ./...`
- `GOTOOLCHAIN=go1.27.0 go vet ./...`
- `GOTOOLCHAIN=go1.27.0 go build ./...`
- `GOTOOLCHAIN=go1.27.0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...`
- `GOTOOLCHAIN=go1.27.0 go tool staticcheck ./...`
- `GOTOOLCHAIN=go1.27.0 go tool govulncheck ./...`
- `GOTOOLCHAIN=go1.27.0 go tool deadcode ./...`
- `GOTOOLCHAIN=go1.27.0 go mod verify`
- `hadolint Dockerfile tests/Dockerfile.testdb`
- Docker BuildKit checks and Compose config validation for both Dockerfiles/stacks
- `docker build --pull` for the native ARM64 production image and PostgreSQL test image
- `docker build --pull --platform=linux/amd64` plus emulated version smoke test
- PostgreSQL 17.11 readiness and fixture smoke: 1,000 artists and 1,100 tracks
- production runtime smoke against the fixture database: healthy endpoint, UID/GID 1000, read-only app/binary, writable backup volume, and pg_dump/pg_restore 17.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated source-build requirements to Go 1.27 or newer.
  - Updated Docker quick-start instructions to prepare the backups directory with appropriate permissions.

- **Chores**
  - Updated the build and runtime container setup for improved security and more reliable health checks.
  - Consolidated dependency declarations without changing dependencies or versions.

- **Tests**
  - Updated test database infrastructure to PostgreSQL 17.11.
  - Modernized test concurrency and error-checking patterns while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
